### PR TITLE
Add right-click bulldozing shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Then open the provided local URL. The service worker caches assets after first l
 
 ## Controls (quick reference)
 - Pan: drag with mouse or use `WASD` / arrow keys; zoom with scroll/pinch.
+- Quick bulldoze: right-click to bulldoze the tile under your cursor, or hold and drag to clear a path. Middle-click or Alt-drag still pans. The Inspect tool does not bulldoze on right-click.
 - Tools: click toolbar buttons or hotkeys — Inspect (`I`), Raise (`E`), Lower (`Q`), Water paint (`F`), Trees (`T`), Road (`R`), Rail (`L`), Power Lines (`P`), Hydro (`H`), Pump (`U`), Tower (`Y`), Elementary School (`J`), High School (`N`), Residential (`Z`), Commercial (`X`), Industrial (`C`), Park (`K`), Bulldoze (`B`).
 - Speed: `1` Slow (0.5x), `2` Fast (1x), `3` Ludicrous (3x).
 - Inspector: select Inspect, click a tile to see utilities, status, and capacity; pin the tool info card to keep build stats visible.

--- a/public/manual.html
+++ b/public/manual.html
@@ -32,6 +32,7 @@
     <h2>Controls</h2>
     <ul>
       <li><strong>Drag</strong> the map to pan. Use your mouse wheel or pinch to zoom.</li>
+      <li><strong>Right-click</strong> to bulldoze tiles quickly — click once or hold and drag to sweep clears. Middle-click or hold <strong>Alt</strong> to pan instead. Right-click does nothing while Inspect is active.</li>
       <li>Choose a tool from the toolbar and click tiles to apply it.</li>
       <li>Hover over demand bars to view the approximate need for Residential, Commercial, and Industrial zones.</li>
       <li>Switch to the <strong>Inspect</strong> tool and click tiles to view terrain, utilities, and zone data.</li>


### PR DESCRIPTION
## Summary
- allow holding or clicking the right mouse button to temporarily activate bulldozing, while keeping inspect mode passive
- preserve middle/Alt-drag panning and continuous sweeping clears when the button stays held
- document the new right-click bulldoze control in the README and manual

## Testing
- npm test -- --pool=threads --poolOptions.threads.singleThread=true

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c40f43a3483218ced53be43d31047)