### PR TITLE
Add bylaws modal entry alongside budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Then open the provided local URL. The service worker caches assets after first l
 - Hydro generation, water pumping, and global utility balance that affects growth.
 - Tool info card beside the tile inspector that surfaces cost, upkeep, and stats for the active tool with a pin toggle when you want it always-on.
 - Budget ticker with a colour-coded monthly net projection, calendar month/day readout, population and jobs tracking, and happiness per tile. Open the Budget screen for a quarterly breakdown, detailed revenue/expense shares, and runway.
+- Bylaws button in the toolbar’s city admin cluster next to Budget/Settings, opening a modal that captures city-wide lighting policy plans and future district hooks.
 - LocalStorage save/load plus downloadable JSON exports and uploads for backups.
 - Manual available at `public/manual.html` covering controls and systems.
 - Minimap in the bottom-right HUD: base map view plus power, water, and alerts overlay modes with click-to-jump navigation and viewport framing; the same mode tints the main map for quick at-a-glance status.

--- a/TODO.md
+++ b/TODO.md
@@ -9,3 +9,4 @@ Here are two ready-to-use prompts to resume later:
 - road/rail connections to zones
 - Power through water buildings
 - Toolbar subnav border seam: investigate small blip at parent/subnav junction when submenu is open.
+- TODO: Explore a districts system so bylaws (e.g., lighting standards like LEDs vs carbon arc lamps) can apply to targeted areas instead of the whole city.

--- a/docs/game-parameters.md
+++ b/docs/game-parameters.md
@@ -66,6 +66,15 @@
 - **UI hooks**: Overlays per service reading `serviceScores`; build tooltip shows cost, upkeep, radius, capacity. A shared “underserved” icon can appear on tiles/zones missing required coverage.
 - **Future depth (later)**: Incident spawning by density/hazard, dispatch travel time on roads, queues per station, staffing/budget sliders, and specialised buildings (clinic vs hospital). These plug into the same data shapes without reshaping state.
 
+## Bylaws & District Planning
+- **Purpose**: Bylaws let players set city-wide or district-specific rules that tweak upkeep, utility demand, or happiness without adding new buildings. Early focus: lighting standards that change power draw and ambience.
+- **Baseline toggles**: Add city-wide bylaws for energy-efficient lighting (reduced power use for civic/zone buildings with a small upfront cost) and heritage/carbon-arc lighting (higher power draw, minor happiness boost, visual flavour). Show monthly upkeep/benefit deltas before enabling.
+- **District hooks**: Introduce optional districts as map overlays. Players can paint districts similar to zoning; bylaws can override the city default within those boundaries (e.g., a downtown heritage district using carbon arc lamps while suburbs favour LEDs). Keep district limits modest to avoid pathing bloat.
+- **Simulation impacts**: Lighting bylaws adjust building `powerUse` modifiers and can influence happiness at night. Districts also provide a hook for future policies (noise, pollution, density caps) by storing per-district modifiers alongside zoning data.
+- **UI/UX**: The Bylaws modal opens from the toolbar’s city admin cluster (next to Budget/Settings) with policy copy, tooltips, and projected budget/power effects. The district paint tool should surface the active bylaw theme and allow quick reassignment. Overlays highlight districts with their active policy and show warnings if a district lacks a bylaw (falls back to city default).
+- **Persistence**: Save city-wide bylaw states and a list of districts with polygon/paint masks plus their assigned bylaw bundle. Ensure saves remain backwards-compatible by defaulting to “no bylaws” when absent.
+- **Tech debt avoidance**: Reuse existing overlay/minimap tinting infrastructure for district visualization, and keep district data near zoning/utility state so power/water overlays can respect bylaw modifiers without separate graphs.
+
 ## Next Steps (Suggested)
 - **Visuals**: Build a sprite atlas (road/rail crossings, power-over-road, zone variants, construction states); add subtle animations (water tiles, lit windows at night).
 - **Pipes & Underground**: Finish water network with pipes + underground view toggle; water deficit penalties; overlay for pressure/flow; restore water sim (remove stub).

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ import { createNotificationCenter } from './ui/notifications';
 import { initMinimap } from './ui/minimap';
 import { initBudgetModal } from './ui/budgetModal';
 import { initSettingsModal } from './ui/settingsModal';
+import { initBylawsModal } from './ui/bylawsModal';
 import type { RadioWidget } from './ui/radio';
 
 const appRoot = document.querySelector<HTMLDivElement>('#app');
@@ -367,6 +368,7 @@ function gameLoop(renderer: MapRenderer, hud: ReturnType<typeof createHud>) {
   const budgetModal = initBudgetModal({
     getState: () => state
   });
+  const bylawsModal = initBylawsModal();
 
   const minimapViewport = () => {
     const canvas = renderer.getCanvas();
@@ -532,6 +534,7 @@ function gameLoop(renderer: MapRenderer, hud: ReturnType<typeof createHud>) {
     tool,
     {
       onOpenBudget: () => budgetModal.open(),
+      onOpenBylaws: () => bylawsModal.open(),
       onOpenSettings: () => settingsModal?.open(),
       radioVolume: state.settings.audio.radioVolume
     }

--- a/src/style.css
+++ b/src/style.css
@@ -965,6 +965,105 @@ footer {
   background: linear-gradient(180deg, #0f1b2f 0%, #0b1526 100%);
 }
 
+.bylaws-modal {
+  padding: 14px 14px 16px;
+  gap: 12px;
+  background: linear-gradient(180deg, #0f1b2f 0%, #0a1425 100%);
+  width: min(90vw, 840px);
+}
+
+.bylaws-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.bylaws-title-block {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.bylaws-title {
+  font-size: 18px;
+  font-weight: 700;
+  color: #e8f1ff;
+}
+
+.bylaws-subtitle {
+  color: #9fb2d1;
+  font-size: 12px;
+  max-width: 520px;
+}
+
+.bylaws-lede {
+  background: #0a1224;
+  border: 1px solid #1f2c4b;
+  border-radius: 10px;
+  padding: 10px 12px;
+  color: #d8e6ff;
+  font-size: 13px;
+}
+
+.bylaws-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow: auto;
+  padding: 0 2px 6px;
+}
+
+.bylaws-section {
+  background: #0a1224;
+  border: 1px solid #1f2c4b;
+  border-radius: 10px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.bylaws-section-title {
+  color: #e8f1ff;
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.bylaws-section-hint {
+  color: #9fb2d1;
+  font-size: 12px;
+}
+
+.bylaws-list {
+  margin: 0;
+  padding-left: 18px;
+  color: #d8e6ff;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 13px;
+}
+
+.bylaws-list strong {
+  color: #e8f1ff;
+}
+
+.bylaws-callout {
+  background: #132035;
+  border: 1px solid #2e4c77;
+  border-radius: 8px;
+  padding: 8px 10px;
+  color: #d8e6ff;
+  font-size: 13px;
+}
+
+.bylaws-footer {
+  color: #9fb2d1;
+  font-size: 12px;
+  padding: 0 2px 2px;
+}
+
 .budget-header {
   display: flex;
   align-items: center;

--- a/src/ui/bylawsModal.ts
+++ b/src/ui/bylawsModal.ts
@@ -1,0 +1,118 @@
+import { showToast } from './dialogs';
+
+type BylawsModalOptions = {
+  onClose?: () => void;
+};
+
+export function initBylawsModal(options: BylawsModalOptions = {}) {
+  const { onClose } = options;
+  let backdrop: HTMLDivElement | null = null;
+  let escHandler: ((event: KeyboardEvent) => void) | null = null;
+
+  const cleanup = () => {
+    if (escHandler) {
+      window.removeEventListener('keydown', escHandler);
+      escHandler = null;
+    }
+    if (backdrop) {
+      backdrop.remove();
+      backdrop = null;
+    }
+    onClose?.();
+  };
+
+  const open = () => {
+    if (backdrop) return;
+
+    backdrop = document.createElement('div');
+    backdrop.className = 'modal-backdrop';
+
+    const modal = document.createElement('div');
+    modal.className = 'modal bylaws-modal';
+    modal.setAttribute('role', 'dialog');
+    modal.setAttribute('aria-modal', 'true');
+    modal.setAttribute('aria-label', 'City bylaws');
+
+    const header = document.createElement('div');
+    header.className = 'bylaws-header';
+
+    const heading = document.createElement('div');
+    heading.className = 'bylaws-title';
+    heading.textContent = 'Bylaws';
+
+    const subtitle = document.createElement('div');
+    subtitle.className = 'bylaws-subtitle';
+    subtitle.textContent = 'City-wide policies live here; districts will layer on later.';
+
+    const titleBlock = document.createElement('div');
+    titleBlock.className = 'bylaws-title-block';
+    titleBlock.append(heading, subtitle);
+
+    const closeBtn = document.createElement('button');
+    closeBtn.textContent = 'Close';
+    closeBtn.className = 'secondary modal-close';
+    closeBtn.type = 'button';
+
+    const headerActions = document.createElement('div');
+    headerActions.className = 'bylaws-header-actions';
+    headerActions.appendChild(closeBtn);
+
+    header.append(titleBlock, headerActions);
+
+    const lede = document.createElement('div');
+    lede.className = 'bylaws-lede';
+    lede.textContent =
+      'Set a default lighting standard for the whole city before districts unlock finer-grained overrides.';
+
+    const body = document.createElement('div');
+    body.className = 'bylaws-body';
+
+    const lightingSection = document.createElement('div');
+    lightingSection.className = 'bylaws-section';
+    lightingSection.innerHTML = `
+      <div class="bylaws-section-title">Lighting standards</div>
+      <div class="bylaws-section-hint">City-wide defaults apply everywhere until a district overrides them.</div>
+      <ul class="bylaws-list">
+        <li><strong>Energy-efficient lighting</strong> keeps upkeep lower and conserves power.</li>
+        <li><strong>Carbon arc lamps</strong> satisfy nostalgia districts at a higher energy draw.</li>
+        <li><strong>Mixed corridors</strong> let you preview LED vs. carbon-arc demand before carving districts.</li>
+      </ul>
+    `;
+
+    const districtSection = document.createElement('div');
+    districtSection.className = 'bylaws-section';
+    districtSection.innerHTML = `
+      <div class="bylaws-section-title">District overlays</div>
+      <div class="bylaws-section-hint">Coming soon: mark neighbourhoods to scope lighting bylaws per area.</div>
+      <div class="bylaws-callout">Use the planned district tools to keep carbon-arc lamps downtown and energy-efficient corridors in suburbs.</div>
+    `;
+
+    const footer = document.createElement('div');
+    footer.className = 'bylaws-footer';
+    footer.textContent = 'Tooling is informational for now — policy toggles will tie into power and happiness once districts ship.';
+
+    body.append(lightingSection, districtSection);
+    modal.append(header, lede, body, footer);
+    backdrop.appendChild(modal);
+    document.body.appendChild(backdrop);
+
+    escHandler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') cleanup();
+    };
+    window.addEventListener('keydown', escHandler);
+
+    closeBtn.addEventListener('click', cleanup);
+    backdrop.addEventListener('click', (event) => {
+      if (event.target === backdrop) cleanup();
+    });
+    modal.addEventListener('click', (event) => event.stopPropagation());
+
+    showToast('Bylaws are informational for now — districts will enable enforcement.', {
+      severity: 'info',
+      durationMs: 2000,
+      id: 'bylaws-info'
+    });
+  };
+
+  return { open, close: cleanup };
+}

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -16,6 +16,7 @@ const educationOptions: Tool[] = [Tool.ElementarySchool, Tool.HighSchool];
 
 interface ToolbarOptions {
   onOpenBudget?: () => void;
+  onOpenBylaws?: () => void;
   onOpenSettings?: () => void;
   radioVolume?: number;
   radioStationId?: string;
@@ -34,7 +35,7 @@ export function initToolbar(
   options: ToolbarOptions = {}
 ): ToolbarControllers {
   toolbar.innerHTML = '';
-  const { onOpenBudget, onOpenSettings, radioVolume, radioStationId, onRadioStationChange } = options;
+  const { onOpenBudget, onOpenBylaws, onOpenSettings, radioVolume, radioStationId, onRadioStationChange } = options;
 
   const primaryRow = document.createElement('div');
   primaryRow.className = 'toolbar-row';
@@ -104,29 +105,49 @@ export function initToolbar(
   radioGroup.appendChild(radioStationHost);
   trailingCluster.appendChild(radioGroup);
 
+  const adminGroup = document.createElement('div');
+  adminGroup.className = 'toolbar-group toolbar-group-admin';
+  let hasAdminButtons = false;
+
   if (onOpenSettings) {
-    const settingsGroup = document.createElement('div');
-    settingsGroup.className = 'toolbar-group';
     const settingsBtn = document.createElement('button');
+    settingsBtn.type = 'button';
     settingsBtn.className = 'tool-button';
     settingsBtn.textContent = '⚙️ Settings';
     settingsBtn.title = 'Open settings';
     settingsBtn.addEventListener('click', () => onOpenSettings());
-    settingsGroup.appendChild(settingsBtn);
-    trailingCluster.appendChild(settingsGroup);
+    adminGroup.appendChild(settingsBtn);
+    hasAdminButtons = true;
+  }
+
+  if (onOpenBylaws) {
+    const bylawsBtn = document.createElement('button');
+    bylawsBtn.type = 'button';
+    bylawsBtn.id = 'bylaws-modal-btn';
+    bylawsBtn.className = 'tool-button';
+    bylawsBtn.textContent = '📜 Bylaws';
+    bylawsBtn.title = 'Open bylaws screen';
+    bylawsBtn.addEventListener('click', () => onOpenBylaws());
+    adminGroup.appendChild(bylawsBtn);
+    hasAdminButtons = true;
   }
 
   if (onOpenBudget) {
-    const budgetGroup = document.createElement('div');
-    budgetGroup.className = 'toolbar-group';
     const budgetBtn = document.createElement('button');
+    budgetBtn.type = 'button';
     budgetBtn.id = 'budget-modal-btn';
     budgetBtn.className = 'tool-button budget-button';
     budgetBtn.textContent = '📊 Budget';
     budgetBtn.title = 'Open budget screen';
     budgetBtn.addEventListener('click', () => onOpenBudget());
-    budgetGroup.appendChild(budgetBtn);
-    trailingCluster.appendChild(budgetGroup);
+    adminGroup.appendChild(budgetBtn);
+    hasAdminButtons = true;
+  }
+
+  if (hasAdminButtons) {
+    adminGroup.setAttribute('role', 'group');
+    adminGroup.setAttribute('aria-label', 'City admin tools');
+    trailingCluster.appendChild(adminGroup);
   }
 
   const createSubButton = (row: HTMLElement, key: Tool, labelOverride?: string) => {


### PR DESCRIPTION
## Summary
- add a bylaws modal with city-wide lighting policy copy and district overlay notes, opened from the toolbar admin cluster
- group admin toolbar buttons together and include the new Bylaws trigger next to Settings and Budget
- document the bylaws entry point in the README and systems outline

## Testing
- npm test -- --pool=threads --poolOptions.threads.singleThread=true

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c4163a1fc8321a14aeaa6f05681c7)