### PR TITLE
feat(sim_core): P3-1 — RNG + GameState + Tile types with accessors

### DIFF
--- a/crates/sim_core/src/lib.rs
+++ b/crates/sim_core/src/lib.rs
@@ -1,2 +1,4 @@
 // sim_core — pure-Rust city simulation engine.
-// Filled in during Phase 3 once the bridge seam is proven (Phase 2).
+// Systems are ported incrementally (Phase 3); see docs/rust-migration-tasks.md.
+pub mod rng;
+pub mod state;

--- a/crates/sim_core/src/rng.rs
+++ b/crates/sim_core/src/rng.rs
@@ -1,0 +1,199 @@
+/// SeededRng — SplitMix64 seeding, xoshiro128** generation.
+///
+/// Must match `app/src/game/rng.ts` exactly.  The reference vectors in the
+/// tests below are hardcoded from the TS implementation; do not change them
+/// without also updating `rng.test.ts`.
+///
+/// Algorithm:
+/// - **Seeding**: SplitMix64 expands a u32 seed (zero-extended to u64) into
+///   four u32 state words.
+/// - **Generation**: xoshiro128** — fast, high-quality 32-bit output.
+#[derive(Debug, Clone)]
+pub struct SeededRng {
+    s0: u32,
+    s1: u32,
+    s2: u32,
+    s3: u32,
+}
+
+impl SeededRng {
+    /// Create from a u32 seed using SplitMix64 expansion.
+    pub fn new(seed: u32) -> Self {
+        const INCR: u64 = 0x9e3779b97f4a7c15;
+        const M1:   u64 = 0xbf58476d1ce4e5b9;
+        const M2:   u64 = 0x94d049bb133111eb;
+
+        // TS: `let state = BigInt(seed >>> 0)` — u32 zero-extended to u64.
+        let mut state: u64 = seed as u64;
+
+        let mut sm = || -> u64 {
+            state = state.wrapping_add(INCR);
+            let mut z = state;
+            z = (z ^ (z >> 30)).wrapping_mul(M1);
+            z = (z ^ (z >> 27)).wrapping_mul(M2);
+            z ^ (z >> 31)
+        };
+
+        let w0 = sm();
+        let w1 = sm();
+
+        Self {
+            s0: w0 as u32,
+            s1: (w0 >> 32) as u32,
+            s2: w1 as u32,
+            s3: (w1 >> 32) as u32,
+        }
+    }
+
+    /// Restore RNG from a saved state tuple (no re-seeding).
+    pub fn from_state(s: [u32; 4]) -> Self {
+        Self { s0: s[0], s1: s[1], s2: s[2], s3: s[3] }
+    }
+
+    /// Serialise state for persistence.
+    pub fn to_state(&self) -> [u32; 4] {
+        [self.s0, self.s1, self.s2, self.s3]
+    }
+
+    /// Next u32 via xoshiro128**.
+    pub fn next_u32(&mut self) -> u32 {
+        let result = rotl(self.s1.wrapping_mul(5), 7).wrapping_mul(9);
+        let t = self.s1 << 9;
+        self.s2 ^= self.s0;
+        self.s3 ^= self.s1;
+        self.s1 ^= self.s2;
+        self.s0 ^= self.s3;
+        self.s2 ^= t;
+        self.s3 = rotl(self.s3, 11);
+        result
+    }
+
+    /// Float in [0, 1) — 24 bits of precision, matching TS `nextF32()`.
+    pub fn next_f32(&mut self) -> f32 {
+        (self.next_u32() >> 8) as f32 / 16777216.0
+    }
+
+    /// Integer in [0, max).
+    pub fn next_below(&mut self, max: u32) -> u32 {
+        if max == 0 { return 0; }
+        self.next_u32() % max
+    }
+
+    /// Derive an independent sub-RNG for a named system + tick.
+    ///
+    /// Matches TS `derive(systemId, tick)` — FNV-1a of the ASCII system name
+    /// XOR'd with the tick (truncated to u32), then used as a fresh seed.
+    pub fn derive(&self, system_id: &str, tick: u64) -> SeededRng {
+        SeededRng::new(fnv1a(system_id) ^ (tick as u32))
+    }
+}
+
+#[inline]
+fn rotl(x: u32, k: u32) -> u32 {
+    (x << k) | (x >> (32 - k))
+}
+
+/// FNV-1a 32-bit hash over ASCII bytes — used only by `derive()`.
+fn fnv1a(s: &str) -> u32 {
+    let mut h: u32 = 0x811c9dc5;
+    for b in s.bytes() {
+        h = (h ^ b as u32).wrapping_mul(0x01000193);
+    }
+    h
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Reference vectors hardcoded from the canonical TS rng.test.ts.
+    // The Rust sim_core MUST produce identical values for the same seeds.
+    // Do NOT change without also updating rng.test.ts.
+    const SEED0: [u32; 8]     = [3737715805,2584255861,2876756834,3286328325,1553311962,1625202774,3260698944,2754151956];
+    const SEED1: [u32; 8]     = [1695105466,1423115009,634581793,1068227753,716759206,4186505319,3777694425,2710820970];
+    const SEED12345: [u32; 8] = [2314518269,2498321016,2055377852,4042509560,1267802836,503974162,1443322985,3447162595];
+
+    fn collect8(rng: &mut SeededRng) -> [u32; 8] {
+        std::array::from_fn(|_| rng.next_u32())
+    }
+
+    #[test]
+    fn seed0_reference_vectors() {
+        assert_eq!(collect8(&mut SeededRng::new(0)), SEED0);
+    }
+
+    #[test]
+    fn seed1_reference_vectors() {
+        assert_eq!(collect8(&mut SeededRng::new(1)), SEED1);
+    }
+
+    #[test]
+    fn seed12345_reference_vectors() {
+        assert_eq!(collect8(&mut SeededRng::new(12345)), SEED12345);
+    }
+
+    #[test]
+    fn same_seed_same_sequence() {
+        let mut a = SeededRng::new(42);
+        let mut b = SeededRng::new(42);
+        for _ in 0..100 {
+            assert_eq!(a.next_u32(), b.next_u32());
+        }
+    }
+
+    #[test]
+    fn different_seeds_different_sequences() {
+        let mut a = SeededRng::new(1);
+        let mut b = SeededRng::new(2);
+        let sa: Vec<_> = (0..20).map(|_| a.next_u32()).collect();
+        let sb: Vec<_> = (0..20).map(|_| b.next_u32()).collect();
+        assert_ne!(sa, sb);
+    }
+
+    #[test]
+    fn from_state_round_trips() {
+        let mut rng = SeededRng::new(999);
+        for _ in 0..10 { rng.next_u32(); }
+        let saved = rng.to_state();
+        let mut restored = SeededRng::from_state(saved);
+        for _ in 0..20 {
+            assert_eq!(rng.next_u32(), restored.next_u32());
+        }
+    }
+
+    #[test]
+    fn next_f32_range() {
+        let mut rng = SeededRng::new(7);
+        for _ in 0..1000 {
+            let f = rng.next_f32();
+            assert!((0.0..1.0).contains(&f), "next_f32 out of range: {f}");
+        }
+    }
+
+    #[test]
+    fn next_below_range() {
+        let mut rng = SeededRng::new(13);
+        for max in 1u32..=50 {
+            let v = rng.next_below(max);
+            assert!(v < max, "next_below({max}) = {v} should be < max");
+        }
+    }
+
+    #[test]
+    fn next_below_zero_does_not_panic() {
+        let mut rng = SeededRng::new(0);
+        assert_eq!(rng.next_below(0), 0);
+    }
+
+    #[test]
+    fn derive_produces_independent_rng() {
+        let rng = SeededRng::new(1);
+        let mut a = rng.derive("zone_growth", 0);
+        let mut b = rng.derive("power_check", 0);
+        assert_ne!(a.next_u32(), b.next_u32());
+    }
+}

--- a/crates/sim_core/src/state.rs
+++ b/crates/sim_core/src/state.rs
@@ -1,0 +1,277 @@
+use sim_protocol::tile_kind::TileKind;
+use crate::rng::SeededRng;
+
+// ---------------------------------------------------------------------------
+// Tile flags
+// ---------------------------------------------------------------------------
+
+pub const FLAG_POWERED:       u8 = 0b0000_0001;
+pub const FLAG_WATERED:       u8 = 0b0000_0010;
+pub const FLAG_ABANDONED:     u8 = 0b0000_0100;
+pub const FLAG_ROAD_UNDERLAY: u8 = 0b0000_1000;
+pub const FLAG_RAIL_UNDERLAY: u8 = 0b0001_0000;
+pub const FLAG_POWER_OVERLAY: u8 = 0b0010_0000;
+/// Zone density packed into bits 6–7: 00=Low, 01=Medium, 10=High.
+pub const FLAG_ZONE_DENSITY_MASK:  u8 = 0b1100_0000;
+pub const FLAG_ZONE_DENSITY_SHIFT: u8 = 6;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ZoneDensity { Low = 0, Medium = 1, High = 2 }
+
+// ---------------------------------------------------------------------------
+// Tile
+// ---------------------------------------------------------------------------
+
+/// One grid cell. Mirrors the TS `Tile` interface in `gameState.ts`.
+///
+/// `happiness` is stored as 0–100 (u8) to match the SoA tile buffer field.
+/// `building_id` is `None` for unbuildable/empty tiles; `Some(id)` otherwise.
+/// `underground` holds a buried `TileKind` (e.g. `WaterPipe`) if present.
+#[derive(Debug, Clone)]
+pub struct Tile {
+    pub kind:        TileKind,
+    pub flags:       u8,
+    pub happiness:   u8,
+    pub elevation:   u8,
+    pub building_id: Option<u16>,
+    pub underground: Option<TileKind>,
+}
+
+impl Tile {
+    pub fn land() -> Self {
+        Self {
+            kind:        TileKind::Land,
+            flags:       0,
+            happiness:   100,
+            elevation:   0,
+            building_id: None,
+            underground: None,
+        }
+    }
+
+    pub fn water() -> Self {
+        Self { kind: TileKind::Water, ..Self::land() }
+    }
+
+    // --- flag accessors ---
+
+    pub fn is_powered(&self)        -> bool { self.flags & FLAG_POWERED       != 0 }
+    pub fn is_watered(&self)        -> bool { self.flags & FLAG_WATERED       != 0 }
+    pub fn is_abandoned(&self)      -> bool { self.flags & FLAG_ABANDONED     != 0 }
+    pub fn has_road_underlay(&self) -> bool { self.flags & FLAG_ROAD_UNDERLAY != 0 }
+    pub fn has_rail_underlay(&self) -> bool { self.flags & FLAG_RAIL_UNDERLAY != 0 }
+    pub fn has_power_overlay(&self) -> bool { self.flags & FLAG_POWER_OVERLAY != 0 }
+
+    pub fn zone_density(&self) -> ZoneDensity {
+        match (self.flags & FLAG_ZONE_DENSITY_MASK) >> FLAG_ZONE_DENSITY_SHIFT {
+            1 => ZoneDensity::Medium,
+            2 => ZoneDensity::High,
+            _ => ZoneDensity::Low,
+        }
+    }
+
+    pub fn set_flag(&mut self, mask: u8, on: bool) {
+        if on { self.flags |= mask; } else { self.flags &= !mask; }
+    }
+
+    pub fn set_zone_density(&mut self, density: ZoneDensity) {
+        self.flags = (self.flags & !FLAG_ZONE_DENSITY_MASK)
+            | ((density as u8) << FLAG_ZONE_DENSITY_SHIFT);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GameState (minimal for P3-1; expanded per-task in later sub-phases)
+// ---------------------------------------------------------------------------
+
+/// Top-level simulation state. Mirrors the TS `GameState` interface, extended
+/// with Rust-native types where appropriate.
+#[derive(Debug, Clone)]
+pub struct GameState {
+    pub width:      u32,
+    pub height:     u32,
+    pub tiles:      Vec<Tile>,
+    /// Original seed used to initialise the PRNG for this city.
+    pub seed:       u32,
+    /// Live RNG instance — persisted so saves resume mid-stream.
+    pub rng:        SeededRng,
+    /// Treasury balance in whole dollars (can be negative).
+    pub money:      i64,
+    pub day:        u32,
+    pub tick:       u64,
+    pub population: u32,
+    pub jobs:       u32,
+}
+
+impl GameState {
+    /// Construct a new blank city (all-Land tiles).
+    ///
+    /// Initial values mirror `createInitialState()` in `gameState.ts`:
+    /// money=100 000, day=1, tick=0, population=12, jobs=4.
+    pub fn new(width: u32, height: u32, seed: u32) -> Self {
+        let n = (width * height) as usize;
+        Self {
+            width,
+            height,
+            tiles: vec![Tile::land(); n],
+            seed,
+            rng: SeededRng::new(seed),
+            money: 100_000,
+            day: 1,
+            tick: 0,
+            population: 12,
+            jobs: 4,
+        }
+    }
+
+    // --- coordinate accessors ---
+
+    /// Flat index for (x, y), or `None` if out of bounds.
+    pub fn tile_index(&self, x: u32, y: u32) -> Option<usize> {
+        if x < self.width && y < self.height {
+            Some((y * self.width + x) as usize)
+        } else {
+            None
+        }
+    }
+
+    /// Reverse a flat index to (x, y).
+    pub fn index_to_xy(&self, idx: usize) -> (u32, u32) {
+        let idx = idx as u32;
+        (idx % self.width, idx / self.width)
+    }
+
+    pub fn tile_at(&self, x: u32, y: u32) -> Option<&Tile> {
+        self.tile_index(x, y).map(|i| &self.tiles[i])
+    }
+
+    pub fn tile_at_mut(&mut self, x: u32, y: u32) -> Option<&mut Tile> {
+        self.tile_index(x, y).map(|i| &mut self.tiles[i])
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gs() -> GameState { GameState::new(10, 8, 42) }
+
+    #[test]
+    fn dimensions_and_tile_count() {
+        let g = gs();
+        assert_eq!(g.tiles.len(), 80);
+        assert_eq!(g.width, 10);
+        assert_eq!(g.height, 8);
+    }
+
+    #[test]
+    fn initial_values_match_ts() {
+        let g = gs();
+        assert_eq!(g.money, 100_000);
+        assert_eq!(g.day, 1);
+        assert_eq!(g.tick, 0);
+        assert_eq!(g.population, 12);
+        assert_eq!(g.jobs, 4);
+    }
+
+    #[test]
+    fn all_tiles_start_as_land() {
+        let g = gs();
+        assert!(g.tiles.iter().all(|t| t.kind == TileKind::Land));
+    }
+
+    #[test]
+    fn tile_index_in_bounds() {
+        let g = gs();
+        assert_eq!(g.tile_index(0, 0), Some(0));
+        assert_eq!(g.tile_index(9, 7), Some(79));
+        assert_eq!(g.tile_index(5, 3), Some(35)); // 3*10 + 5
+    }
+
+    #[test]
+    fn tile_index_out_of_bounds() {
+        let g = gs();
+        assert_eq!(g.tile_index(10, 0), None); // x == width
+        assert_eq!(g.tile_index(0, 8), None);  // y == height
+        assert_eq!(g.tile_index(u32::MAX, u32::MAX), None);
+    }
+
+    #[test]
+    fn index_to_xy_round_trips() {
+        let g = gs();
+        for idx in 0..80usize {
+            let (x, y) = g.index_to_xy(idx);
+            assert_eq!(g.tile_index(x, y), Some(idx));
+        }
+    }
+
+    #[test]
+    fn tile_at_returns_correct_tile() {
+        let mut g = gs();
+        g.tiles[35].kind = TileKind::Road;
+        assert_eq!(g.tile_at(5, 3).unwrap().kind, TileKind::Road);
+    }
+
+    #[test]
+    fn tile_at_out_of_bounds_returns_none() {
+        let g = gs();
+        assert!(g.tile_at(10, 0).is_none());
+        assert!(g.tile_at(0, 8).is_none());
+    }
+
+    #[test]
+    fn tile_at_mut_mutates() {
+        let mut g = gs();
+        g.tile_at_mut(2, 3).unwrap().kind = TileKind::Residential;
+        assert_eq!(g.tile_at(2, 3).unwrap().kind, TileKind::Residential);
+    }
+
+    #[test]
+    fn tile_flags_round_trip() {
+        let mut t = Tile::land();
+        assert!(!t.is_powered());
+        t.set_flag(FLAG_POWERED, true);
+        assert!(t.is_powered());
+        t.set_flag(FLAG_POWERED, false);
+        assert!(!t.is_powered());
+    }
+
+    #[test]
+    fn zone_density_default_is_low() {
+        let t = Tile::land();
+        assert_eq!(t.zone_density(), ZoneDensity::Low);
+    }
+
+    #[test]
+    fn zone_density_round_trips() {
+        let mut t = Tile::land();
+        for &d in &[ZoneDensity::Low, ZoneDensity::Medium, ZoneDensity::High] {
+            t.set_zone_density(d);
+            assert_eq!(t.zone_density(), d);
+        }
+    }
+
+    #[test]
+    fn zone_density_does_not_clobber_other_flags() {
+        let mut t = Tile::land();
+        t.set_flag(FLAG_POWERED, true);
+        t.set_flag(FLAG_WATERED, true);
+        t.set_zone_density(ZoneDensity::High);
+        assert!(t.is_powered());
+        assert!(t.is_watered());
+        assert_eq!(t.zone_density(), ZoneDensity::High);
+    }
+
+    #[test]
+    fn rng_is_seeded_from_state_seed() {
+        let mut g = GameState::new(4, 4, 0);
+        // Just confirm the RNG produces the same first value as SeededRng::new(0).
+        let expected = crate::rng::SeededRng::new(0).next_u32();
+        assert_eq!(g.rng.next_u32(), expected);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `SeededRng` (SplitMix64 seeding + xoshiro128\*\* generation) with `Debug`/`Clone` derives; verified against the P0-1 reference vectors from `rng.test.ts`
- Introduces minimal `GameState` (width/height/tiles/seed/rng/money/day/tick/population/jobs) matching TS initial values
- `Tile` struct with `TileKind`, flags byte (powered/watered/abandoned/underlays/overlay + 2-bit zone density), happiness, elevation, optional `building_id` and `underground`
- Coordinate accessors: `tile_index`, `tile_at`, `tile_at_mut`, `index_to_xy`

## Test plan

- [x] `cargo test -p sim_core` — 24 tests pass (10 RNG reference vectors, 14 state/accessor tests)
- [x] RNG reference vectors match `rng.test.ts` exactly (SEED0, SEED1, SEED12345)
- [x] Zone density packed into bits 6–7 of flags without clobbering power/water flags

## Phase 3 DoD

P3-1 DoD: "Rust RNG matches the P0-1 reference vectors; state unit tests pass." ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AR6ezY6qjLad3JLXScFaY8