### PR TITLE
feat(sim_core): P3-4 — zone growth with adjacency checks (seeded RNG)

### DIFF
--- a/crates/sim_core/src/adjacency.rs
+++ b/crates/sim_core/src/adjacency.rs
@@ -1,0 +1,229 @@
+use std::collections::{HashSet, VecDeque};
+use sim_protocol::tile_kind::TileKind;
+use crate::state::{GameState, Tile, FLAG_POWERED, FLAG_WATERED};
+
+/// Four orthogonal directions as (dx, dy) pairs.
+const DIRS: [(i32, i32); 4] = [(0, -1), (1, 0), (0, 1), (-1, 0)];
+
+/// Iterator over in-bounds orthogonal neighbours of (x, y).
+pub fn orthogonal_neighbours(
+    width: u32,
+    height: u32,
+    x: u32,
+    y: u32,
+) -> impl Iterator<Item = (u32, u32)> {
+    DIRS.into_iter().filter_map(move |(dx, dy)| {
+        let nx = x as i32 + dx;
+        let ny = y as i32 + dy;
+        if nx >= 0 && ny >= 0 && (nx as u32) < width && (ny as u32) < height {
+            Some((nx as u32, ny as u32))
+        } else {
+            None
+        }
+    })
+}
+
+/// Returns true if the tile is a zone (residential / commercial / industrial).
+/// Mirrors `isZone()` in `app/src/game/adjacency.ts`.
+pub fn is_zone(tile: &Tile) -> bool {
+    matches!(tile.kind, TileKind::Residential | TileKind::Commercial | TileKind::Industrial)
+}
+
+/// Returns true if any orthogonal neighbour of (x, y) is a road, road-underlay,
+/// or power line.  Mirrors `hasRoadAccess()` in `adjacency.ts`.
+pub fn has_road_access(state: &GameState, x: u32, y: u32) -> bool {
+    for (nx, ny) in orthogonal_neighbours(state.width, state.height, x, y) {
+        let Some(t) = state.tile_at(nx, ny) else { continue };
+        if t.kind == TileKind::Road || t.has_road_underlay() || t.kind == TileKind::PowerLine {
+            return true;
+        }
+    }
+    false
+}
+
+/// Returns true if (x, y) is a zone tile that has at least one non-zone
+/// orthogonal neighbour.  Mirrors `isFrontierZone()` in `adjacency.ts`.
+pub fn is_frontier_zone(state: &GameState, x: u32, y: u32) -> bool {
+    let Some(tile) = state.tile_at(x, y) else { return false };
+    if !is_zone(tile) { return false; }
+    for (nx, ny) in orthogonal_neighbours(state.width, state.height, x, y) {
+        let Some(n) = state.tile_at(nx, ny) else { continue };
+        if !is_zone(n) { return true; }
+    }
+    false
+}
+
+/// BFS through zone tiles from (start_x, start_y): returns true if a road
+/// tile can be reached.  Mirrors `zoneHasRoadPath()` in `adjacency.ts`.
+pub fn zone_has_road_path(state: &GameState, start_x: u32, start_y: u32) -> bool {
+    let Some(start) = state.tile_at(start_x, start_y) else { return false };
+    if !is_zone(start) { return false; }
+    if has_road_access(state, start_x, start_y) { return true; }
+
+    let mut visited: HashSet<usize> = HashSet::new();
+    let mut queue: VecDeque<(u32, u32)> = VecDeque::new();
+    queue.push_back((start_x, start_y));
+
+    while let Some((x, y)) = queue.pop_front() {
+        for (nx, ny) in orthogonal_neighbours(state.width, state.height, x, y) {
+            let idx = (ny * state.width + nx) as usize;
+            if visited.contains(&idx) { continue; }
+            visited.insert(idx);
+            let Some(n) = state.tile_at(nx, ny) else { continue };
+            if !is_zone(n) { continue; }
+            if has_road_access(state, nx, ny) { return true; }
+            queue.push_back((nx, ny));
+        }
+    }
+    false
+}
+
+/// Returns true if (x, y) is powered directly or via an adjacent powered carrier.
+/// Mirrors `tileHasPower()` in `adjacency.ts`.
+pub fn tile_has_power(state: &GameState, x: u32, y: u32) -> bool {
+    if state.tile_at(x, y).map_or(false, |t| t.flags & FLAG_POWERED != 0) {
+        return true;
+    }
+    use crate::utilities::is_power_carrier_pub;
+    for (nx, ny) in orthogonal_neighbours(state.width, state.height, x, y) {
+        if let Some(n) = state.tile_at(nx, ny) {
+            if n.flags & FLAG_POWERED != 0 && is_power_carrier_pub(n) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Returns true if (x, y) is watered directly or via an adjacent watered carrier.
+/// Mirrors `tileHasWater()` in `adjacency.ts`.
+pub fn tile_has_water(state: &GameState, x: u32, y: u32) -> bool {
+    if state.tile_at(x, y).map_or(false, |t| t.flags & FLAG_WATERED != 0) {
+        return true;
+    }
+    use crate::utilities::is_water_carrier_pub;
+    for (nx, ny) in orthogonal_neighbours(state.width, state.height, x, y) {
+        if let Some(n) = state.tile_at(nx, ny) {
+            if n.flags & FLAG_WATERED != 0 && is_water_carrier_pub(n) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::FLAG_ROAD_UNDERLAY;
+
+    fn g(w: u32, h: u32) -> GameState { GameState::new(w, h, 0) }
+    fn kind(state: &mut GameState, x: u32, y: u32, k: TileKind) {
+        state.tile_at_mut(x, y).unwrap().kind = k;
+    }
+
+    #[test]
+    fn road_gives_road_access() {
+        let mut s = g(3, 1);
+        kind(&mut s, 0, 0, TileKind::Residential);
+        kind(&mut s, 1, 0, TileKind::Road);
+        assert!(has_road_access(&s, 0, 0));
+    }
+
+    #[test]
+    fn no_adjacent_road_returns_false() {
+        let mut s = g(3, 1);
+        kind(&mut s, 0, 0, TileKind::Residential);
+        assert!(!has_road_access(&s, 0, 0));
+    }
+
+    #[test]
+    fn road_underlay_gives_access() {
+        let mut s = g(2, 1);
+        kind(&mut s, 0, 0, TileKind::Residential);
+        s.tile_at_mut(1, 0).unwrap().set_flag(FLAG_ROAD_UNDERLAY, true);
+        assert!(has_road_access(&s, 0, 0));
+    }
+
+    #[test]
+    fn is_zone_true_for_zone_kinds() {
+        for k in [TileKind::Residential, TileKind::Commercial, TileKind::Industrial] {
+            assert!(is_zone(&Tile { kind: k, ..Tile::land() }));
+        }
+    }
+
+    #[test]
+    fn is_zone_false_for_non_zone() {
+        assert!(!is_zone(&Tile::land()));
+        assert!(!is_zone(&Tile { kind: TileKind::Road, ..Tile::land() }));
+    }
+
+    #[test]
+    fn frontier_zone_adjacent_to_non_zone() {
+        // 3×2 grid: top row all Residential; (0,1) is Land — it is a non-zone
+        // in-bounds neighbour of (0,0), making (0,0) a frontier zone.
+        let mut s = g(3, 2);
+        kind(&mut s, 0, 0, TileKind::Residential);
+        kind(&mut s, 1, 0, TileKind::Residential);
+        kind(&mut s, 2, 0, TileKind::Residential);
+        // Row 1 stays as Land (default)
+        assert!(is_frontier_zone(&s, 0, 0), "(0,0) has non-zone neighbour (0,1)");
+    }
+
+    #[test]
+    fn non_frontier_zone_all_zone_neighbours() {
+        let mut s = g(3, 3);
+        for y in 0..3 {
+            for x in 0..3 {
+                kind(&mut s, x, y, TileKind::Residential);
+            }
+        }
+        // Interior tile (1,1) has only in-bounds zone neighbours — not frontier
+        assert!(!is_frontier_zone(&s, 1, 1));
+    }
+
+    #[test]
+    fn zone_has_road_path_via_adjacent_zone() {
+        let mut s = g(4, 1);
+        kind(&mut s, 0, 0, TileKind::Residential);
+        kind(&mut s, 1, 0, TileKind::Residential);
+        kind(&mut s, 2, 0, TileKind::Road);
+        // Start at (0,0) — no direct road access, but (1,0) has road access
+        assert!(zone_has_road_path(&s, 0, 0));
+    }
+
+    #[test]
+    fn zone_has_road_path_false_when_isolated() {
+        let mut s = g(3, 1);
+        kind(&mut s, 0, 0, TileKind::Residential);
+        kind(&mut s, 1, 0, TileKind::Residential);
+        assert!(!zone_has_road_path(&s, 0, 0));
+    }
+
+    #[test]
+    fn tile_has_power_direct() {
+        let mut s = g(1, 1);
+        s.tile_at_mut(0, 0).unwrap().set_flag(FLAG_POWERED, true);
+        assert!(tile_has_power(&s, 0, 0));
+    }
+
+    #[test]
+    fn tile_has_power_via_adjacent() {
+        let mut s = g(2, 1);
+        // (0,0) is an unpowered zone; (1,0) is a powered road
+        kind(&mut s, 0, 0, TileKind::Residential);
+        kind(&mut s, 1, 0, TileKind::Road);
+        s.tile_at_mut(1, 0).unwrap().set_flag(FLAG_POWERED, true);
+        assert!(tile_has_power(&s, 0, 0));
+    }
+
+    #[test]
+    fn tile_has_power_false_when_not_powered() {
+        let s = g(2, 1);
+        assert!(!tile_has_power(&s, 0, 0));
+    }
+}

--- a/crates/sim_core/src/lib.rs
+++ b/crates/sim_core/src/lib.rs
@@ -3,3 +3,5 @@
 pub mod rng;
 pub mod state;
 pub mod utilities;
+pub mod adjacency;
+pub mod zones;

--- a/crates/sim_core/src/state.rs
+++ b/crates/sim_core/src/state.rs
@@ -89,6 +89,29 @@ impl Tile {
 }
 
 // ---------------------------------------------------------------------------
+// DemandStats
+// ---------------------------------------------------------------------------
+
+/// Zone demand levels in [0, 100].  Mirrors `DemandStats` in `gameState.ts`.
+///
+/// Computed each tick by the demand system (P3-6).  P3-4 zone growth reads
+/// these values; initial city starts with modest demand so early growth fires.
+#[derive(Debug, Clone)]
+pub struct DemandStats {
+    pub residential: f32,
+    pub commercial:  f32,
+    pub industrial:  f32,
+}
+
+impl DemandStats {
+    /// Matches the initial demand a freshly-placed city would exhibit before
+    /// the first demand tick runs.  Deliberately low: growth is demand-gated.
+    pub fn initial() -> Self {
+        Self { residential: 50.0, commercial: 30.0, industrial: 20.0 }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // UtilityStats
 // ---------------------------------------------------------------------------
 
@@ -138,9 +161,15 @@ pub struct GameState {
     pub money:      i64,
     pub day:        u32,
     pub tick:       u64,
-    pub population: u32,
-    pub jobs:       u32,
-    pub utilities:  UtilityStats,
+    pub population:       u32,
+    pub jobs:             u32,
+    pub utilities:        UtilityStats,
+    pub demand:           DemandStats,
+    /// Monotonically increasing counter — bumped whenever tiles change.
+    /// Used by the zone growth cache to know when to rescan vacant lots.
+    pub tile_revision:    u32,
+    /// Next building ID to assign on placement.
+    pub next_building_id: u32,
 }
 
 impl GameState {
@@ -161,7 +190,10 @@ impl GameState {
             tick: 0,
             population: 12,
             jobs: 4,
-            utilities: UtilityStats::initial(),
+            utilities:        UtilityStats::initial(),
+            demand:           DemandStats::initial(),
+            tile_revision:    0,
+            next_building_id: 1,
         }
     }
 

--- a/crates/sim_core/src/utilities.rs
+++ b/crates/sim_core/src/utilities.rs
@@ -15,6 +15,9 @@ pub enum UtilityKind { Power, Water }
 // ---------------------------------------------------------------------------
 
 /// Mirrors `isPowerCarrier()` in `app/src/game/adjacency.ts`.
+/// Public alias for use by `adjacency.rs`.
+pub fn is_power_carrier_pub(tile: &Tile) -> bool { is_power_carrier(tile) }
+
 fn is_power_carrier(tile: &Tile) -> bool {
     use TileKind::*;
     if tile.power_plant_mw > 0       { return true; }
@@ -26,6 +29,9 @@ fn is_power_carrier(tile: &Tile) -> bool {
 }
 
 /// Mirrors `isWaterCarrier()` in `app/src/game/adjacency.ts`.
+/// Public alias for use by `adjacency.rs`.
+pub fn is_water_carrier_pub(tile: &Tile) -> bool { is_water_carrier(tile) }
+
 fn is_water_carrier(tile: &Tile) -> bool {
     use TileKind::*;
     if tile.underground == Some(WaterPipe) { return true; }

--- a/crates/sim_core/src/zones.rs
+++ b/crates/sim_core/src/zones.rs
@@ -1,0 +1,345 @@
+use std::collections::{BTreeSet, HashMap};
+use sim_protocol::tile_kind::TileKind;
+use crate::adjacency::{has_road_access, is_frontier_zone, zone_has_road_path, tile_has_power, tile_has_water};
+use crate::rng::SeededRng;
+use crate::state::{GameState, FLAG_ABANDONED};
+
+// ---------------------------------------------------------------------------
+// Zone growth simulation state (not serialised — rebuilt from GameState)
+// ---------------------------------------------------------------------------
+
+/// Transient zone growth state — lives on the simulation driver, not in
+/// `GameState`, mirroring how `Simulation` holds these in the TS codebase.
+///
+/// `vacant` uses `BTreeSet` for deterministic iteration order, matching TS
+/// `Set<number>` which iterates in insertion (numeric) order.
+#[derive(Debug, Default)]
+pub struct ZoneGrowthSim {
+    /// Countdown timers (ticks remaining) per vacant-zone tile index.
+    timers:        HashMap<usize, u32>,
+    /// Set of tile indices that are vacant zone tiles.
+    vacant:        BTreeSet<usize>,
+    /// Last seen `GameState.tile_revision` — used to invalidate the cache.
+    last_revision: u32,
+}
+
+impl ZoneGrowthSim {
+    pub fn new() -> Self { Self::default() }
+
+    /// Rebuild the vacant-zone cache if `tile_revision` changed or cache is empty.
+    fn refresh_vacant(&mut self, state: &GameState) {
+        let rev = state.tile_revision;
+        if rev == self.last_revision && !self.vacant.is_empty() { return; }
+
+        self.vacant.clear();
+        for (idx, tile) in state.tiles.iter().enumerate() {
+            if tile.building_id.is_some() { continue; }
+            if matches!(tile.kind, TileKind::Residential | TileKind::Commercial | TileKind::Industrial) {
+                self.vacant.insert(idx);
+            }
+        }
+        // Prune stale timers
+        self.timers.retain(|k, _| self.vacant.contains(k));
+        self.last_revision = rev;
+    }
+
+    /// Number of tracked vacant zones (for tests / diagnostics).
+    #[cfg(test)]
+    pub fn vacant_count(&self) -> usize { self.vacant.len() }
+
+    /// Run one zone-growth tick.  Returns `true` if any building was placed.
+    ///
+    /// Mirrors `spawnZoneBuildings()` + `applyZoneGrowthForType()` from
+    /// `simulation.ts`.  `delay_ticks` ≈ `ticksPerSecond * 2` (~2 s delay).
+    pub fn tick(&mut self, state: &mut GameState, rng: &mut SeededRng, delay_ticks: u32) -> bool {
+        self.refresh_vacant(state);
+
+        // --- build candidate lists ---
+        let mut residential: Vec<Candidate> = Vec::new();
+        let mut commercial:  Vec<Candidate> = Vec::new();
+        let mut industrial:  Vec<Candidate> = Vec::new();
+
+        let vacant_snapshot: Vec<usize> = self.vacant.iter().copied().collect();
+
+        for idx in vacant_snapshot {
+            let tile = &state.tiles[idx];
+            // Already developed (building placed by another system)
+            if tile.building_id.is_some() {
+                self.timers.remove(&idx);
+                self.vacant.remove(&idx);
+                continue;
+            }
+            if !matches!(tile.kind, TileKind::Residential | TileKind::Commercial | TileKind::Industrial) {
+                self.timers.remove(&idx);
+                self.vacant.remove(&idx);
+                continue;
+            }
+
+            let x = (idx as u32) % state.width;
+            let y = (idx as u32) / state.width;
+            let has_road  = has_road_access(state, x, y);
+            let has_chain = zone_has_road_path(state, x, y);
+            let frontier  = is_frontier_zone(state, x, y);
+            if !has_road && !has_chain && !frontier {
+                self.timers.remove(&idx);
+                continue;
+            }
+
+            // Growth-delay countdown
+            let delay = delay_ticks.max(1);
+            let timer = self.timers.entry(idx).or_insert(delay);
+            if *timer > 1 {
+                *timer -= 1;
+                continue;
+            }
+            self.timers.remove(&idx);
+
+            let has_power = tile_has_power(state, x, y);
+            let has_water = tile_has_water(state, x, y);
+            let kind = tile.kind;
+            match kind {
+                TileKind::Residential => residential.push(Candidate { idx, x, y, has_power, has_water }),
+                TileKind::Commercial  => commercial .push(Candidate { idx, x, y, has_power, has_water }),
+                TileKind::Industrial  => industrial .push(Candidate { idx, x, y, has_power, has_water }),
+                _ => {}
+            }
+        }
+
+        let demand_r = state.demand.residential;
+        let demand_c = state.demand.commercial;
+        let demand_i = state.demand.industrial;
+        let grew_r = grow_zone_type(state, rng, TileKind::Residential, demand_r, &mut residential, &mut self.vacant);
+        let grew_c = grow_zone_type(state, rng, TileKind::Commercial,  demand_c, &mut commercial,  &mut self.vacant);
+        let grew_i = grow_zone_type(state, rng, TileKind::Industrial,  demand_i, &mut industrial,  &mut self.vacant);
+
+        if grew_r || grew_c || grew_i {
+            self.last_revision = state.tile_revision;
+        }
+
+        grew_r || grew_c || grew_i
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+struct Candidate { idx: usize, x: u32, y: u32, has_power: bool, has_water: bool }
+
+/// Mirrors `applyZoneGrowthForType()` from `simulation.ts`.
+fn grow_zone_type(
+    state:      &mut GameState,
+    rng:        &mut SeededRng,
+    _kind:      TileKind,
+    demand:     f32,
+    candidates: &mut Vec<Candidate>,
+    vacant:     &mut BTreeSet<usize>,
+) -> bool {
+    if candidates.is_empty() { return false; }
+
+    // Cap: how many lots can develop this tick
+    let max_new = (1 + (demand / 40.0) as u32).clamp(0, 4);
+    if max_new == 0 { return false; }
+
+    // Base growth probability
+    let p_grow: f32 = if demand >= 50.0 {
+        1.0
+    } else if demand <= 0.0 {
+        0.0
+    } else {
+        ((demand + 20.0) / 120.0).clamp(0.0, 1.0)
+    };
+
+    let power_bal = state.utilities.power as f32;
+    let water_bal = state.utilities.water as f32;
+
+    // Fisher-Yates shuffle over candidates (matches TS shuffle loop)
+    let n = candidates.len();
+    for i in (1..n).rev() {
+        let j = rng.next_below((i + 1) as u32) as usize;
+        candidates.swap(i, j);
+    }
+
+    let mut grown = 0u32;
+    for c in candidates.iter() {
+        if grown >= max_new { break; }
+
+        let mut util_factor: f32 = 1.0;
+        if !c.has_power { util_factor *= 0.15; }
+        if !c.has_water { util_factor *= 0.35; }
+        if power_bal < 0.0 { util_factor *= (1.0 + power_bal / 20.0).clamp(0.05, 1.0); }
+        if water_bal < 0.0 { util_factor *= (1.0 + water_bal / 30.0).clamp(0.05, 1.0); }
+
+        let adj_p = (p_grow * util_factor).clamp(0.0, 1.0);
+        if adj_p <= 0.0 || rng.next_f32() > adj_p { continue; }
+
+        if place_zone_building(state, c.x, c.y) {
+            vacant.remove(&c.idx);
+            grown += 1;
+        }
+    }
+    grown > 0
+}
+
+/// Minimal building placement for zone tiles — sets `building_id` and bumps
+/// state counters.  Full building-record tracking is wired in P3-5.
+fn place_zone_building(state: &mut GameState, x: u32, y: u32) -> bool {
+    let Some(idx) = state.tile_index(x, y) else { return false };
+    if state.tiles[idx].building_id.is_some() { return false; }
+
+    let bid = state.next_building_id as u16;
+    state.next_building_id += 1;
+    state.tile_revision += 1;
+
+    let tile = &mut state.tiles[idx];
+    tile.building_id = Some(bid);
+    tile.set_flag(FLAG_ABANDONED, false);
+    true
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::FLAG_POWERED;
+
+    fn gs(w: u32, h: u32) -> GameState { GameState::new(w, h, 42) }
+
+    fn kind(s: &mut GameState, x: u32, y: u32, k: TileKind) {
+        s.tile_at_mut(x, y).unwrap().kind = k;
+    }
+
+    fn road(s: &mut GameState, x: u32, y: u32) { kind(s, x, y, TileKind::Road); }
+
+    fn residential(s: &mut GameState, x: u32, y: u32) {
+        kind(s, x, y, TileKind::Residential);
+    }
+
+    fn power_tile(s: &mut GameState, x: u32, y: u32) {
+        s.tile_at_mut(x, y).unwrap().set_flag(FLAG_POWERED, true);
+    }
+
+    #[test]
+    fn no_growth_without_demand() {
+        let mut s = gs(3, 1);
+        residential(&mut s, 0, 0);
+        road(&mut s, 1, 0);
+        s.demand.residential = 0.0;
+        let mut zg = ZoneGrowthSim::new();
+        let mut rng = SeededRng::new(42);
+        // Even with long enough timer countdown, demand=0 → no growth
+        for _ in 0..100 {
+            zg.tick(&mut s, &mut rng, 1);
+        }
+        assert!(s.tile_at(0, 0).unwrap().building_id.is_none());
+    }
+
+    #[test]
+    fn growth_with_high_demand_and_road() {
+        let mut s = gs(3, 1);
+        residential(&mut s, 0, 0);
+        road(&mut s, 1, 0);
+        power_tile(&mut s, 1, 0);
+        // Also mark the residential as powered (it's adjacent to powered road)
+        power_tile(&mut s, 0, 0);
+        s.demand.residential = 100.0;
+        s.utilities.power = 100;
+        s.utilities.water = 100;
+        let mut zg = ZoneGrowthSim::new();
+        let mut rng = SeededRng::new(0);
+        let mut grew = false;
+        for _ in 0..50 {
+            if zg.tick(&mut s, &mut rng, 1) { grew = true; break; }
+        }
+        assert!(grew, "should have grown with demand=100");
+        assert!(s.tile_at(0, 0).unwrap().building_id.is_some());
+    }
+
+    #[test]
+    fn no_growth_without_road_access() {
+        // 3×3 grid: interior (1,1) is Residential surrounded by Residential on all
+        // four sides — not a frontier zone, no road access, no road path.
+        let mut s = gs(3, 3);
+        for y in 0..3u32 {
+            for x in 0..3u32 {
+                residential(&mut s, x, y);
+            }
+        }
+        s.demand.residential = 100.0;
+        let mut zg = ZoneGrowthSim::new();
+        let mut rng = SeededRng::new(0);
+        for _ in 0..50 {
+            zg.tick(&mut s, &mut rng, 1);
+        }
+        // Centre tile should never develop — it is excluded by road-access check
+        assert!(s.tile_at(1, 1).unwrap().building_id.is_none());
+    }
+
+    #[test]
+    fn growth_delay_prevents_immediate_growth() {
+        let mut s = gs(3, 1);
+        residential(&mut s, 0, 0);
+        road(&mut s, 1, 0);
+        power_tile(&mut s, 0, 0);
+        s.demand.residential = 100.0;
+        s.utilities.power = 100;
+        s.utilities.water = 100;
+        let mut zg = ZoneGrowthSim::new();
+        let mut rng = SeededRng::new(0);
+        // delay_ticks=10 → first 9 ticks must not grow
+        for i in 0..9 {
+            let grew = zg.tick(&mut s, &mut rng, 10);
+            assert!(!grew, "should not grow on tick {i} (delay not expired)");
+        }
+    }
+
+    #[test]
+    fn place_zone_building_sets_building_id() {
+        let mut s = gs(1, 1);
+        kind(&mut s, 0, 0, TileKind::Residential);
+        let ok = place_zone_building(&mut s, 0, 0);
+        assert!(ok);
+        assert_eq!(s.tile_at(0, 0).unwrap().building_id, Some(1));
+        assert_eq!(s.next_building_id, 2);
+        assert_eq!(s.tile_revision, 1);
+    }
+
+    #[test]
+    fn place_zone_building_rejects_occupied() {
+        let mut s = gs(1, 1);
+        kind(&mut s, 0, 0, TileKind::Residential);
+        place_zone_building(&mut s, 0, 0);
+        let ok2 = place_zone_building(&mut s, 0, 0);
+        assert!(!ok2, "second placement should fail");
+        assert_eq!(s.next_building_id, 2);
+    }
+
+    #[test]
+    fn determinism_same_seed_same_outcome() {
+        fn run(seed: u32) -> Option<u16> {
+            let mut s = gs(4, 1);
+            residential(&mut s, 0, 0);
+            residential(&mut s, 1, 0);
+            road(&mut s, 2, 0);
+            power_tile(&mut s, 0, 0);
+            power_tile(&mut s, 1, 0);
+            s.demand.residential = 60.0;
+            s.utilities.power = 100;
+            s.utilities.water = 100;
+            let mut zg = ZoneGrowthSim::new();
+            let mut rng = SeededRng::new(seed);
+            for _ in 0..30 {
+                zg.tick(&mut s, &mut rng, 1);
+            }
+            s.tile_at(0, 0).unwrap().building_id
+                .or_else(|| s.tile_at(1, 0).unwrap().building_id)
+        }
+        // Same seed → same outcome
+        assert_eq!(run(7), run(7));
+        // Different seeds → might differ (at least one should grow)
+        assert!(run(7).is_some() || run(99).is_some());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `DemandStats` and `tile_revision`/`next_building_id` to `GameState`
- `adjacency.rs`: ports all six predicates from `adjacency.ts` — `has_road_access`, `is_zone`, `is_frontier_zone`, `zone_has_road_path`, `tile_has_power`, `tile_has_water`; 12 unit tests
- `zones.rs`: `ZoneGrowthSim` with per-tile growth-delay timers and demand-scaled probability roll; Fisher-Yates shuffle uses the seeded RNG (matching TS exactly); `BTreeSet` used for the vacant-zone cache to guarantee deterministic iteration order (TS `Set<number>` iterates in insertion/numeric order — `HashSet` would be non-deterministic); 7 unit tests including same-seed→same-outcome check

## Test plan

- [x] `cargo test -p sim_core` — 65 tests pass, zero warnings
- [x] `determinism_same_seed_same_outcome` — same seed produces same building placement
- [x] `growth_delay_prevents_immediate_growth` — delay countdown works
- [x] `no_growth_without_road_access` — interior zone tile with no road access never develops
- [x] `no_growth_without_demand` — demand=0 yields zero growth

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AR6ezY6qjLad3JLXScFaY8