### PR TITLE
feat(sim_core): P3-5 — building state machine + update/decay

### DIFF
--- a/crates/sim_core/src/buildings.rs
+++ b/crates/sim_core/src/buildings.rs
@@ -1,0 +1,405 @@
+use sim_protocol::tile_kind::TileKind;
+use crate::adjacency::{tile_has_power, tile_has_water};
+use crate::state::{GameState, FLAG_ABANDONED};
+
+// ---------------------------------------------------------------------------
+// BuildingStatus
+// ---------------------------------------------------------------------------
+
+/// Runtime status of a building.  Mirrors `BuildingStatus` in
+/// `app/src/game/buildings/state.ts`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuildingStatus {
+    Active,
+    InactiveNoPower,
+    InactiveNoWater,
+    InactiveDamaged,
+}
+
+// ---------------------------------------------------------------------------
+// BuildingTemplate (static per-kind data)
+// ---------------------------------------------------------------------------
+
+/// Static properties of a building kind — looked up by `TileKind`.
+/// Mirrors the `BuildingTemplate` interface in `buildings/templates.ts`.
+pub struct BuildingTemplate {
+    pub footprint:      (u32, u32),   // (width, height)
+    pub requires_power: bool,
+    pub requires_water: bool,
+    pub water_use:      f32,
+    pub is_zone:        bool,
+    pub is_power_plant: bool,
+}
+
+impl BuildingTemplate {
+    const fn zone(w: u32, h: u32) -> Self {
+        Self { footprint: (w, h), requires_power: true, requires_water: true, water_use: 1.0, is_zone: true, is_power_plant: false }
+    }
+    const fn civic_power(w: u32, h: u32) -> Self {
+        Self { footprint: (w, h), requires_power: true, requires_water: false, water_use: 0.0, is_zone: false, is_power_plant: false }
+    }
+    const fn civic_no_power(w: u32, h: u32) -> Self {
+        Self { footprint: (w, h), requires_power: false, requires_water: false, water_use: 0.0, is_zone: false, is_power_plant: false }
+    }
+    const fn power_plant(w: u32, h: u32) -> Self {
+        Self { footprint: (w, h), requires_power: false, requires_water: false, water_use: 0.0, is_zone: false, is_power_plant: true }
+    }
+}
+
+/// Look up static template data by the tile kind used when placing a building.
+///
+/// Returns `None` for non-building tile kinds (Land, Road, etc.).
+pub fn get_building_template(kind: TileKind) -> Option<&'static BuildingTemplate> {
+    use TileKind::*;
+    static RESIDENTIAL: BuildingTemplate  = BuildingTemplate::zone(1, 1);
+    static COMMERCIAL:  BuildingTemplate  = BuildingTemplate::zone(1, 1);
+    static INDUSTRIAL:  BuildingTemplate  = BuildingTemplate::zone(1, 1);
+    static WATER_PUMP:  BuildingTemplate  = BuildingTemplate::civic_power(1, 1);
+    static WATER_TOWER: BuildingTemplate  = BuildingTemplate::civic_power(2, 2);
+    static PARK:        BuildingTemplate  = BuildingTemplate::civic_no_power(1, 1);
+    static ELEM_SCHOOL: BuildingTemplate  = BuildingTemplate::civic_power(2, 2);
+    static HIGH_SCHOOL: BuildingTemplate  = BuildingTemplate::civic_power(2, 2);
+    static HYDRO_PLANT: BuildingTemplate  = BuildingTemplate::power_plant(2, 2);
+
+    match kind {
+        Residential     => Some(&RESIDENTIAL),
+        Commercial      => Some(&COMMERCIAL),
+        Industrial      => Some(&INDUSTRIAL),
+        WaterPump       => Some(&WATER_PUMP),
+        WaterTower      => Some(&WATER_TOWER),
+        Park            => Some(&PARK),
+        ElementarySchool => Some(&ELEM_SCHOOL),
+        HighSchool      => Some(&HIGH_SCHOOL),
+        HydroPlant      => Some(&HYDRO_PLANT),
+        _               => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// BuildingInstance
+// ---------------------------------------------------------------------------
+
+/// A placed building in the world.  Mirrors `BuildingInstance` in
+/// `app/src/game/buildings/state.ts`.
+#[derive(Debug, Clone)]
+pub struct BuildingInstance {
+    pub id:            u32,
+    /// The tile kind used to identify this building (determines template lookup).
+    pub kind:          TileKind,
+    /// Top-left corner of the building footprint.
+    pub origin:        (u32, u32),
+    pub status:        BuildingStatus,
+    /// 0–100; reaches 0 → InactiveDamaged (not yet implemented in the Rust sim).
+    pub health:        u8,
+    /// Pressure counter — see `apply_building_decay`.  Float to accumulate fractional
+    /// increments matching the TS implementation.
+    pub trouble_ticks: f32,
+}
+
+impl BuildingInstance {
+    pub fn new(id: u32, kind: TileKind, origin: (u32, u32)) -> Self {
+        Self { id, kind, origin, status: BuildingStatus::Active, health: 100, trouble_ticks: 0.0 }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DecayConfig (matches `this.decayConfig` in `simulation.ts`)
+// ---------------------------------------------------------------------------
+
+pub struct DecayConfig {
+    pub demand_low_threshold:   f32,
+    pub happiness_threshold:    f32,
+    pub trouble_increment:      f32,
+    pub trouble_power_penalty:  f32,
+    pub trouble_decay:          f32,
+    pub trouble_abandon_thresh: f32,
+}
+
+impl Default for DecayConfig {
+    fn default() -> Self {
+        Self {
+            demand_low_threshold:   5.0,
+            happiness_threshold:    0.4,
+            trouble_increment:      1.0,
+            trouble_power_penalty:  3.0,
+            trouble_decay:          2.0,
+            trouble_abandon_thresh: 12.0,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// update_building_states
+// ---------------------------------------------------------------------------
+
+/// Update `BuildingStatus` for every placed building based on power/water
+/// coverage.  Mirrors `updateBuildingStates()` in `manager.ts`.
+pub fn update_building_states(state: &mut GameState, water_enabled: bool) {
+    for i in 0..state.buildings.len() {
+        let bid      = state.buildings[i].kind;
+        let (ox, oy) = state.buildings[i].origin;
+        let health   = state.buildings[i].health;
+
+        let Some(tmpl) = get_building_template(bid) else { continue };
+
+        if health == 0 {
+            state.buildings[i].status = BuildingStatus::InactiveDamaged;
+            continue;
+        }
+
+        let (w, h) = tmpl.footprint;
+
+        let has_power = if tmpl.requires_power {
+            let mut powered_tiles = 0u32;
+            for dy in 0..h {
+                for dx in 0..w {
+                    if tile_has_power(state, ox + dx, oy + dy) {
+                        powered_tiles += 1;
+                    }
+                }
+            }
+            powered_tiles == w * h
+        } else {
+            true
+        };
+
+        if !has_power {
+            state.buildings[i].status = BuildingStatus::InactiveNoPower;
+            continue;
+        }
+
+        let needs_water = water_enabled && tmpl.requires_water && tmpl.water_use > 0.0;
+        if needs_water {
+            let mut watered_tiles = 0u32;
+            for dy in 0..h {
+                for dx in 0..w {
+                    if tile_has_water(state, ox + dx, oy + dy) {
+                        watered_tiles += 1;
+                    }
+                }
+            }
+            state.buildings[i].status = if watered_tiles == w * h {
+                BuildingStatus::Active
+            } else {
+                BuildingStatus::InactiveNoWater
+            };
+        } else {
+            state.buildings[i].status = BuildingStatus::Active;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// apply_building_decay
+// ---------------------------------------------------------------------------
+
+/// Increment trouble ticks for zone buildings under stress; abandon those that
+/// exceed the threshold.  Mirrors `applyBuildingDecay()` in `simulation.ts`.
+pub fn apply_building_decay(state: &mut GameState, cfg: &DecayConfig) {
+    let mut to_abandon: Vec<u32> = Vec::new();
+
+    for i in 0..state.buildings.len() {
+        let kind   = state.buildings[i].kind;
+        let origin = state.buildings[i].origin;
+        let status = state.buildings[i].status;
+
+        let Some(tmpl) = get_building_template(kind) else { continue };
+        if !tmpl.is_zone { continue; }
+
+        let (ox, oy) = origin;
+        let tile_happiness = state.tiles
+            .get((oy * state.width + ox) as usize)
+            .map(|t| t.happiness)
+            .unwrap_or(1.0);
+
+        // Inline demand lookup to avoid a second borrow of `state`
+        let demand: f32 = match kind {
+            TileKind::Residential => state.demand.residential,
+            TileKind::Commercial  => state.demand.commercial,
+            TileKind::Industrial  => state.demand.industrial,
+            _                     => 0.0,
+        };
+
+        let no_power = status == BuildingStatus::InactiveNoPower;
+        let no_water = status == BuildingStatus::InactiveNoWater;
+        let unhappy  = tile_happiness < cfg.happiness_threshold;
+        // Education service coverage — stub until P3-8 (always unserved for now)
+        let education_unserved = false;
+
+        let low_demand = demand < cfg.demand_low_threshold;
+        let mut trouble = state.buildings[i].trouble_ticks;
+
+        if low_demand && (unhappy || no_power || no_water) { trouble += cfg.trouble_increment; }
+        if unhappy && (no_power || no_water)               { trouble += cfg.trouble_increment; }
+        if no_power                                         { trouble += cfg.trouble_power_penalty; }
+        if no_water                                         { trouble += cfg.trouble_increment * 0.5; }
+        if education_unserved                               { trouble += cfg.trouble_increment * 0.5; }
+
+        if !low_demand && !unhappy && !no_power && !no_water {
+            trouble = (trouble - cfg.trouble_decay).max(0.0);
+            if !education_unserved {
+                trouble = (trouble - cfg.trouble_decay * 0.25).max(0.0);
+            }
+        }
+
+        state.buildings[i].trouble_ticks = trouble;
+
+        if trouble >= cfg.trouble_abandon_thresh {
+            to_abandon.push(state.buildings[i].id);
+        }
+    }
+
+    for bid in to_abandon {
+        abandon_zone_building(state, bid);
+    }
+}
+
+/// Remove a zone building, clearing the tile but preserving the zone kind so
+/// the lot can regrow.  Mirrors `abandonZoneBuilding()` in `simulation.ts`.
+fn abandon_zone_building(state: &mut GameState, building_id: u32) {
+    state.buildings.retain(|b| b.id != building_id);
+    for tile in &mut state.tiles {
+        if tile.building_id == Some(building_id as u16) {
+            tile.building_id = None;
+            tile.power_plant_mw = 0;
+            tile.set_flag(FLAG_ABANDONED, true);
+            tile.happiness = (tile.happiness - 0.1_f32).max(0.1);
+        }
+    }
+    state.tile_revision += 1;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::FLAG_POWERED;
+
+    fn gs(w: u32, h: u32) -> GameState { GameState::new(w, h, 0) }
+
+    fn place(s: &mut GameState, kind: TileKind, x: u32, y: u32) -> u32 {
+        let id = s.next_building_id;
+        s.next_building_id += 1;
+        let tile = s.tile_at_mut(x, y).unwrap();
+        tile.kind = kind;
+        tile.building_id = Some(id as u16);
+        s.buildings.push(BuildingInstance::new(id, kind, (x, y)));
+        s.tile_revision += 1;
+        id
+    }
+
+    #[test]
+    fn zone_building_active_when_powered_and_watered() {
+        let mut s = gs(1, 1);
+        place(&mut s, TileKind::Residential, 0, 0);
+        s.tile_at_mut(0, 0).unwrap().set_flag(FLAG_POWERED, true);
+        s.tile_at_mut(0, 0).unwrap().set_flag(crate::state::FLAG_WATERED, true);
+        update_building_states(&mut s, true);
+        assert_eq!(s.buildings[0].status, BuildingStatus::Active);
+    }
+
+    #[test]
+    fn zone_building_inactive_no_power() {
+        let mut s = gs(1, 1);
+        place(&mut s, TileKind::Residential, 0, 0);
+        // not powered, not watered
+        update_building_states(&mut s, true);
+        assert_eq!(s.buildings[0].status, BuildingStatus::InactiveNoPower);
+    }
+
+    #[test]
+    fn zone_building_inactive_no_water_when_powered_but_not_watered() {
+        let mut s = gs(1, 1);
+        place(&mut s, TileKind::Residential, 0, 0);
+        s.tile_at_mut(0, 0).unwrap().set_flag(FLAG_POWERED, true);
+        // not watered
+        update_building_states(&mut s, true);
+        assert_eq!(s.buildings[0].status, BuildingStatus::InactiveNoWater);
+    }
+
+    #[test]
+    fn park_active_without_power_or_water() {
+        let mut s = gs(1, 1);
+        place(&mut s, TileKind::Park, 0, 0);
+        update_building_states(&mut s, true);
+        assert_eq!(s.buildings[0].status, BuildingStatus::Active);
+    }
+
+    #[test]
+    fn power_plant_active_without_power_input() {
+        let mut s = gs(2, 2);
+        let id = s.next_building_id;
+        // Place 2×2 hydro plant manually
+        for dy in 0..2 {
+            for dx in 0..2 {
+                let tile = s.tile_at_mut(dx, dy).unwrap();
+                tile.kind = TileKind::HydroPlant;
+                tile.building_id = Some(id as u16);
+            }
+        }
+        s.buildings.push(BuildingInstance::new(id, TileKind::HydroPlant, (0, 0)));
+        s.next_building_id += 1;
+        update_building_states(&mut s, true);
+        assert_eq!(s.buildings[0].status, BuildingStatus::Active,
+            "power plants require no external power");
+    }
+
+    #[test]
+    fn decay_increments_trouble_on_no_power() {
+        let mut s = gs(1, 1);
+        place(&mut s, TileKind::Residential, 0, 0);
+        s.buildings[0].status = BuildingStatus::InactiveNoPower;
+        s.demand.residential = 50.0;  // above low threshold — only noPower penalty
+        let cfg = DecayConfig::default();
+        apply_building_decay(&mut s, &cfg);
+        assert_eq!(s.buildings[0].trouble_ticks, cfg.trouble_power_penalty);
+    }
+
+    #[test]
+    fn decay_abandons_building_at_threshold() {
+        let mut s = gs(1, 1);
+        place(&mut s, TileKind::Residential, 0, 0);
+        s.buildings[0].status = BuildingStatus::InactiveNoPower;
+        let cfg = DecayConfig::default();
+        s.buildings[0].trouble_ticks = cfg.trouble_abandon_thresh - 1.0;
+        s.demand.residential = 0.0;  // low demand — extra pressure
+        apply_building_decay(&mut s, &cfg);
+        // Building should be abandoned
+        assert!(s.buildings.is_empty(), "building should be removed on abandon");
+        assert!(s.tile_at(0, 0).unwrap().building_id.is_none());
+        assert!(s.tile_at(0, 0).unwrap().is_abandoned());
+    }
+
+    #[test]
+    fn decay_bleeds_trouble_when_conditions_are_good() {
+        let mut s = gs(1, 1);
+        place(&mut s, TileKind::Residential, 0, 0);
+        s.buildings[0].status = BuildingStatus::Active;
+        s.buildings[0].trouble_ticks = 5.0;
+        s.demand.residential = 50.0;
+        s.tile_at_mut(0, 0).unwrap().happiness = 1.0;  // above threshold
+        let cfg = DecayConfig::default();
+        apply_building_decay(&mut s, &cfg);
+        // Trouble should decrease by trouble_decay + trouble_decay * 0.25 (no education unserved)
+        let expected = (5.0_f32 - cfg.trouble_decay - cfg.trouble_decay * 0.25).max(0.0);
+        assert!((s.buildings[0].trouble_ticks - expected).abs() < 0.001);
+    }
+
+    #[test]
+    fn get_building_template_returns_none_for_road() {
+        assert!(get_building_template(TileKind::Road).is_none());
+        assert!(get_building_template(TileKind::Land).is_none());
+    }
+
+    #[test]
+    fn get_building_template_zone_footprint_is_1x1() {
+        for k in [TileKind::Residential, TileKind::Commercial, TileKind::Industrial] {
+            let tmpl = get_building_template(k).unwrap();
+            assert_eq!(tmpl.footprint, (1, 1));
+            assert!(tmpl.is_zone);
+        }
+    }
+}

--- a/crates/sim_core/src/lib.rs
+++ b/crates/sim_core/src/lib.rs
@@ -1,6 +1,7 @@
 // sim_core — pure-Rust city simulation engine.
 // Systems are ported incrementally (Phase 3); see docs/rust-migration-tasks.md.
 pub mod rng;
+pub mod buildings;
 pub mod state;
 pub mod utilities;
 pub mod adjacency;

--- a/crates/sim_core/src/state.rs
+++ b/crates/sim_core/src/state.rs
@@ -1,5 +1,6 @@
 use sim_protocol::tile_kind::TileKind;
 use crate::rng::SeededRng;
+use crate::buildings::BuildingInstance;
 
 // ---------------------------------------------------------------------------
 // Tile flags
@@ -35,7 +36,9 @@ pub enum ZoneDensity { Low = 0, Medium = 1, High = 2 }
 pub struct Tile {
     pub kind:            TileKind,
     pub flags:           u8,
-    pub happiness:       u8,
+    /// Happiness in [0.0, 1.5] matching the TS float range (createInitialState
+    /// sets 1.0; the SoA wire buffer quantises this to u8 on output).
+    pub happiness:       f32,
     pub elevation:       u8,
     pub building_id:     Option<u16>,
     pub underground:     Option<TileKind>,
@@ -48,7 +51,7 @@ impl Tile {
         Self {
             kind:           TileKind::Land,
             flags:          0,
-            happiness:      100,
+            happiness:      1.0,
             elevation:      0,
             building_id:    None,
             underground:    None,
@@ -170,6 +173,8 @@ pub struct GameState {
     pub tile_revision:    u32,
     /// Next building ID to assign on placement.
     pub next_building_id: u32,
+    /// All placed buildings — grows when zones develop, shrinks on abandonment.
+    pub buildings:        Vec<BuildingInstance>,
 }
 
 impl GameState {
@@ -194,6 +199,7 @@ impl GameState {
             demand:           DemandStats::initial(),
             tile_revision:    0,
             next_building_id: 1,
+            buildings:        Vec::new(),
         }
     }
 

--- a/crates/sim_core/src/zones.rs
+++ b/crates/sim_core/src/zones.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeSet, HashMap};
 use sim_protocol::tile_kind::TileKind;
 use crate::adjacency::{has_road_access, is_frontier_zone, zone_has_road_path, tile_has_power, tile_has_water};
+use crate::buildings::BuildingInstance;
 use crate::rng::SeededRng;
 use crate::state::{GameState, FLAG_ABANDONED};
 
@@ -181,19 +182,19 @@ fn grow_zone_type(
     grown > 0
 }
 
-/// Minimal building placement for zone tiles — sets `building_id` and bumps
-/// state counters.  Full building-record tracking is wired in P3-5.
+/// Place a zone building: set tile.building_id, add to state.buildings, bump counters.
 fn place_zone_building(state: &mut GameState, x: u32, y: u32) -> bool {
     let Some(idx) = state.tile_index(x, y) else { return false };
     if state.tiles[idx].building_id.is_some() { return false; }
 
-    let bid = state.next_building_id as u16;
+    let bid  = state.next_building_id;
+    let kind = state.tiles[idx].kind;
     state.next_building_id += 1;
     state.tile_revision += 1;
 
-    let tile = &mut state.tiles[idx];
-    tile.building_id = Some(bid);
-    tile.set_flag(FLAG_ABANDONED, false);
+    state.tiles[idx].building_id = Some(bid as u16);
+    state.tiles[idx].set_flag(FLAG_ABANDONED, false);
+    state.buildings.push(BuildingInstance::new(bid, kind, (x, y)));
     true
 }
 


### PR DESCRIPTION
## Summary

- `state.rs`: `happiness` changed from `u8` to `f32` (matches TS 0.0–1.5 range); `buildings: Vec<BuildingInstance>` added to `GameState`
- `buildings.rs`: `BuildingStatus` enum; static `BuildingTemplate` per `TileKind` (footprint, power/water requirements); `BuildingInstance` struct; `get_building_template()` lookup; `update_building_states()` checks all tiles in footprint for power/water coverage; `apply_building_decay()` accumulates trouble ticks and abandons at threshold; education service stub returns false until P3-8
- `zones.rs`: `place_zone_building()` now also pushes a `BuildingInstance` into `state.buildings`

## Test plan

- [x] `cargo test -p sim_core` — 75 tests pass, zero warnings
- [x] Zone building goes Active when both powered and watered
- [x] Zone building goes InactiveNoPower / InactiveNoWater correctly
- [x] Park (no power/water requirement) stays Active without utilities
- [x] 2×2 power plant stays Active without external power input
- [x] Decay accumulates trouble on no-power; abandons at threshold; bleeds down when conditions are good

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AR6ezY6qjLad3JLXScFaY8