### PR TITLE
feat(sim_core): P3-6 demand system

### DIFF
--- a/crates/sim_core/src/buildings.rs
+++ b/crates/sim_core/src/buildings.rs
@@ -20,30 +20,22 @@ pub enum BuildingStatus {
 // BuildingTemplate (static per-kind data)
 // ---------------------------------------------------------------------------
 
-/// Static properties of a building kind — looked up by `TileKind`.
-/// Mirrors the `BuildingTemplate` interface in `buildings/templates.ts`.
+/// Static properties of a building kind.  Mirrors the `BuildingTemplate`
+/// interface in `buildings/templates.ts`.
+///
+/// Values are taken directly from the TS static template objects.
 pub struct BuildingTemplate {
-    pub footprint:      (u32, u32),   // (width, height)
-    pub requires_power: bool,
-    pub requires_water: bool,
-    pub water_use:      f32,
-    pub is_zone:        bool,
-    pub is_power_plant: bool,
-}
-
-impl BuildingTemplate {
-    const fn zone(w: u32, h: u32) -> Self {
-        Self { footprint: (w, h), requires_power: true, requires_water: true, water_use: 1.0, is_zone: true, is_power_plant: false }
-    }
-    const fn civic_power(w: u32, h: u32) -> Self {
-        Self { footprint: (w, h), requires_power: true, requires_water: false, water_use: 0.0, is_zone: false, is_power_plant: false }
-    }
-    const fn civic_no_power(w: u32, h: u32) -> Self {
-        Self { footprint: (w, h), requires_power: false, requires_water: false, water_use: 0.0, is_zone: false, is_power_plant: false }
-    }
-    const fn power_plant(w: u32, h: u32) -> Self {
-        Self { footprint: (w, h), requires_power: false, requires_water: false, water_use: 0.0, is_zone: false, is_power_plant: true }
-    }
+    pub footprint:           (u32, u32),  // (width, height) in tiles
+    pub requires_power:      bool,
+    pub requires_water:      bool,
+    pub water_use:           f32,         // kL/day consumed (demand side)
+    pub water_output:        i32,         // kL/day produced (supply side, 0 if not a source)
+    pub power_use:           f32,         // MW consumed when active
+    pub population_capacity: u32,
+    pub jobs_capacity:       u32,
+    pub maintenance:         f32,         // $/day
+    pub is_zone:             bool,
+    pub is_power_plant:      bool,
 }
 
 /// Look up static template data by the tile kind used when placing a building.
@@ -51,27 +43,70 @@ impl BuildingTemplate {
 /// Returns `None` for non-building tile kinds (Land, Road, etc.).
 pub fn get_building_template(kind: TileKind) -> Option<&'static BuildingTemplate> {
     use TileKind::*;
-    static RESIDENTIAL: BuildingTemplate  = BuildingTemplate::zone(1, 1);
-    static COMMERCIAL:  BuildingTemplate  = BuildingTemplate::zone(1, 1);
-    static INDUSTRIAL:  BuildingTemplate  = BuildingTemplate::zone(1, 1);
-    static WATER_PUMP:  BuildingTemplate  = BuildingTemplate::civic_power(1, 1);
-    static WATER_TOWER: BuildingTemplate  = BuildingTemplate::civic_power(2, 2);
-    static PARK:        BuildingTemplate  = BuildingTemplate::civic_no_power(1, 1);
-    static ELEM_SCHOOL: BuildingTemplate  = BuildingTemplate::civic_power(2, 2);
-    static HIGH_SCHOOL: BuildingTemplate  = BuildingTemplate::civic_power(2, 2);
-    static HYDRO_PLANT: BuildingTemplate  = BuildingTemplate::power_plant(2, 2);
+    macro_rules! tmpl {
+        ($fp:expr, pwr=$p:expr, wat=$w:expr, wu=$wu:expr, wo=$wo:expr,
+         pu=$pu:expr, pop=$pop:expr, jobs=$j:expr, maint=$m:expr,
+         zone=$z:expr, plant=$pl:expr) => {
+            BuildingTemplate {
+                footprint: $fp, requires_power: $p, requires_water: $w,
+                water_use: $wu, water_output: $wo, power_use: $pu,
+                population_capacity: $pop, jobs_capacity: $j,
+                maintenance: $m, is_zone: $z, is_power_plant: $pl,
+            }
+        };
+    }
+
+    // Mirrors TS ZONE_BUILDING_TEMPLATES
+    static RESIDENTIAL: BuildingTemplate = tmpl! {
+        (1,1), pwr=true,  wat=true,  wu=1.0,  wo=0,  pu=1.5,
+        pop=14, jobs=0,  maint=1.0,    zone=true,  plant=false
+    };
+    static COMMERCIAL: BuildingTemplate = tmpl! {
+        (1,1), pwr=true,  wat=true,  wu=1.5,  wo=0,  pu=2.5,
+        pop=0,  jobs=8,  maint=1.2,    zone=true,  plant=false
+    };
+    static INDUSTRIAL: BuildingTemplate = tmpl! {
+        (1,1), pwr=true,  wat=true,  wu=2.0,  wo=0,  pu=3.0,
+        pop=0,  jobs=12, maint=1.4,    zone=true,  plant=false
+    };
+    // Mirrors TS CIVIC_BUILDING_TEMPLATES
+    static WATER_PUMP: BuildingTemplate = tmpl! {
+        (1,1), pwr=true,  wat=false, wu=0.0,  wo=50, pu=0.0,
+        pop=0,  jobs=0,  maint=5.0,    zone=false, plant=false
+    };
+    static WATER_TOWER: BuildingTemplate = tmpl! {
+        (2,2), pwr=true,  wat=false, wu=0.0,  wo=120, pu=0.0,
+        pop=0,  jobs=0,  maint=12.0,   zone=false, plant=false
+    };
+    static PARK: BuildingTemplate = tmpl! {
+        (1,1), pwr=false, wat=false, wu=0.0,  wo=0,  pu=0.0,
+        pop=0,  jobs=0,  maint=0.05,   zone=false, plant=false
+    };
+    static ELEM_SCHOOL: BuildingTemplate = tmpl! {
+        (2,2), pwr=true,  wat=false, wu=0.0,  wo=0,  pu=4.0,
+        pop=0,  jobs=0,  maint=40.0,   zone=false, plant=false
+    };
+    static HIGH_SCHOOL: BuildingTemplate = tmpl! {
+        (2,2), pwr=true,  wat=false, wu=0.0,  wo=0,  pu=5.0,
+        pop=0,  jobs=0,  maint=55.0,   zone=false, plant=false
+    };
+    // Mirrors TS POWER_PLANT_TEMPLATES (all use HydroPlant tile kind in TS)
+    static HYDRO_PLANT: BuildingTemplate = tmpl! {
+        (2,2), pwr=false, wat=false, wu=0.0,  wo=0,  pu=0.0,
+        pop=0,  jobs=0,  maint=150.0,  zone=false, plant=true
+    };
 
     match kind {
-        Residential     => Some(&RESIDENTIAL),
-        Commercial      => Some(&COMMERCIAL),
-        Industrial      => Some(&INDUSTRIAL),
-        WaterPump       => Some(&WATER_PUMP),
-        WaterTower      => Some(&WATER_TOWER),
-        Park            => Some(&PARK),
+        Residential      => Some(&RESIDENTIAL),
+        Commercial       => Some(&COMMERCIAL),
+        Industrial       => Some(&INDUSTRIAL),
+        WaterPump        => Some(&WATER_PUMP),
+        WaterTower       => Some(&WATER_TOWER),
+        Park             => Some(&PARK),
         ElementarySchool => Some(&ELEM_SCHOOL),
-        HighSchool      => Some(&HIGH_SCHOOL),
-        HydroPlant      => Some(&HYDRO_PLANT),
-        _               => None,
+        HighSchool       => Some(&HIGH_SCHOOL),
+        HydroPlant       => Some(&HYDRO_PLANT),
+        _                => None,
     }
 }
 

--- a/crates/sim_core/src/demand.rs
+++ b/crates/sim_core/src/demand.rs
@@ -1,0 +1,350 @@
+use sim_protocol::tile_kind::TileKind;
+use crate::buildings::{get_building_template, BuildingStatus};
+use crate::state::{DemandStats, GameState};
+
+// ---------------------------------------------------------------------------
+// Constants (from `app/src/game/demand.ts` and `constants.ts`)
+// ---------------------------------------------------------------------------
+
+const PENDING_PENALTY_MAX:            f32 = 35.0;
+const PENDING_PENALTY_BASE_FRACTION:  f32 = 0.6;
+const DEMAND_FLOOR:                   f32 = 8.0;
+const FLOOR_FILL_THRESHOLD:           f32 = 0.92;
+const PRESSURE_THRESHOLD:             f32 = 60.0;
+const PRESSURE_RELIEF_FACTOR:         f32 = 0.5;
+const DEFAULT_WORKER_SHARE:           f32 = 0.55;
+
+// ---------------------------------------------------------------------------
+// Labour stats (mirrors `computeLabourStats.ts`)
+// ---------------------------------------------------------------------------
+
+pub struct LabourStats {
+    pub population:        f32,
+    pub res_capacity:      f32,
+    pub job_capacity:      f32,
+    pub workers:           f32,
+    pub employed:          f32,
+    pub unemployed:        f32,
+    pub unemployment_rate: f32,
+    pub vacancy_rate:      f32,
+}
+
+pub fn compute_labour_stats(
+    population: f32,
+    res_capacity: f32,
+    job_capacity: f32,
+) -> LabourStats {
+    let workers    = (population * DEFAULT_WORKER_SHARE).max(0.0);
+    let employed   = workers.min(job_capacity);
+    let unemployed = (workers - job_capacity).max(0.0);
+    let unemployment_rate = if workers == 0.0 { 0.0 } else { unemployed / workers };
+    let vacancy_rate = if job_capacity == 0.0 {
+        1.0
+    } else {
+        ((job_capacity - employed) / job_capacity).max(0.0)
+    };
+    LabourStats { population, res_capacity, job_capacity, workers, employed, unemployed, unemployment_rate, vacancy_rate }
+}
+
+// ---------------------------------------------------------------------------
+// DemandInput / compute_demand (mirrors `demand.ts`)
+// ---------------------------------------------------------------------------
+
+pub struct DemandInput {
+    pub base:                    f32,
+    pub fill_fraction:           f32,
+    pub workforce_term:          f32,
+    pub labour_term:             f32,
+    pub pending_zones:           f32,
+    pub pending_slope:           f32,
+    pub utility_penalty:         f32,
+    pub seeded:                  bool,
+    pub seeded_value:            f32,
+    pub pending_penalty_enabled: bool,
+    pub floor_override:          Option<f32>,
+}
+
+pub fn compute_demand(i: &DemandInput) -> f32 {
+    if i.seeded { return i.seeded_value; }
+
+    let fill_term     = i.base * (1.0 - i.fill_fraction);
+    let base_demand   = fill_term + i.workforce_term + i.labour_term;
+
+    let pending_penalty_raw = if i.pending_penalty_enabled {
+        i.pending_zones * i.pending_slope
+    } else {
+        0.0
+    };
+    let pending_penalty_capped = if i.pending_penalty_enabled {
+        pending_penalty_raw
+            .min(base_demand * PENDING_PENALTY_BASE_FRACTION)
+            .min(PENDING_PENALTY_MAX)
+    } else {
+        0.0
+    };
+    let pressure_relief       = (base_demand - PRESSURE_THRESHOLD).max(0.0) * PRESSURE_RELIEF_FACTOR;
+    let pending_penalty_applied = (pending_penalty_capped - pressure_relief).max(0.0);
+    let demand_after_penalty  = base_demand - pending_penalty_applied;
+
+    let demand_before_utilities = match i.floor_override {
+        Some(fo) => demand_after_penalty.max(fo),
+        None => if i.fill_fraction < FLOOR_FILL_THRESHOLD {
+            demand_after_penalty.max(DEMAND_FLOOR)
+        } else {
+            demand_after_penalty
+        },
+    };
+
+    (demand_before_utilities - i.utility_penalty).clamp(0.0, 100.0)
+}
+
+// ---------------------------------------------------------------------------
+// compute_city_demand — assembles inputs from GameState and calls the above
+// ---------------------------------------------------------------------------
+
+/// Zone & capacity counters accumulated from one tile+building pass.
+struct CityCounters {
+    residential_zones:           u32,
+    developed_residential_zones: u32,
+    commercial_zones:            u32,
+    developed_commercial_zones:  u32,
+    industrial_zones:            u32,
+    developed_industrial_zones:  u32,
+    population_capacity:         u32,
+    job_capacity:                u32,
+    commercial_job_capacity:     u32,
+    industrial_job_capacity:     u32,
+}
+
+fn count_city(state: &GameState) -> CityCounters {
+    let mut c = CityCounters {
+        residential_zones: 0, developed_residential_zones: 0,
+        commercial_zones:  0, developed_commercial_zones:  0,
+        industrial_zones:  0, developed_industrial_zones:  0,
+        population_capacity: 0, job_capacity: 0,
+        commercial_job_capacity: 0, industrial_job_capacity: 0,
+    };
+
+    for tile in &state.tiles {
+        match tile.kind {
+            TileKind::Residential => {
+                c.residential_zones += 1;
+                if tile.building_id.is_some() { c.developed_residential_zones += 1; }
+            }
+            TileKind::Commercial => {
+                c.commercial_zones += 1;
+                if tile.building_id.is_some() { c.developed_commercial_zones += 1; }
+            }
+            TileKind::Industrial => {
+                c.industrial_zones += 1;
+                if tile.building_id.is_some() { c.developed_industrial_zones += 1; }
+            }
+            _ => {}
+        }
+    }
+
+    for building in &state.buildings {
+        let Some(tmpl) = get_building_template(building.kind) else { continue };
+        // Capacity counts when active OR when inactive due to power/water (still occupies slot)
+        let contributes = building.status == BuildingStatus::Active
+            || (tmpl.is_zone && matches!(
+                building.status,
+                BuildingStatus::InactiveNoPower | BuildingStatus::InactiveNoWater
+            ));
+        if !contributes { continue; }
+        c.population_capacity  += tmpl.population_capacity;
+        c.job_capacity         += tmpl.jobs_capacity;
+        if building.kind == TileKind::Commercial { c.commercial_job_capacity += tmpl.jobs_capacity; }
+        if building.kind == TileKind::Industrial { c.industrial_job_capacity += tmpl.jobs_capacity; }
+    }
+
+    c
+}
+
+/// Compute `DemandStats` from the current `GameState` — matches the demand
+/// assembly block in `simulation.ts:tick()`.
+///
+/// Education is stubbed to 0 until P3-8 (score=0, high_coverage=0).
+pub fn compute_city_demand(state: &GameState) -> DemandStats {
+    let c = count_city(state);
+
+    let pop    = state.population as f32;
+    let jobs   = state.jobs as f32;
+    let pop_cap = c.population_capacity as f32;
+    let job_cap = c.job_capacity as f32;
+    let com_cap = c.commercial_job_capacity as f32;
+    let ind_cap = c.industrial_job_capacity as f32;
+
+    let labour = compute_labour_stats(pop, pop_cap, job_cap);
+
+    let seeded = state.population == 0 && state.jobs == 0;
+
+    // Education stub — P3-8 will compute these properly
+    let education_score   = 0.0_f32;
+    let high_coverage     = 0.0_f32;
+    let education_demand_delta = education_score * 4.0 - (1.0 - education_score) * 12.0;
+    let workforce_penalty = (1.0 - high_coverage) * 20.0;
+
+    let utility_penalty = (if state.utilities.power < 0 { 15.0 } else { 0.0 })
+        + (if state.utilities.water < 0 { 15.0 } else { 0.0 });
+
+    // Fill fractions
+    let fill_residential = if pop_cap > 0.0 { (pop / pop_cap).min(1.0) } else { 0.0 };
+    let jobs_in_commercial = if job_cap > 0.0 { (com_cap / job_cap.max(1.0)) * jobs } else { 0.0 };
+    let jobs_in_industrial = if job_cap > 0.0 { (ind_cap / job_cap.max(1.0)) * jobs } else { 0.0 };
+    let fill_commercial = if com_cap > 0.0 { (jobs_in_commercial / com_cap).min(1.0) } else { 1.0 };
+    let fill_industrial = if ind_cap > 0.0 { (jobs_in_industrial / ind_cap).min(1.0) } else { 1.0 };
+
+    // Pending (undeveloped) zones
+    let pending_residential = (c.residential_zones.saturating_sub(c.developed_residential_zones)) as f32;
+    let pending_commercial  = (c.commercial_zones .saturating_sub(c.developed_commercial_zones))  as f32;
+    let pending_industrial  = (c.industrial_zones .saturating_sub(c.developed_industrial_zones))  as f32;
+
+    // pendingPenaltyEnabled is stored in GameSettings — not yet ported (P3-9+);
+    // default to true matching createDefaultSettings().
+    let pending_penalty_enabled = true;
+
+    let residential = compute_demand(&DemandInput {
+        base: 70.0,
+        fill_fraction: fill_residential,
+        workforce_term: 0.0,
+        labour_term: labour.vacancy_rate * 60.0 - labour.unemployment_rate * 80.0 + education_demand_delta,
+        pending_zones: pending_residential,
+        pending_slope: 0.45,
+        utility_penalty,
+        seeded,
+        seeded_value: 50.0,
+        pending_penalty_enabled,
+        floor_override: None,
+    });
+
+    let commercial = compute_demand(&DemandInput {
+        base: 50.0,
+        fill_fraction: fill_commercial,
+        workforce_term: labour.unemployment_rate * 30.0
+            + (pop / pop_cap.max(1.0)).min(1.0) * 20.0
+            - workforce_penalty * 0.6,
+        labour_term: 0.0,
+        pending_zones: pending_commercial,
+        pending_slope: 0.35,
+        utility_penalty: utility_penalty * 0.5,
+        seeded,
+        seeded_value: 30.0,
+        pending_penalty_enabled,
+        floor_override: None,
+    });
+
+    let industrial = compute_demand(&DemandInput {
+        base: 55.0,
+        fill_fraction: fill_industrial,
+        workforce_term: labour.unemployment_rate * 80.0
+            + (0.95_f32 - fill_industrial).max(0.0) * 20.0
+            - workforce_penalty,
+        labour_term: labour.vacancy_rate * -5.0,
+        pending_zones: pending_industrial,
+        pending_slope: 0.35,
+        utility_penalty: utility_penalty * 0.5,
+        seeded,
+        seeded_value: 30.0,
+        pending_penalty_enabled,
+        floor_override: if fill_industrial >= 0.95 { Some(5.0) } else { None },
+    });
+
+    DemandStats { residential, commercial, industrial }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn input(base: f32, fill: f32, pending: f32) -> DemandInput {
+        DemandInput {
+            base, fill_fraction: fill, workforce_term: 0.0, labour_term: 0.0,
+            pending_zones: pending, pending_slope: 0.35, utility_penalty: 0.0,
+            seeded: false, seeded_value: 50.0, pending_penalty_enabled: true,
+            floor_override: None,
+        }
+    }
+
+    #[test]
+    fn seeded_returns_seeded_value() {
+        let i = DemandInput { seeded: true, seeded_value: 42.0, ..input(70.0, 0.5, 0.0) };
+        assert_eq!(compute_demand(&i), 42.0);
+    }
+
+    #[test]
+    fn empty_city_fills_from_base() {
+        // 0% fill → fill_term = base; no pending penalty; should be near base (clamped)
+        let v = compute_demand(&input(70.0, 0.0, 0.0));
+        // fill_term = 70*(1-0) = 70; no labour/pending → demand = max(70, floor=8) = 70
+        assert!((v - 70.0).abs() < 0.01, "expected ~70, got {v}");
+    }
+
+    #[test]
+    fn full_city_has_low_demand() {
+        // 100% fill → fill_term = 0; demand should hit the floor (8) or lower
+        let i = input(70.0, 1.0, 0.0);
+        let v = compute_demand(&i);
+        // fill >= FLOOR_FILL_THRESHOLD → no floor applied; demand could be 0
+        assert!(v <= DEMAND_FLOOR, "demand {v} should be at most floor {DEMAND_FLOOR}");
+    }
+
+    #[test]
+    fn pending_zones_reduce_demand() {
+        let without = compute_demand(&input(70.0, 0.0, 0.0));
+        let with_pending = compute_demand(&input(70.0, 0.0, 20.0));
+        assert!(with_pending < without, "pending zones should reduce demand");
+    }
+
+    #[test]
+    fn utility_penalty_reduces_demand() {
+        let without = compute_demand(&input(70.0, 0.5, 0.0));
+        let with_penalty = DemandInput { utility_penalty: 15.0, ..input(70.0, 0.5, 0.0) };
+        let v = compute_demand(&with_penalty);
+        assert!(v < without, "utility penalty should reduce demand");
+    }
+
+    #[test]
+    fn demand_clamped_to_zero_to_hundred() {
+        let high = DemandInput { base: 200.0, ..input(0.0, 0.0, 0.0) };
+        assert!(compute_demand(&high) <= 100.0);
+        let low = DemandInput { utility_penalty: 200.0, ..input(70.0, 0.5, 0.0) };
+        assert!(compute_demand(&low) >= 0.0);
+    }
+
+    #[test]
+    fn compute_city_demand_on_empty_state() {
+        let s = GameState::new(4, 4, 0);
+        let d = compute_city_demand(&s);
+        // New city: pop=12, jobs=4, no zones, no buildings → seeded=false;
+        // residential base=70, fill=0 → demand high; commercial/industrial less so
+        assert!(d.residential > 0.0, "residential demand should be positive");
+        assert!(d.commercial >= 0.0);
+        assert!(d.industrial >= 0.0);
+    }
+
+    #[test]
+    fn labour_stats_basic() {
+        let l = compute_labour_stats(100.0, 100.0, 40.0);
+        assert_eq!(l.workers, 55.0);   // 100 * 0.55
+        assert_eq!(l.employed, 40.0);  // min(55, 40)
+        assert!((l.unemployment_rate - 15.0/55.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn labour_stats_no_jobs() {
+        let l = compute_labour_stats(50.0, 100.0, 0.0);
+        assert_eq!(l.vacancy_rate, 1.0, "vacancy is 1 when job_capacity=0");
+        assert_eq!(l.unemployment_rate, 1.0);
+    }
+
+    #[test]
+    fn labour_stats_no_workers() {
+        let l = compute_labour_stats(0.0, 0.0, 10.0);
+        assert_eq!(l.unemployment_rate, 0.0, "unemployment=0 when no workers");
+    }
+}

--- a/crates/sim_core/src/lib.rs
+++ b/crates/sim_core/src/lib.rs
@@ -6,3 +6,4 @@ pub mod state;
 pub mod utilities;
 pub mod adjacency;
 pub mod zones;
+pub mod demand;


### PR DESCRIPTION
## Summary

- Adds `crates/sim_core/src/demand.rs` porting `demand.ts` demand calculation to Rust
- `LabourStats` + `compute_labour_stats`: workforce/unemployment/vacancy rates (mirrors `computeLabourStats.ts`)
- `DemandInput` + `compute_demand`: fill-fraction, pending-zone penalty, pressure relief, floor, utility penalty, clamp — exact port of `demand.ts`
- `compute_city_demand`: scans `GameState` tiles + buildings to assemble all inputs and return `DemandStats`; education stubbed to 0.0 until P3-8
- Expands `BuildingTemplate` in `buildings.rs` with `population_capacity`, `jobs_capacity`, `maintenance`, `power_use`, `water_use`, `water_output`; all nine static templates populated from TS values

## Test plan

- [x] `cargo test -p sim_core` → 85 tests pass, zero warnings
- [x] Seeded demand short-circuits to `seeded_value`
- [x] Empty-city demand ≈ base (fill=0, no pending, no penalty)
- [x] Full-city demand ≤ floor (fill≥0.92 threshold, no floor applied)
- [x] Pending zones reduce demand
- [x] Utility penalty reduces demand
- [x] Output clamped to [0, 100]
- [x] `compute_city_demand` on fresh `GameState::new` produces positive residential demand
- [x] Labour stats: basic, no-jobs, no-workers edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AR6ezY6qjLad3JLXScFaY8