### PR TITLE
Fix Pages deploy: correct WASM crate path

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -28,10 +28,10 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        uses: taiki-e/install-action@wasm-pack
 
       - name: Build WASM
-        run: wasm-pack build crates/sim_wasm --target web --out-dir ../../app/src/wasm/sim_wasm
+        run: wasm-pack build crates/city-sim-wasm --target web --out-dir ../../app/src/wasm/sim_wasm
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary

- Corrects `crates/sim_wasm` → `crates/city-sim-wasm` in `gh-pages.yml` — the crate was renamed during the Rust workspace setup (P1) but the deploy workflow was never updated
- Replaces the bare `curl | sh` wasm-pack installer with `taiki-e/install-action@wasm-pack` for reproducibility

The Pages deploy has been failing on every push to main since the Rust workspace landed on the branch. The game itself (TypeScript build) was unaffected, but `?bridge=wasm` on the live site was broken.

## Test plan

- [ ] Pages deploy run triggered by this PR merge succeeds
- [ ] `?bridge=wasm` works on the deployed site after merge