### PR TITLE
Map/seed export (P5-3)

### DIFF
--- a/crates/tauri-plugin-city-sim/build.rs
+++ b/crates/tauri-plugin-city-sim/build.rs
@@ -1,4 +1,12 @@
-const COMMANDS: &[&str] = &["start", "apply_tool", "set_speed", "stop"];
+const COMMANDS: &[&str] = &[
+    "start",
+    "apply_tool",
+    "set_speed",
+    "stop",
+    "get_snapshot",
+    "load_snapshot",
+    "get_map_seed",
+];
 
 fn main() {
     tauri_plugin::Builder::new(COMMANDS).build();

--- a/crates/tauri-plugin-city-sim/guest-js/index.ts
+++ b/crates/tauri-plugin-city-sim/guest-js/index.ts
@@ -132,6 +132,32 @@ export async function stop(): Promise<void> {
   await invoke('plugin:city-sim|stop', {})
 }
 
+// ── Map seed ──────────────────────────────────────────────────────────────────
+
+/**
+ * The three parameters that uniquely identify a city's starting conditions.
+ *
+ * Pass all three back to `start()` to recreate an empty city on the same map.
+ * Can be serialised to JSON for sharing: `JSON.stringify(seed)`.
+ */
+export interface MapSeed {
+  width: number
+  height: number
+  seed: number
+}
+
+/**
+ * Return the width, height, and seed that identify this city's starting map.
+ *
+ * The returned value can be passed back to `start()` to begin a fresh city
+ * on the same grid — useful for sharing a blank canvas or restarting a run.
+ */
+export async function getMapSeed(): Promise<MapSeed> {
+  return await invoke<MapSeed>('plugin:city-sim|get_map_seed', {})
+}
+
+// ── Snapshots ─────────────────────────────────────────────────────────────────
+
 /**
  * Serialise the current simulation state to a compact postcard snapshot.
  *

--- a/crates/tauri-plugin-city-sim/guest-js/index.ts
+++ b/crates/tauri-plugin-city-sim/guest-js/index.ts
@@ -149,8 +149,8 @@ export interface MapSeed {
 /**
  * Return the width, height, and seed that identify this city's starting map.
  *
- * The returned value can be passed back to `start()` to begin a fresh city
- * on the same grid — useful for sharing a blank canvas or restarting a run.
+ * To recreate an empty city on the same map:
+ * `const s = await getMapSeed(); start(s.width, s.height, s.seed, onTick)`
  */
 export async function getMapSeed(): Promise<MapSeed> {
   return await invoke<MapSeed>('plugin:city-sim|get_map_seed', {})

--- a/crates/tauri-plugin-city-sim/src/commands.rs
+++ b/crates/tauri-plugin-city-sim/src/commands.rs
@@ -262,6 +262,8 @@ pub fn load_snapshot(state: State<'_, SimState>, bytes: Vec<u8>) -> Result<(), E
 pub fn get_map_seed(state: State<'_, SimState>) -> Result<MapSeed, Error> {
     let (tx, rx) = mpsc::sync_channel(0);
     state.send(SimCmd::GetMapSeed(tx))?;
+    // Reuses SnapshotTimeout — both paths mean "sim thread did not respond
+    // within 2 s"; the message is slightly imprecise but acceptable.
     rx.recv_timeout(Duration::from_secs(2))
         .map_err(|e| match e {
             RecvTimeoutError::Timeout => Error::SnapshotTimeout,

--- a/crates/tauri-plugin-city-sim/src/commands.rs
+++ b/crates/tauri-plugin-city-sim/src/commands.rs
@@ -50,7 +50,21 @@ pub enum SimCmd {
     SetSpeed(f32),
     GetSnapshot(mpsc::SyncSender<Result<Vec<u8>, String>>),
     LoadSnapshot(Box<GameState>),
+    GetMapSeed(mpsc::SyncSender<MapSeed>),
     Stop,
+}
+
+// ── Map seed ──────────────────────────────────────────────────────────────────
+
+/// The three parameters that uniquely identify a city's starting conditions.
+///
+/// Pass all three back to `start()` to recreate an empty city on the same map.
+/// Serialises to `{ "width": N, "height": N, "seed": N }` via Tauri IPC.
+#[derive(Clone, Serialize)]
+pub struct MapSeed {
+    pub width: u32,
+    pub height: u32,
+    pub seed: u32,
 }
 
 // ── Managed plugin state ──────────────────────────────────────────────────────
@@ -160,6 +174,13 @@ pub fn start(
                     Ok(SimCmd::LoadSnapshot(gs)) => {
                         sim.load_state(*gs);
                     }
+                    Ok(SimCmd::GetMapSeed(tx)) => {
+                        let _ = tx.send(MapSeed {
+                            width: sim.state.width,
+                            height: sim.state.height,
+                            seed: sim.state.seed,
+                        });
+                    }
                     Ok(SimCmd::Stop) => return,
                     Err(_) => break,
                 }
@@ -230,4 +251,20 @@ pub fn get_snapshot(state: State<'_, SimState>) -> Result<Vec<u8>, Error> {
 pub fn load_snapshot(state: State<'_, SimState>, bytes: Vec<u8>) -> Result<(), Error> {
     let game_state = snapshot::from_bytes(&bytes).map_err(|e| Error::Snapshot(e.to_string()))?;
     state.send(SimCmd::LoadSnapshot(Box::new(game_state)))
+}
+
+/// Return the width, height, and seed that identify this city's starting map.
+///
+/// The returned `MapSeed` can be passed back to `start()` to create a fresh
+/// city on the same grid with the same RNG seed — useful for sharing a blank
+/// canvas or starting a new run on a known map.
+#[tauri::command]
+pub fn get_map_seed(state: State<'_, SimState>) -> Result<MapSeed, Error> {
+    let (tx, rx) = mpsc::sync_channel(0);
+    state.send(SimCmd::GetMapSeed(tx))?;
+    rx.recv_timeout(Duration::from_secs(2))
+        .map_err(|e| match e {
+            RecvTimeoutError::Timeout => Error::SnapshotTimeout,
+            RecvTimeoutError::Disconnected => Error::ChannelClosed,
+        })
 }

--- a/crates/tauri-plugin-city-sim/src/lib.rs
+++ b/crates/tauri-plugin-city-sim/src/lib.rs
@@ -13,6 +13,7 @@
 //   stop()
 //   get_snapshot() -> Vec<u8>
 //   load_snapshot(bytes: Vec<u8>)
+//   get_map_seed() -> MapSeed
 
 pub mod commands;
 mod error;
@@ -43,6 +44,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             commands::stop,
             commands::get_snapshot,
             commands::load_snapshot,
+            commands::get_map_seed,
         ])
         .setup(|app, _api| {
             app.manage(SimState::default());


### PR DESCRIPTION
## Summary

- Adds `get_map_seed()` Tauri command returning `{ width, height, seed }` — the three parameters that identify a city's blank starting map
- Uses the same `sync_channel(0)` rendezvous pattern as `get_snapshot` for thread-safe retrieval from the sim thread
- `MapSeed` interface exported from guest-JS bindings; JSON-serialisable for sharing
- Callers can pass the result directly back to `start()` to recreate an empty city on the same map

## Test plan

- [ ] `cargo check --workspace --exclude city-sim-wasm` passes
- [ ] CI green (Rust format, clippy, tests; TS typecheck and tests)
- [ ] `getMapSeed()` returns the correct `{ width, height, seed }` from a running sim

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AR6ezY6qjLad3JLXScFaY8