### PR TITLE
Criterion benchmarks and WASM/Tauri CI jobs (P5-6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,7 +334,7 @@ jobs:
 
   report-pr-results:
     name: PR summary
-    if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
+    if: always() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
     needs:
       - rust-fmt
       - rust-clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,75 @@ jobs:
             echo "- Run URL: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           } >> "${GITHUB_STEP_SUMMARY}"
 
+  wasm-build:
+    name: WASM build
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@wasm-pack
+
+      - name: Build WASM target
+        id: wasm_build
+        run: wasm-pack build crates/city-sim-wasm --target web --out-dir ../../app/src/wasm/sim_wasm
+
+      - name: Write summary
+        if: always()
+        run: |
+          {
+            echo "## WASM build"
+            echo
+            echo "- Runner: \`ubuntu-24.04\`"
+            echo "- Result: \`${{ steps.wasm_build.outcome }}\`"
+            echo "- Command: \`wasm-pack build crates/city-sim-wasm --target web --out-dir ../../app/src/wasm/sim_wasm\`"
+            echo "- Run URL: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  tauri-plugin-build:
+    name: Tauri plugin build
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            libwebkit2gtk-4.1-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Restore Rust cache
+        uses: swatinem/rust-cache@v2
+
+      - name: Build Tauri plugin
+        id: tauri_plugin_build
+        run: cargo build -p tauri-plugin-city-sim
+
+      - name: Write summary
+        if: always()
+        run: |
+          {
+            echo "## Tauri plugin build"
+            echo
+            echo "- Runner: \`ubuntu-24.04\`"
+            echo "- Result: \`${{ steps.tauri_plugin_build.outcome }}\`"
+            echo "- Command: \`cargo build -p tauri-plugin-city-sim\`"
+            echo "- Run URL: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
   report-pr-results:
     name: PR summary
     if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
@@ -273,6 +342,8 @@ jobs:
       - rust-determinism
       - ts-typecheck
       - ts-test
+      - wasm-build
+      - tauri-plugin-build
     runs-on: ubuntu-latest
     steps:
       - name: Post CI summary comment
@@ -290,6 +361,8 @@ jobs:
             const rustDeterm = '${{ needs.rust-determinism.result }}';
             const tsCheck    = '${{ needs.ts-typecheck.result }}';
             const tsTests    = '${{ needs.ts-test.result }}';
+            const wasmBuild  = '${{ needs.wasm-build.result }}';
+            const tauriBuild = '${{ needs.tauri-plugin-build.result }}';
 
             const body = [
               marker,
@@ -301,6 +374,8 @@ jobs:
               `- ${label(rustDeterm)} Rust determinism (x64 + arm64): \`${rustDeterm}\``,
               `- ${label(tsCheck)} TypeScript typecheck: \`${tsCheck}\``,
               `- ${label(tsTests)} TypeScript tests: \`${tsTests}\``,
+              `- ${label(wasmBuild)} WASM build: \`${wasmBuild}\``,
+              `- ${label(tauriBuild)} Tauri plugin build: \`${tauriBuild}\``,
             ].join('\n');
 
             const issue_number = context.issue.number;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,6 +288,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,10 +349,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "city-sim-core"
 version = "0.1.0"
 dependencies = [
  "city-sim-protocol",
+ "criterion",
  "postcard",
  "serde",
  "thiserror 1.0.69",
@@ -361,6 +407,31 @@ dependencies = [
  "serde",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cobs"
@@ -450,6 +521,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,10 +572,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -736,6 +868,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "embed-resource"
@@ -1238,6 +1376,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1283,6 +1432,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1562,6 +1717,26 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -2102,6 +2277,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2237,6 +2418,34 @@ dependencies = [
  "quick-xml",
  "serde",
  "time",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -2396,6 +2605,26 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -3370,6 +3599,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4459,6 +4698,26 @@ dependencies = [
  "quote",
  "syn 2.0.118",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ serde_json  = "1"
 # Utility
 thiserror   = "1"
 
+# Benchmarking (dev-only)
+criterion   = { version = "0.5", features = ["html_reports"] }
+
 # WASM
 wasm-bindgen = "0.2"
 js-sys       = "0.3"

--- a/crates/city-sim-core/Cargo.toml
+++ b/crates/city-sim-core/Cargo.toml
@@ -11,3 +11,10 @@ city-sim-protocol = { path = "../city-sim-protocol" }
 postcard     = { workspace = true }
 serde        = { workspace = true }
 thiserror    = { workspace = true }
+
+[dev-dependencies]
+criterion = { workspace = true }
+
+[[bench]]
+name = "sim_bench"
+harness = false

--- a/crates/city-sim-core/benches/sim_bench.rs
+++ b/crates/city-sim-core/benches/sim_bench.rs
@@ -1,0 +1,177 @@
+// sim_bench.rs — criterion benchmarks for city-sim-core simulation systems.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+use city_sim_core::{
+    command_log::CommandLog,
+    commands::apply_tool,
+    sim::Simulation,
+    snapshot::{from_bytes, to_bytes},
+    state::GameState,
+};
+use city_sim_protocol::commands::Tool;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Build a small but non-trivial 8×8 city: roads + zones + demand primed.
+/// Mirrors the `make_city_sim` helper in sim.rs tests.
+fn make_populated_8x8(seed: u32) -> Simulation {
+    let mut sim = Simulation::new(8, 8, seed);
+    // Roads
+    apply_tool(&mut sim.state, Tool::Road, 3, 0);
+    apply_tool(&mut sim.state, Tool::Road, 3, 1);
+    apply_tool(&mut sim.state, Tool::Road, 3, 2);
+    apply_tool(&mut sim.state, Tool::Road, 3, 3);
+    // Zones
+    apply_tool(&mut sim.state, Tool::Residential, 0, 0);
+    apply_tool(&mut sim.state, Tool::Residential, 1, 0);
+    apply_tool(&mut sim.state, Tool::Residential, 0, 1);
+    apply_tool(&mut sim.state, Tool::Residential, 1, 1);
+    apply_tool(&mut sim.state, Tool::Commercial, 0, 2);
+    apply_tool(&mut sim.state, Tool::Industrial, 0, 3);
+    // Prime demand so zone growth fires from tick 1
+    sim.state.demand.residential = 80.0;
+    sim.state.demand.commercial = 60.0;
+    sim.state.demand.industrial = 60.0;
+    sim
+}
+
+/// Build a command log with ~50 entries spread across tick 0..10.
+fn make_command_log_50() -> CommandLog {
+    let mut log = CommandLog::new(8, 8, 42);
+    // Lay roads along column 3 (ticks 0..5)
+    for row in 0..5u32 {
+        log.record(row as u64, Tool::Road, 3, row);
+    }
+    // Place zones adjacent to roads (ticks 5..10)
+    for row in 0..5u32 {
+        log.record((5 + row) as u64, Tool::Residential, 2, row);
+    }
+    // Additional commercial / industrial (tick 10)
+    log.record(10, Tool::Commercial, 4, 0);
+    log.record(10, Tool::Commercial, 4, 1);
+    log.record(10, Tool::Industrial, 4, 2);
+    log.record(10, Tool::Industrial, 4, 3);
+    // Water infrastructure (tick 12)
+    log.record(12, Tool::WaterPump, 6, 0);
+    log.record(12, Tool::WaterPipe, 5, 0);
+    log.record(12, Tool::WaterPipe, 4, 0);
+    // More roads to reach 50 entries
+    for i in 0..35u32 {
+        let x = (i % 7) + 1;
+        let y = (i / 7) % 8;
+        let tick = 15 + i as u64;
+        log.record(tick, Tool::Road, x, y);
+    }
+    log
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+/// 100 ticks of a populated 8×8 city at dt = 1/20 s.
+///
+/// Exercises the full tick loop: utility BFS, zone growth, building states,
+/// demand, economy, and decay. A good overall regression benchmark.
+fn tick_100(c: &mut Criterion) {
+    c.bench_function("tick_100", |b| {
+        b.iter_batched(
+            || make_populated_8x8(42),
+            |mut sim| {
+                for _ in 0..100 {
+                    sim.tick(black_box(1.0 / 20.0));
+                }
+                black_box(sim)
+            },
+            criterion::BatchSize::SmallInput,
+        )
+    });
+}
+
+/// 1000 ticks of a blank 64×64 city.
+///
+/// Stresses the O(n) per-tile operations (BFS seeds, tile iteration) on a
+/// larger grid. Blank city means zone growth never fires, isolating the
+/// utility/budget subsystems.
+fn tick_1000_64x64(c: &mut Criterion) {
+    c.bench_function("tick_1000_64x64", |b| {
+        b.iter_batched(
+            || Simulation::new(64, 64, 0),
+            |mut sim| {
+                for _ in 0..1000 {
+                    sim.tick(black_box(1.0 / 20.0));
+                }
+                black_box(sim)
+            },
+            criterion::BatchSize::SmallInput,
+        )
+    });
+}
+
+/// Single `apply_tool(Road)` call on a fresh 8×8 state.
+///
+/// Measures the cost of the hottest player-action path: bounds check, fund
+/// deduction, tile mutation, and tile_revision bump.
+fn apply_tool_road(c: &mut Criterion) {
+    c.bench_function("apply_tool_road", |b| {
+        b.iter_batched(
+            || GameState::new(8, 8, 0),
+            |mut state| {
+                let result = apply_tool(&mut state, black_box(Tool::Road), 3, 3);
+                black_box(result)
+            },
+            criterion::BatchSize::SmallInput,
+        )
+    });
+}
+
+/// `to_bytes` + `from_bytes` round-trip of a populated 8×8 city.
+///
+/// Measures snapshot serialisation performance, which determines save/load
+/// and send-over-channel latency.
+fn snapshot_roundtrip(c: &mut Criterion) {
+    let sim = make_populated_8x8(42);
+    let state = &sim.state;
+
+    c.bench_function("snapshot_roundtrip", |b| {
+        b.iter(|| {
+            let bytes = to_bytes(black_box(state)).expect("serialise");
+            let restored = from_bytes(black_box(&bytes)).expect("deserialise");
+            black_box(restored)
+        })
+    });
+}
+
+/// `CommandLog::replay()` on a log with ~50 entries.
+///
+/// Replay must advance the sim tick-by-tick between commands, so this
+/// measures both the replay dispatcher overhead and the underlying tick cost.
+fn command_log_replay(c: &mut Criterion) {
+    let log = make_command_log_50();
+
+    c.bench_function("command_log_replay", |b| {
+        b.iter(|| {
+            let sim = black_box(&log).replay();
+            black_box(sim)
+        })
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+criterion_group!(
+    benches,
+    tick_100,
+    tick_1000_64x64,
+    apply_tool_road,
+    snapshot_roundtrip,
+    command_log_replay,
+);
+criterion_main!(benches);

--- a/docs/rust-migration-tasks.md
+++ b/docs/rust-migration-tasks.md
@@ -125,7 +125,7 @@ Add a Rust-to-Rust golden hash + tick-by-tick hash log to binary-search divergen
   **DoD:** `CommandLog::pop()` in core; `UndoLast` `SimCmd` + `undo_last_command()` Tauri
   command; `SimBridge.undo()` interface; `TauriSimBridge` (real) + `WasmSimBridge` (no-op)
   implementations; Ctrl+Z handler in `main.ts` with "Undone" notification.
-- [ ] **P5-6 · Benchmarks + CI for both targets** (criterion in `city-sim-core`; wasm + tauri
+- [x] **P5-6 · Benchmarks + CI for both targets** (criterion in `city-sim-core`; wasm + tauri
   build workflows). `deps:` P4-2.
 
 ---


### PR DESCRIPTION
## Summary

- Adds five Criterion benchmarks to `city-sim-core/benches/sim_bench.rs` covering the main simulation hot paths: `tick_100`, `tick_1000_64x64`, `apply_tool_road`, `snapshot_roundtrip`, and `command_log_replay`. Uses `iter_batched` for setup-cost exclusion.
- Adds `wasm-build` CI job: installs `wasm32-unknown-unknown` target + wasm-pack via `taiki-e/install-action`, then runs `wasm-pack build crates/city-sim-wasm` (no Rust cache — avoids wasm32 target complications with `swatinem/rust-cache`).
- Adds `tauri-plugin-build` CI job: installs webkit/appindicator system deps, then runs `cargo build -p tauri-plugin-city-sim` with Rust cache.
- Both new jobs added to `report-pr-results` `needs:` list and PR comment body so they appear in the per-PR CI summary.

## Test plan

- [ ] `cargo bench --no-run` — all five benchmarks compile cleanly
- [ ] `cargo test --workspace` — 143 tests still pass (bench harness is `harness = false`, no conflict)
- [ ] CI `wasm-build` job passes on the PR
- [ ] CI `tauri-plugin-build` job passes on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AR6ezY6qjLad3JLXScFaY8