### PR TITLE
Persistence back-fill and camera zoom unit tests (M0-0 test prep)

### DIFF
--- a/app/src/game/persistence.test.ts
+++ b/app/src/game/persistence.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect } from 'vitest';
+import { serialize, deserialize, copyState } from './persistence';
+import {
+  TileKind,
+  createDefaultSettings,
+  createInitialState
+} from './gameState';
+import { DEFAULT_BYLAWS } from './bylaws';
+import { SeededRng } from './rng';
+import { DEFAULT_SERVICE_DEFINITIONS } from './services';
+import { createEmptyEducationStats } from './education';
+
+// Serialize a fresh state, strip or mutate fields the way an old save would
+// lack them, and hand the result to deserialize. Working on the parsed object
+// keeps each test focused on the single field it degrades.
+function degrade(mutate: (parsed: any) => void, seed = 42) {
+  const parsed = JSON.parse(serialize(createInitialState(8, 8, seed)));
+  mutate(parsed);
+  return deserialize(JSON.stringify(parsed));
+}
+
+describe('serialize/deserialize round-trip', () => {
+  it('copyState reproduces a fresh state exactly', () => {
+    const state = createInitialState(8, 8, 42);
+    expect(copyState(state)).toEqual(state);
+  });
+
+  it('deserialize is idempotent', () => {
+    const once = copyState(createInitialState(8, 8, 42));
+    expect(copyState(once)).toEqual(once);
+  });
+});
+
+describe('settings back-fill', () => {
+  it('applies full defaults when settings are absent', () => {
+    const state = degrade((parsed) => {
+      delete parsed.settings;
+    });
+    expect(state.settings).toEqual(createDefaultSettings());
+  });
+
+  it('back-fills a missing settings section without touching the others', () => {
+    const state = degrade((parsed) => {
+      delete parsed.settings.narrative;
+      parsed.settings.audio.radioVolume = 0.25;
+    });
+    expect(state.settings.narrative).toEqual(createDefaultSettings().narrative);
+    expect(state.settings.audio.radioVolume).toBe(0.25);
+  });
+
+  it('merges defaults into a partially-populated section', () => {
+    const state = degrade((parsed) => {
+      parsed.settings.input = { panSpeed: 'fast' };
+    });
+    expect(state.settings.input.panSpeed).toBe('fast');
+    // Fields the old save never had arrive with their defaults.
+    const defaults = createDefaultSettings().input;
+    expect(state.settings.input.zoomSensitivity).toBe(defaults.zoomSensitivity);
+    expect(state.settings.input.ctrlScrollsToPan).toBe(defaults.ctrlScrollsToPan);
+  });
+
+  it('back-fills each nested section independently', () => {
+    const state = degrade((parsed) => {
+      parsed.settings = {
+        minimap: { open: false },
+        accessibility: { reducedMotion: true },
+        audio: {},
+        hotkeys: {},
+        cosmetics: {},
+        narrative: { enabled: false }
+      };
+    });
+    const defaults = createDefaultSettings();
+    expect(state.settings.minimap.open).toBe(false);
+    expect(state.settings.minimap.size).toBe(defaults.minimap.size);
+    expect(state.settings.accessibility.reducedMotion).toBe(true);
+    expect(state.settings.accessibility.highContrastOverlays).toBe(
+      defaults.accessibility.highContrastOverlays
+    );
+    expect(state.settings.audio).toEqual(defaults.audio);
+    expect(state.settings.hotkeys).toEqual(defaults.hotkeys);
+    expect(state.settings.narrative.enabled).toBe(false);
+    expect(state.settings.narrative.tickerEnabled).toBe(defaults.narrative.tickerEnabled);
+    expect(state.settings.pendingPenaltyEnabled).toBe(defaults.pendingPenaltyEnabled);
+  });
+});
+
+describe('seed and RNG back-fill', () => {
+  it('assigns seed 0 to saves that predate seeding', () => {
+    const state = degrade((parsed) => {
+      delete parsed.seed;
+      delete parsed.rngState;
+    });
+    expect(state.seed).toBe(0);
+    expect(state.rngState).toEqual(new SeededRng(0).toJSON());
+  });
+
+  it('re-derives an invalid rngState from the seed', () => {
+    const state = degrade((parsed) => {
+      parsed.rngState = [1, 2];
+    });
+    expect(state.rngState).toEqual(new SeededRng(state.seed).toJSON());
+  });
+
+  it('preserves a valid rngState untouched', () => {
+    const original = createInitialState(8, 8, 42);
+    const state = deserialize(serialize(original));
+    expect(state.rngState).toEqual(original.rngState);
+  });
+});
+
+describe('utilities back-fill', () => {
+  it('builds utilities from legacy top-level power/water fields', () => {
+    const state = degrade((parsed) => {
+      delete parsed.utilities;
+      parsed.power = 5;
+      parsed.water = 3;
+    });
+    expect(state.utilities).toEqual({
+      power: 5,
+      water: 3,
+      powerProduced: 0,
+      powerUsed: 0,
+      waterProduced: 0,
+      waterUsed: 0
+    });
+  });
+
+  it('back-fills produced/used on a partial utilities object', () => {
+    const state = degrade((parsed) => {
+      parsed.utilities = { power: 2, water: 1 };
+    });
+    expect(state.utilities.powerProduced).toBe(0);
+    expect(state.utilities.waterUsed).toBe(0);
+    expect(state.utilities.power).toBe(2);
+  });
+});
+
+describe('scalar and structural back-fill', () => {
+  it('defaults tick and tileRevision to 0', () => {
+    const state = degrade((parsed) => {
+      delete parsed.tick;
+      delete parsed.tileRevision;
+    });
+    expect(state.tick).toBe(0);
+    expect(state.tileRevision).toBe(0);
+  });
+
+  it('creates a default budget when absent', () => {
+    const state = degrade((parsed) => {
+      delete parsed.budget;
+    });
+    expect(state.budget.net).toBe(0);
+    expect(state.budget.breakdown.revenue).toEqual({
+      base: 0,
+      residents: 0,
+      commercial: 0,
+      industrial: 0
+    });
+    expect(state.budget.breakdown.details.transport.rail).toBe(0);
+  });
+
+  it('migrates the legacy revenue.population field to residents', () => {
+    const state = degrade((parsed) => {
+      parsed.budget.breakdown.revenue = { base: 10, population: 7 };
+    });
+    expect(state.budget.breakdown.revenue.residents).toBe(7);
+    expect(state.budget.breakdown.revenue.base).toBe(10);
+  });
+
+  it('back-fills the *ByType breakdown maps', () => {
+    const state = degrade((parsed) => {
+      parsed.budget.breakdown.details.buildings = { power: 1, civic: 2, zones: 3 };
+    });
+    expect(state.budget.breakdown.details.buildings.powerByType).toEqual({});
+    expect(state.budget.breakdown.details.buildings.civicByType).toEqual({});
+    expect(state.budget.breakdown.details.buildings.zonesByType).toEqual({});
+    expect(state.budget.breakdown.details.buildings.zones).toBe(3);
+  });
+
+  it('defaults budgetHistory, education, and bylaws', () => {
+    const state = degrade((parsed) => {
+      delete parsed.budgetHistory;
+      delete parsed.education;
+      delete parsed.bylaws;
+    });
+    expect(state.budgetHistory).toEqual({ daily: [], lastRecordedDay: 0 });
+    expect(state.education).toEqual(createEmptyEducationStats());
+    expect(state.bylaws).toEqual(DEFAULT_BYLAWS);
+  });
+
+  it('back-fills a missing bylaws section without clobbering the rest', () => {
+    const state = degrade((parsed) => {
+      delete parsed.bylaws.lighting;
+    });
+    expect(state.bylaws.lighting).toEqual(DEFAULT_BYLAWS.lighting);
+  });
+
+  it('back-fills missing service definitions individually', () => {
+    const firstId = Object.keys(
+      DEFAULT_SERVICE_DEFINITIONS
+    )[0] as keyof typeof DEFAULT_SERVICE_DEFINITIONS;
+    const state = degrade((parsed) => {
+      delete parsed.services.definitions[firstId];
+    });
+    expect(state.services.definitions[firstId]).toEqual(DEFAULT_SERVICE_DEFINITIONS[firstId]);
+  });
+});
+
+describe('tile back-fill', () => {
+  it('defaults powered/watered/services on old tiles', () => {
+    const state = degrade((parsed) => {
+      delete parsed.tiles[0].powered;
+      delete parsed.tiles[0].watered;
+      delete parsed.tiles[0].services;
+    });
+    expect(state.tiles[0].powered).toBe(false);
+    expect(state.tiles[0].watered).toBe(false);
+    expect(state.tiles[0].services).toBeDefined();
+  });
+});
+
+describe('building back-fill and legacy civic migration', () => {
+  it('repairs missing building state fields', () => {
+    const state = degrade((parsed) => {
+      parsed.tiles[0].kind = TileKind.Park;
+      parsed.tiles[0].buildingId = 1;
+      parsed.buildings = [
+        { id: 1, templateId: 'park', origin: { x: 0, y: 0 }, state: { status: undefined } }
+      ];
+    });
+    const building = state.buildings[0];
+    expect(building.state.health).toBe(100);
+    expect(building.state.status).toBeDefined();
+    expect(building.state.serviceLoad).toBeDefined();
+  });
+
+  it('creates building instances for legacy civic tiles without buildingId', () => {
+    const idx = 3 * 8 + 4; // (4, 3) on the 8x8 map
+    const state = degrade((parsed) => {
+      parsed.tiles[idx].kind = TileKind.Park;
+      delete parsed.tiles[idx].buildingId;
+      parsed.buildings = [];
+      delete parsed.nextBuildingId;
+    });
+    const tile = state.tiles[idx];
+    expect(tile.buildingId).toBeDefined();
+    const created = state.buildings.find((b) => b.id === tile.buildingId);
+    expect(created).toBeDefined();
+    expect(created!.origin).toEqual({ x: 4, y: 3 });
+    expect(state.nextBuildingId).toBeGreaterThan(tile.buildingId!);
+  });
+});

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -25,7 +25,7 @@ import { applyToolCmd } from './game/protocol/commands';
 import type { FromSim } from './game/protocol/events';
 import { loadFromBrowser } from './game/persistence';
 import { initMcpBridge } from './game/mcpBridge';
-import { createCamera, centerCamera, screenToTile } from './rendering/camera';
+import { createCamera, centerCamera, screenToTile, zoomAt } from './rendering/camera';
 import { MapRenderer, Position } from './rendering/renderer';
 import { palette, TILE_SIZE } from './rendering/sprites';
 import { loadPaletteTexture, loadTileTextures } from './rendering/tileAtlas';
@@ -485,15 +485,10 @@ function attachViewportEvents(canvas: HTMLCanvasElement) {
         camera.y -= e.deltaY * scale;
         return;
       }
-      const prevScale = camera.scale;
       const zoomStep = ZOOM_STEPS[inputSettings.zoomSensitivity] ?? ZOOM_STEPS.normal;
       const factor = e.deltaY > 0 ? 1 - zoomStep : 1 + zoomStep;
-      camera.scale = Math.min(3, Math.max(0.5, camera.scale * factor));
       const rect = canvas.getBoundingClientRect();
-      const focusX = e.clientX - rect.left;
-      const focusY = e.clientY - rect.top;
-      camera.x = focusX - ((focusX - camera.x) / prevScale) * camera.scale;
-      camera.y = focusY - ((focusY - camera.y) / prevScale) * camera.scale;
+      zoomAt(camera, e.clientX - rect.left, e.clientY - rect.top, factor);
     },
     { passive: false }
   );

--- a/app/src/rendering/camera.test.ts
+++ b/app/src/rendering/camera.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from 'vitest';
+import {
+  Camera,
+  MAX_SCALE,
+  MIN_SCALE,
+  createCamera,
+  centerCamera,
+  screenToTile,
+  zoomAt
+} from './camera';
+
+const TILE_SIZE = 32;
+
+// screenToTile only touches width/height/getBoundingClientRect, so a plain
+// object stands in for the canvas under the node test environment.
+function fakeCanvas(
+  width: number,
+  height: number,
+  rect: Partial<DOMRect> = {}
+): HTMLCanvasElement {
+  const fullRect = { left: 0, top: 0, width, height, ...rect };
+  return {
+    width,
+    height,
+    getBoundingClientRect: () => fullRect
+  } as unknown as HTMLCanvasElement;
+}
+
+function fakeWrapper(clientWidth: number, clientHeight: number): HTMLElement {
+  return { clientWidth, clientHeight } as HTMLElement;
+}
+
+// Screen position of a tile's centre for a 1:1 canvas anchored at the origin —
+// the inverse of screenToTile, used to drive round-trip checks.
+function tileCentreToScreen(camera: Camera, tx: number, ty: number) {
+  const size = TILE_SIZE * camera.scale;
+  return {
+    clientX: camera.x + (tx + 0.5) * size,
+    clientY: camera.y + (ty + 0.5) * size
+  };
+}
+
+describe('createCamera', () => {
+  it('starts at the origin with scale 1', () => {
+    expect(createCamera()).toEqual({ x: 0, y: 0, scale: 1 });
+  });
+});
+
+describe('centerCamera', () => {
+  it('centres the map in the wrapper at scale 1', () => {
+    const camera = createCamera();
+    const state = { width: 10, height: 10 } as any;
+    centerCamera(state, fakeWrapper(800, 600), TILE_SIZE, camera);
+    expect(camera.x).toBe(800 / 2 - (10 * TILE_SIZE) / 2);
+    expect(camera.y).toBe(600 / 2 - (10 * TILE_SIZE) / 2);
+  });
+
+  it('accounts for the current scale', () => {
+    const camera = createCamera();
+    camera.scale = 2;
+    const state = { width: 10, height: 10 } as any;
+    centerCamera(state, fakeWrapper(800, 600), TILE_SIZE, camera);
+    expect(camera.x).toBe(800 / 2 - (10 * TILE_SIZE * 2) / 2);
+    expect(camera.y).toBe(600 / 2 - (10 * TILE_SIZE * 2) / 2);
+  });
+});
+
+describe('screenToTile', () => {
+  it('maps client coordinates to tiles with an identity camera', () => {
+    const camera = createCamera();
+    const canvas = fakeCanvas(800, 600);
+    expect(screenToTile(camera, TILE_SIZE, canvas, 0, 0)).toEqual({ x: 0, y: 0 });
+    expect(screenToTile(camera, TILE_SIZE, canvas, TILE_SIZE - 1, 0)).toEqual({ x: 0, y: 0 });
+    expect(screenToTile(camera, TILE_SIZE, canvas, TILE_SIZE, TILE_SIZE * 2)).toEqual({
+      x: 1,
+      y: 2
+    });
+  });
+
+  it('floors towards negative infinity left of the map', () => {
+    const camera = createCamera();
+    camera.x = TILE_SIZE;
+    const canvas = fakeCanvas(800, 600);
+    expect(screenToTile(camera, TILE_SIZE, canvas, TILE_SIZE / 2, 0)).toEqual({ x: -1, y: 0 });
+  });
+
+  it('applies camera pan and zoom', () => {
+    const camera: Camera = { x: 100, y: 50, scale: 2 };
+    const canvas = fakeCanvas(800, 600);
+    const size = TILE_SIZE * camera.scale;
+    expect(
+      screenToTile(camera, TILE_SIZE, canvas, 100 + 3 * size + 1, 50 + 2 * size + 1)
+    ).toEqual({ x: 3, y: 2 });
+  });
+
+  it('compensates for a canvas whose backing store differs from its CSS size', () => {
+    const camera = createCamera();
+    // Backing store at 2x the CSS rect — e.g. a devicePixelRatio-2 display.
+    const canvas = fakeCanvas(1600, 1200, { width: 800, height: 600 });
+    expect(screenToTile(camera, TILE_SIZE, canvas, TILE_SIZE / 2, 0)).toEqual({ x: 1, y: 0 });
+  });
+
+  it('offsets by the canvas position in the page', () => {
+    const camera = createCamera();
+    const canvas = fakeCanvas(800, 600, { left: 40, top: 20, width: 800, height: 600 });
+    expect(screenToTile(camera, TILE_SIZE, canvas, 40, 20)).toEqual({ x: 0, y: 0 });
+  });
+
+  it('round-trips tile centres across pans and zooms', () => {
+    const canvas = fakeCanvas(800, 600);
+    const cameras: Camera[] = [
+      { x: 0, y: 0, scale: 1 },
+      { x: 240, y: 140, scale: 1 },
+      { x: -37.5, y: 12.25, scale: 0.5 },
+      { x: 15.75, y: -60.5, scale: 2.4 }
+    ];
+    for (const camera of cameras) {
+      for (const [tx, ty] of [
+        [0, 0],
+        [5, 3],
+        [12, 12]
+      ]) {
+        const { clientX, clientY } = tileCentreToScreen(camera, tx, ty);
+        expect(screenToTile(camera, TILE_SIZE, canvas, clientX, clientY)).toEqual({
+          x: tx,
+          y: ty
+        });
+      }
+    }
+  });
+});
+
+describe('zoomAt', () => {
+  const worldPointAt = (camera: Camera, focusX: number, focusY: number) => ({
+    x: (focusX - camera.x) / camera.scale,
+    y: (focusY - camera.y) / camera.scale
+  });
+
+  it('keeps the world point under the focus stationary while zooming in', () => {
+    const camera: Camera = { x: 240, y: 140, scale: 1 };
+    const before = worldPointAt(camera, 400, 300);
+    zoomAt(camera, 400, 300, 1.25);
+    expect(camera.scale).toBeCloseTo(1.25, 10);
+    const after = worldPointAt(camera, 400, 300);
+    expect(after.x).toBeCloseTo(before.x, 10);
+    expect(after.y).toBeCloseTo(before.y, 10);
+  });
+
+  it('keeps the anchor stationary across repeated zooms in both directions', () => {
+    const camera: Camera = { x: -12.5, y: 48, scale: 1 };
+    const before = worldPointAt(camera, 123, 456);
+    for (const factor of [1.1, 1.1, 0.85, 1.3, 0.9]) {
+      zoomAt(camera, 123, 456, factor);
+      const after = worldPointAt(camera, 123, 456);
+      expect(after.x).toBeCloseTo(before.x, 8);
+      expect(after.y).toBeCloseTo(before.y, 8);
+    }
+  });
+
+  it('keeps the hovered tile fixed under the cursor through a zoom', () => {
+    const camera: Camera = { x: 240, y: 140, scale: 1 };
+    const canvas = fakeCanvas(800, 600);
+    const clientX = 500.5;
+    const clientY = 322.25;
+    const before = screenToTile(camera, TILE_SIZE, canvas, clientX, clientY);
+    zoomAt(camera, clientX, clientY, 1.15);
+    zoomAt(camera, clientX, clientY, 1.15);
+    expect(screenToTile(camera, TILE_SIZE, canvas, clientX, clientY)).toEqual(before);
+  });
+
+  it('is a no-op with factor 1', () => {
+    const camera: Camera = { x: 33, y: -7, scale: 1.5 };
+    zoomAt(camera, 100, 200, 1);
+    expect(camera).toEqual({ x: 33, y: -7, scale: 1.5 });
+  });
+
+  it('inverse factors restore the original view', () => {
+    const camera: Camera = { x: 240, y: 140, scale: 1 };
+    zoomAt(camera, 400, 300, 2);
+    zoomAt(camera, 400, 300, 0.5);
+    expect(camera.scale).toBeCloseTo(1, 10);
+    expect(camera.x).toBeCloseTo(240, 10);
+    expect(camera.y).toBeCloseTo(140, 10);
+  });
+
+  it('clamps to MAX_SCALE and stays anchored when the clamp engages', () => {
+    const camera: Camera = { x: 0, y: 0, scale: 2.9 };
+    const before = worldPointAt(camera, 400, 300);
+    zoomAt(camera, 400, 300, 1.5);
+    expect(camera.scale).toBe(MAX_SCALE);
+    const after = worldPointAt(camera, 400, 300);
+    expect(after.x).toBeCloseTo(before.x, 10);
+    expect(after.y).toBeCloseTo(before.y, 10);
+    // Further zooming in changes nothing once clamped.
+    const clamped = { ...camera };
+    zoomAt(camera, 400, 300, 1.5);
+    expect(camera.scale).toBe(MAX_SCALE);
+    expect(camera.x).toBeCloseTo(clamped.x, 10);
+    expect(camera.y).toBeCloseTo(clamped.y, 10);
+  });
+
+  it('clamps to MIN_SCALE and stays anchored when the clamp engages', () => {
+    const camera: Camera = { x: 120, y: 80, scale: 0.55 };
+    const before = worldPointAt(camera, 50, 60);
+    zoomAt(camera, 50, 60, 0.5);
+    expect(camera.scale).toBe(MIN_SCALE);
+    const after = worldPointAt(camera, 50, 60);
+    expect(after.x).toBeCloseTo(before.x, 10);
+    expect(after.y).toBeCloseTo(before.y, 10);
+  });
+
+  it('honours custom clamp bounds', () => {
+    const camera: Camera = { x: 0, y: 0, scale: 1 };
+    zoomAt(camera, 0, 0, 10, 0.25, 4);
+    expect(camera.scale).toBe(4);
+    zoomAt(camera, 0, 0, 0.001, 0.25, 4);
+    expect(camera.scale).toBe(0.25);
+  });
+});

--- a/app/src/rendering/camera.ts
+++ b/app/src/rendering/camera.ts
@@ -30,3 +30,23 @@ export function screenToTile(
   const y = ((clientY - rect.top) * scaleY - camera.y) / (tileSize * camera.scale);
   return { x: Math.floor(x), y: Math.floor(y) };
 }
+
+export const MIN_SCALE = 0.5;
+export const MAX_SCALE = 3;
+
+// Scales by `factor` (clamped to [minScale, maxScale]) while keeping the world
+// point under (focusX, focusY) stationary — focus coordinates are in the same
+// space as `camera.x`/`camera.y`.
+export function zoomAt(
+  camera: Camera,
+  focusX: number,
+  focusY: number,
+  factor: number,
+  minScale = MIN_SCALE,
+  maxScale = MAX_SCALE
+) {
+  const prevScale = camera.scale;
+  camera.scale = Math.min(maxScale, Math.max(minScale, camera.scale * factor));
+  camera.x = focusX - ((focusX - camera.x) / prevScale) * camera.scale;
+  camera.y = focusY - ((focusY - camera.y) / prevScale) * camera.scale;
+}

--- a/docs/mobile-web-plan.md
+++ b/docs/mobile-web-plan.md
@@ -32,7 +32,7 @@ out of scope for now; Tauri supports it, so it can be added later once Android w
 *Goal: the app knows what it's running on and renders correctly inside mobile browser
 chrome. No visible UI changes on desktop.*
 
-- [ ] **M0-0 · Test prep: persistence back-fill + camera math unit tests.** The mobile
+- [x] **M0-0 · Test prep: persistence back-fill + camera math unit tests.** The mobile
   work refactors exactly the untested areas. Before touching them: `persistence.test.ts`
   covering `deserialize` back-fill behaviour (old saves gain new settings fields with
   defaults — M0-2 relies on this), and `camera.ts` unit tests for screen↔tile


### PR DESCRIPTION
Closes #86 (M0-0 · Test prep).

The mobile web work (epic #61) refactors the currently untested areas of the frontend; this puts the safety net under them first. Test count goes from 106 to **144**, all green, `bun run lint` clean.

## `camera.test.ts` — 17 tests

- `screenToTile`: identity/pan/zoom mapping, flooring left of the map, backing-store vs CSS-size compensation (devicePixelRatio-style), canvas page offset, and tile-centre round-trips across camera states.
- `zoomAt`: the anchor invariant (the world point under the focus stays stationary), held through repeated mixed zooms and while the scale clamp engages; factor-1 no-op; inverse-factor restoration; `MIN_SCALE`/`MAX_SCALE`/custom clamp bounds.
- The integration case touch input will rely on: the hovered tile stays fixed under the cursor through a zoom.

## `persistence.test.ts` — 21 tests

Built on a `degrade()` helper — serialize a fresh state, strip fields the way an old save would lack them, assert the back-fill:

- Full and per-section settings defaults, preserving values the player set (the DoD case: a save predating a known settings field deserializes with the default applied — the template for M0-2's `ui` field).
- Seed/`rngState` recovery, legacy top-level `power`/`water` → `utilities` migration, `tick`/`tileRevision` defaults.
- Budget shape, legacy `revenue.population` → `residents` mapping, `*ByType` breakdown maps, `budgetHistory`/education/bylaws defaults.
- Per-tile `powered`/`watered`/`services` defaults, building-state repair, legacy civic tile → `BuildingInstance` migration.
- `copyState` round-trip fidelity and `deserialize` idempotence.

## One small refactor

The zoom-about-a-point maths moved from `main.ts`'s wheel handler into a pure `zoomAt()` in `camera.ts` — behaviour identical, but the invariant is now unit-testable, and it's the exact function M1-2's pinch-zoom will call.

Also ticks M0-0 `[x]` in `docs/mobile-web-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbqnAje7hTeRJnYqkcqstQ