### PR TITLE
Mobile viewport foundations — safe areas, dvh sizing, gesture suppression

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ npm run dev
 
 Then open the provided local URL. The service worker caches assets after first load so the game keeps running offline. Use `npm run build` for a production bundle.
 
+### Testing on a phone (LAN dev loop)
+
+```bash
+npm run dev -- --host   # or: bun run dev --host
+```
+
+Vite prints an extra `Network:` URL — open it in the phone's browser (phone and desktop must be on the same network). Changes hot-reload on the phone just like on desktop.
+
+To inspect the phone's tab from the desktop: enable **Developer options → USB debugging** on an Android phone, connect it over USB, and open `chrome://inspect` in desktop Chrome — the tab appears with full DevTools (console, profiler, remote screencast).
+
+Pointer/touch debugging: in a dev build, run `localStorage.setItem('debug-pointer', '1')` in the console to log the pointer→tile mapping for every input event.
+
 ## Deployment
 - GitHub Pages publishes to `https://scottmorris.github.io/city-sim-1000` via the `Deploy to GitHub Pages` workflow (runs on `main` pushes or manually).
 - The Pages build sets `VITE_BASE=/city-sim-1000/` so assets resolve under the project path; local builds default to `/`. To preview locally with the Pages base, run `VITE_BASE=/city-sim-1000/ npm run build` then `npm run preview`.

--- a/app/index.html
+++ b/app/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <link rel="apple-touch-icon" sizes="180x180" href="icons/apple-touch-icon.png" />
     <link rel="manifest" href="manifest.webmanifest" />
     <link rel="icon" type="image/png" sizes="32x32" href="icons/favicon-32.png" />

--- a/app/src/style.css
+++ b/app/src/style.css
@@ -44,6 +44,11 @@ select {
   height: 100vh;
   height: 100dvh;
   min-height: 0;
+  /* The app shell is a fixed one-screen layout — overflowing content must
+     scroll within its own region (e.g. the topbar HUD), never push the
+     document taller than the viewport, or toggling the mobile address bar
+     leaves dead space behind. */
+  overflow: hidden;
 }
 
 .topbar {
@@ -1700,6 +1705,25 @@ footer {
 @media (max-width: 900px) {
   body {
     font-size: 12px;
+  }
+  #app {
+    /* The stacked HUD panels can outgrow one screen on phone widths — cap
+       the topbar's row and let it scroll internally instead of overflowing
+       the fixed-height app shell. */
+    grid-template-rows: minmax(0, 40dvh) auto minmax(0, 1fr) auto;
+  }
+  .topbar {
+    min-height: 0;
+    overflow-y: auto;
+    /* A centered flex item that overflows its box can leave the start-side
+       content unreachable by scroll — align to the top instead so nothing
+       above the fold gets stranded. */
+    align-items: flex-start;
+  }
+  .logo {
+    /* Re-centre just the logo against the (tall) HUD next to it — only the
+       HUD needs flex-start, for scroll reachability. */
+    align-self: center;
   }
   .hud {
     grid-template-columns: repeat(2, minmax(120px, 1fr));

--- a/app/src/style.css
+++ b/app/src/style.css
@@ -55,6 +55,11 @@ select {
   display: flex;
   align-items: center;
   gap: 12px;
+  min-height: 0;
+  /* Safety net for any width: if the HUD ever grows taller than the
+     viewport, it scrolls within the topbar instead of relying on #app's
+     overflow: hidden to silently clip it with no way back in. */
+  overflow-y: auto;
   background: #0d1731;
   border-bottom: 2px solid #1f2c4b;
   padding: 10px 16px;
@@ -1713,8 +1718,6 @@ footer {
     grid-template-rows: minmax(0, 40dvh) auto minmax(0, 1fr) auto;
   }
   .topbar {
-    min-height: 0;
-    overflow-y: auto;
     /* A centered flex item that overflows its box can leave the start-side
        content unreachable by scroll — align to the top instead so nothing
        above the fold gets stranded. */

--- a/app/src/style.css
+++ b/app/src/style.css
@@ -12,18 +12,37 @@
   box-sizing: border-box;
 }
 
+html,
+body {
+  /* Keep rubber-banding and pull-to-refresh from hijacking canvas pans. */
+  overscroll-behavior: none;
+}
+
 body {
   margin: 0;
   background: linear-gradient(180deg, #0b1424 0%, #0f1c33 50%, #0b1424 100%);
   color: var(--text);
   font-family: "Press Start 2P", "Lucida Console", Monaco, monospace;
+  /* dvh tracks the visible viewport as mobile browser chrome shows/hides. */
   min-height: 100vh;
+  min-height: 100dvh;
+  /* Game chrome is not prose — stop long-presses from starting text selection. */
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+input,
+textarea,
+select {
+  user-select: text;
+  -webkit-user-select: text;
 }
 
 #app {
   display: grid;
   grid-template-rows: auto auto minmax(0, 1fr) auto;
   height: 100vh;
+  height: 100dvh;
   min-height: 0;
 }
 
@@ -34,6 +53,10 @@ body {
   background: #0d1731;
   border-bottom: 2px solid #1f2c4b;
   padding: 10px 16px;
+  /* Keep controls clear of notches and rounded corners in viewport-fit=cover. */
+  padding-top: calc(10px + env(safe-area-inset-top, 0px));
+  padding-left: calc(16px + env(safe-area-inset-left, 0px));
+  padding-right: calc(16px + env(safe-area-inset-right, 0px));
   box-shadow: inset 0 -4px 0 #0a0f1b;
 }
 
@@ -164,6 +187,8 @@ body {
   flex-direction: column;
   gap: 8px;
   padding: 10px 16px;
+  padding-left: calc(16px + env(safe-area-inset-left, 0px));
+  padding-right: calc(16px + env(safe-area-inset-right, 0px));
   background: #0d1a2f;
   border-top: 2px solid #1f2c4b;
   border-bottom: 2px solid #1f2c4b;
@@ -612,6 +637,9 @@ body {
   min-height: 0;
   overflow: hidden;
   z-index: 0;
+  /* All touch gestures on the map belong to the game, not the browser. */
+  touch-action: none;
+  -webkit-touch-callout: none;
 }
 
 .canvas-wrapper canvas {
@@ -636,8 +664,8 @@ body {
 
 .minimap-panel {
   position: absolute;
-  right: 12px;
-  bottom: 12px;
+  right: calc(12px + env(safe-area-inset-right, 0px));
+  bottom: calc(12px + env(safe-area-inset-bottom, 0px));
   background: rgba(12, 20, 40, 0.9);
   border: 2px solid #223557;
   border-radius: 12px;
@@ -947,6 +975,9 @@ footer {
   flex-wrap: wrap;
   background: #0c1324;
   padding: 12px 16px;
+  padding-bottom: calc(12px + env(safe-area-inset-bottom, 0px));
+  padding-left: calc(16px + env(safe-area-inset-left, 0px));
+  padding-right: calc(16px + env(safe-area-inset-right, 0px));
   border-top: 2px solid #1f2c4b;
   color: #7bffb7;
 }
@@ -1034,6 +1065,7 @@ footer {
   box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
   width: min(90vw, 960px);
   height: min(80vh, 720px);
+  height: min(80dvh, 720px);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -1674,11 +1706,12 @@ footer {
   }
   .canvas-wrapper {
     height: 60vh;
+    height: 60dvh;
   }
   .minimap-panel {
     width: min(100%, 280px);
-    right: 8px;
-    bottom: 8px;
+    right: calc(8px + env(safe-area-inset-right, 0px));
+    bottom: calc(8px + env(safe-area-inset-bottom, 0px));
   }
 }
 

--- a/docs/mobile-web-plan.md
+++ b/docs/mobile-web-plan.md
@@ -183,7 +183,7 @@ hardware.*
 ## Phase M5 — Testing + dev loop
 *Goal: the mobile experience can't silently regress.*
 
-- [ ] **M5-1 · LAN dev loop documented.** `bun run dev -- --host` + phone-on-LAN, and
+- [x] **M5-1 · LAN dev loop documented.** `bun run dev -- --host` + phone-on-LAN, and
   `chrome://inspect` USB debugging, documented in the README dev section (note the
   existing `debug-pointer` localStorage flag). `deps:` none.
   **DoD:** a fresh contributor can iterate on a phone against the dev server from


### PR DESCRIPTION
Closes #64, closes #65, closes #83.

First feature PR of the mobile web plan (epic #61) — the page-level groundwork that makes the game behave inside mobile browser chrome. No behaviour change on desktop mouse play; all additions are inert until a phone (or notched/touch device) is involved.

## Summary

- **`app/index.html`** — adds `viewport-fit=cover` to the viewport meta tag
- **`app/src/style.css`** — `env(safe-area-inset-*)` padding on the topbar (top/sides), toolbar (sides), footer (bottom/sides), and minimap corner offsets, so controls stay clear of notches, rounded corners, and the home bar in standalone PWA mode
- **`app/src/style.css`** — `dvh` sizing with `vh` fallbacks for the app shell, modals, and narrow-layout canvas height, so layout tracks the visible viewport as the mobile address bar shows/hides
- **`app/src/style.css`** — browser gesture suppression: `overscroll-behavior: none` (stops pull-to-refresh/rubber-banding hijacking canvas pans), `touch-action: none` + `-webkit-touch-callout: none` on the canvas wrapper, `user-select: none` on game chrome (re-enabled for `input`/`textarea`/`select`)
- **`app/src/style.css`** — clips `#app` to `overflow: hidden` so the app shell is a fixed one-screen layout; on narrow viewports the topbar's HUD grid is capped to `minmax(0, 40dvh)` and scrolls internally instead of overflowing into document-level scroll (root cause of the address-bar dead-space bug found during on-device testing)
- **`README.md`** — new "Testing on a phone" section documenting the LAN dev loop: `npm run dev -- --host` / `bun run dev --host`, `chrome://inspect` USB debugging, and the `debug-pointer` localStorage flag

### Known limitations

- **Notch/home-bar clearance not yet verified.** Both Firefox and Chrome on Android fell back to a plain bookmark-style shortcut instead of a true standalone install when testing over the LAN dev server, because `http://<lan-ip>:<port>` isn't a secure context (HTTPS or `localhost` is required for full PWA installability) — neither browser offered a real "Install app" prompt. Verifying this needs either a secure-context workaround (e.g. Chrome's `chrome://flags` insecure-origin allowlist) or a real HTTPS dev setup; deferred for now.
- Android's edge back-swipe has no reliable web-side exclusion — if it fights edge painting in practice, that's a follow-up for the gestures PR.
- The desktop-oriented HUD isn't responsive yet (M2 — Compact UI shell); on phone widths it now scrolls internally within the topbar rather than overflowing the page, but a real touch-friendly layout is still a later milestone.

## Test plan

- [x] `bun run lint` clean
- [x] All 144 TypeScript tests green
- [ ] On-device: notch/home-bar clearance in standalone PWA mode — blocked, see Known limitations
- [x] On-device: pull-to-refresh suppressed mid-pan — verified on Firefox and Chrome/Android
- [x] On-device: long-press no longer starts text selection — verified on Firefox and Chrome/Android
- [x] On-device: address-bar show/hide leaves no dead space — verified on Firefox and Chrome/Android after the `#app`/`.topbar` overflow fix; all HUD panels remain reachable via internal scroll in portrait, and rotating to landscape resizes cleanly

🤖 Generated with [Claude Code](https://claude.ai/code/session_01RbqnAje7hTeRJnYqkcqstQ)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbqnAje7hTeRJnYqkcqstQ)
