### PR TITLE
Align contribution conventions with Liminal HQ house rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ Never pass markdown-heavy bodies via `git commit -m "..."` — backticks trigger
 - Do not start with `feat:`, `fix:`, `chore:`, etc.
 - Describe the outcome or behaviour change.
 - Keep title style consistent across every open PR in the same stack.
+- Do not mention internal planning documents, local worksheet names, or internal-only process artefacts (e.g. milestone codes like `M0-3`) in PR titles.
 
 Examples:
 - ✅ `TauriSimBridge — native Rust simulation via Tauri IPC Channel`
@@ -80,6 +81,17 @@ Write the message to a temp file (single-quoted heredoc) before amending to avoi
 - `## Test plan` section with checklist bullets (`- [x]` / `- [ ]`) and concrete commands
 - Keep the summary focused on outcomes and behaviour, not commit history
 
+When a PR spans multiple kinds of change, use this fixed vocabulary for `###` sub-sections instead of ad hoc headings:
+
+- `### User-facing changes`
+- `### Maintainer-facing changes`
+- `### Packaging`
+- `### Workflow and infrastructure`
+- `### Documentation`
+- `### Known limitations`
+
+If verification is incomplete, say so plainly under `## Test plan` rather than folding it into prose elsewhere.
+
 ## Pull Request Labels
 
 Every PR must have at least one label. Primary categories:
@@ -87,6 +99,15 @@ Every PR must have at least one label. Primary categories:
 `enhancement`, `bug`, `documentation`, `infrastructure`, `chore`, `refactor`
 
 Use `gh pr edit <number> --add-label "<label>"` immediately after `gh pr create`.
+
+## Git Workflow
+
+- Do not push or force-push unless explicitly requested by the user.
+- Do not commit local planning or scratch files unless the user explicitly asks for them to become part of the repository.
+
+## Markdown Formatting
+
+- Do not manually hard-wrap prose in markdown files (no inserting line breaks mid-paragraph to keep lines under some width). Let paragraphs run as single long lines and rely on the renderer/editor to soft-wrap.
 
 ## Licence and Copyright
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,10 @@ Each station lives under `app/public/audio/radio/<station>/` with audio files + 
 
 - **Canadian English** in code comments, docs, and identifiers where not constrained by a web standard: *colour, centre, licence (noun), organise, behaviour, favour*. CSS/DOM properties (`color`, `center`) keep their standard spelling.
 - **Commits**: Conventional Commits, imperative mood, atomic. Backtick all code references in commit bodies. Use a single-quoted heredoc + `git commit -F` when the body contains backticks or special characters to avoid shell interpolation. Update `README.md`, `docs/game-parameters.md`, `app/public/manual.html`, and `SPEC.md` alongside any behaviour change they describe, in the same commit.
-- **PR titles**: Human-readable, no Conventional Commit prefix. Start with a capital letter. Example: `TauriSimBridge — native Rust simulation via Tauri IPC Channel`, not `feat(p4-2): TauriSimBridge`.
+- **PR titles**: Human-readable, no Conventional Commit prefix. Start with a capital letter. Example: `TauriSimBridge — native Rust simulation via Tauri IPC Channel`, not `feat(p4-2): TauriSimBridge`. Do not mention internal planning docs or milestone shorthand (e.g. `M0-3`) in the title.
+- **PR descriptions**: `## Summary` (flat bullets, bold lead-ins) + optional `###` subsections (`User-facing changes`, `Maintainer-facing changes`, `Packaging`, `Workflow and infrastructure`, `Documentation`, `Known limitations`) + `## Test plan` (checklist bullets, concrete commands, explicit gaps if verification is incomplete).
 - **PR merge**: Always `--no-ff`. Never squash. Merge commit format: `PR title (#N)\n\nPR body` — matches GitHub's "Pull request title and description" setting.
 - **Pull request labels**: Apply at least one label when opening a PR. Available labels: `bug`, `enhancement`, `documentation`, `infrastructure` (CI/CD/tooling), `chore` (maintenance/housekeeping), `refactor`. Use `gh pr edit <number> --add-label "<label>"` after creation.
+- **Git workflow**: Do not push or force-push, and do not commit local planning/scratch files, unless explicitly requested by the user.
+- **Markdown formatting**: Do not manually hard-wrap prose — write each paragraph as one line and let the renderer/editor soft-wrap.
 - The in-game manual is `app/public/manual.html`, opened via a modal iframe — keep it in sync with UI/behaviour changes.


### PR DESCRIPTION
## Summary

- **`AGENTS.md`** — adds a rule against referencing internal planning docs or milestone shorthand (e.g. `M0-3`) in PR titles
- **`AGENTS.md`** — defines a fixed `###` subsection vocabulary for PR descriptions (`User-facing changes`, `Maintainer-facing changes`, `Packaging`, `Workflow and infrastructure`, `Documentation`, `Known limitations`) instead of ad hoc headings
- **`AGENTS.md`** — adds a `Git Workflow` section: no unsolicited push/force-push, no committing scratch/planning files unless explicitly asked
- **`AGENTS.md`** — adds a `Markdown Formatting` section: no manual hard-wrapping of prose
- **`CLAUDE.md`** — updates the condensed "Conventions" summary to match the above

### Documentation

Brings this repo's `AGENTS.md`/`CLAUDE.md` in line with conventions already established in `liminal-hq/.github`'s org-wide `AGENTS.md`/`CLAUDE.md`. The gap surfaced while reviewing PR #89 against house rules — its title embedded milestone codes, and its description used ad hoc headings instead of the `## Summary` / `## Test plan` structure.

## Test plan

- [x] Diffed against `liminal-hq/.github`'s `AGENTS.md`/`CLAUDE.md` to confirm the added rules match verbatim where applicable
- [x] No code/behaviour change — no build or test suite applicable
