### PR TITLE
UI mode setting with dev override param

### DIFF
--- a/app/src/game/gameState.ts
+++ b/app/src/game/gameState.ts
@@ -94,6 +94,12 @@ export interface NarrativeSettings {
   tickerEnabled: boolean;
 }
 
+export type UiMode = 'auto' | 'desktop' | 'mobile';
+
+export interface UiSettings {
+  mode: UiMode;
+}
+
 export interface GameSettings {
   pendingPenaltyEnabled: boolean;
   minimap: MinimapSettings;
@@ -103,6 +109,7 @@ export interface GameSettings {
   hotkeys: HotkeyBindings;
   cosmetics: CosmeticSettings;
   narrative: NarrativeSettings;
+  ui: UiSettings;
 }
 
 export interface UtilityStats {
@@ -225,6 +232,12 @@ export function createDefaultNarrativeSettings(): NarrativeSettings {
   };
 }
 
+export function createDefaultUiSettings(): UiSettings {
+  return {
+    mode: 'auto'
+  };
+}
+
 export function createDefaultSettings(): GameSettings {
   return {
     pendingPenaltyEnabled: true,
@@ -234,7 +247,8 @@ export function createDefaultSettings(): GameSettings {
     audio: createDefaultAudioSettings(),
     hotkeys: { ...defaultHotkeys },
     cosmetics: createDefaultCosmeticSettings(),
-    narrative: createDefaultNarrativeSettings()
+    narrative: createDefaultNarrativeSettings(),
+    ui: createDefaultUiSettings()
   };
 }
 

--- a/app/src/game/persistence.test.ts
+++ b/app/src/game/persistence.test.ts
@@ -83,6 +83,20 @@ describe('settings back-fill', () => {
     expect(state.settings.narrative.tickerEnabled).toBe(defaults.narrative.tickerEnabled);
     expect(state.settings.pendingPenaltyEnabled).toBe(defaults.pendingPenaltyEnabled);
   });
+
+  it('defaults ui.mode to auto on a save that predates the setting', () => {
+    const state = degrade((parsed) => {
+      delete parsed.settings.ui;
+    });
+    expect(state.settings.ui).toEqual(createDefaultSettings().ui);
+  });
+
+  it('preserves an explicit ui.mode choice', () => {
+    const state = degrade((parsed) => {
+      parsed.settings.ui = { mode: 'mobile' };
+    });
+    expect(state.settings.ui.mode).toBe('mobile');
+  });
 });
 
 describe('seed and RNG back-fill', () => {

--- a/app/src/game/persistence.ts
+++ b/app/src/game/persistence.ts
@@ -206,7 +206,8 @@ export function deserialize(payload: string): GameState {
     narrative: {
       ...defaultSettings.narrative,
       ...(incomingSettings.narrative ?? {})
-    }
+    },
+    ui: { ...defaultSettings.ui, ...(incomingSettings.ui ?? {}) }
   };
   return parsed as GameState;
 }

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -12,6 +12,7 @@ import {
   createDefaultInputSettings,
   createDefaultMinimapSettings,
   createDefaultNarrativeSettings,
+  createDefaultUiSettings,
   createInitialState,
   GameState,
   getTile
@@ -149,6 +150,11 @@ function ensureSettingsShape(settings?: GameState['settings']): GameState['setti
   const audioDefaults = createDefaultAudioSettings();
   const cosmeticDefaults = createDefaultCosmeticSettings();
   const narrativeDefaults = createDefaultNarrativeSettings();
+  const uiDefaults = createDefaultUiSettings();
+  const uiSettings = { ...uiDefaults, ...(settings?.ui ?? {}) };
+  if (!['auto', 'desktop', 'mobile'].includes(uiSettings.mode)) {
+    uiSettings.mode = 'auto';
+  }
   return {
     pendingPenaltyEnabled: settings?.pendingPenaltyEnabled ?? true,
     minimap: minimapSettings,
@@ -157,7 +163,8 @@ function ensureSettingsShape(settings?: GameState['settings']): GameState['setti
     audio: { ...audioDefaults, ...(settings?.audio ?? {}) },
     hotkeys: { ...defaultHotkeys, ...(settings?.hotkeys ?? {}) },
     cosmetics: { ...cosmeticDefaults, ...(settings?.cosmetics ?? {}) },
-    narrative: { ...narrativeDefaults, ...(settings?.narrative ?? {}) }
+    narrative: { ...narrativeDefaults, ...(settings?.narrative ?? {}) },
+    ui: uiSettings
   };
 }
 
@@ -176,6 +183,12 @@ let selectedTool: Tool = Tool.Inspect;
 let temporaryTool: Tool | null = null;
 let state: GameState = loadFromBrowser() ?? createInitialState();
 state.settings = ensureSettingsShape(state.settings);
+// Dev override, same pattern as `?bridge=`: forces `desktop`/`mobile` for this
+// session only — never written back to the persisted setting.
+const uiParam = new URLSearchParams(window.location.search).get('ui');
+if (uiParam === 'desktop' || uiParam === 'mobile') {
+  state.settings.ui.mode = uiParam;
+}
 const notifications = createNotificationCenter();
 const narrativeManager = new NarrativeManager({
   enabled: state.settings.narrative.enabled,

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -183,8 +183,10 @@ let selectedTool: Tool = Tool.Inspect;
 let temporaryTool: Tool | null = null;
 let state: GameState = loadFromBrowser() ?? createInitialState();
 state.settings = ensureSettingsShape(state.settings);
-// Dev override, same pattern as `?bridge=`: forces `desktop`/`mobile` for this
-// session only — never written back to the persisted setting.
+// Dev override, same pattern as `?bridge=`: forces `desktop`/`mobile` for
+// this load. Unlike the bridge param, this mutates `state.settings` (the
+// persisted shape), so — same as any other in-session settings change — an
+// explicit Save while the override is active will persist it too.
 const uiParam = new URLSearchParams(window.location.search).get('ui');
 if (uiParam === 'desktop' || uiParam === 'mobile') {
   state.settings.ui.mode = uiParam;

--- a/app/src/ui/settingsModal.ts
+++ b/app/src/ui/settingsModal.ts
@@ -1,4 +1,4 @@
-import { GameSettings, MinimapSize, PanSpeedPreset, ZoomSensitivityPreset } from '../game/gameState';
+import { GameSettings, MinimapSize, PanSpeedPreset, UiMode, ZoomSensitivityPreset } from '../game/gameState';
 import { defaultHotkeys, HotkeyAction } from './hotkeys';
 
 interface SettingsModalOptions {
@@ -16,6 +16,12 @@ const ZOOM_SPEED_LABELS: Record<ZoomSensitivityPreset, string> = {
   gentle: 'Gentle',
   normal: 'Normal',
   fast: 'Fast'
+};
+
+const UI_MODE_LABELS: Record<UiMode, string> = {
+  auto: 'Auto-detect',
+  desktop: 'Desktop',
+  mobile: 'Mobile'
 };
 
 const HOTKEY_LABELS: Record<HotkeyAction, string> = {
@@ -138,6 +144,30 @@ export function initSettingsModal(options: SettingsModalOptions) {
 
     const body = document.createElement('div');
     body.className = 'settings-body';
+
+    const interfaceSection = createSection('Interface', 'Force a layout/input mode for testing; auto-detect is recommended.');
+    const uiModeRow = document.createElement('div');
+    uiModeRow.className = 'settings-row';
+    const uiModeLabel = document.createElement('div');
+    uiModeLabel.className = 'settings-label';
+    uiModeLabel.textContent = 'Display mode';
+    const uiModeDesc = document.createElement('div');
+    uiModeDesc.className = 'settings-description';
+    uiModeDesc.textContent = 'Auto-detect picks touch/mouse input and compact/full layout from the device.';
+    const uiModeSelect = document.createElement('select');
+    (['auto', 'desktop', 'mobile'] as UiMode[]).forEach((mode) => {
+      const opt = document.createElement('option');
+      opt.value = mode;
+      opt.textContent = UI_MODE_LABELS[mode];
+      opt.selected = draft.ui.mode === mode;
+      uiModeSelect.appendChild(opt);
+    });
+    uiModeSelect.addEventListener('change', () => {
+      draft.ui.mode = uiModeSelect.value as UiMode;
+      onApply(draft);
+    });
+    uiModeRow.append(uiModeLabel, uiModeDesc, uiModeSelect);
+    interfaceSection.append(uiModeRow);
 
     const general = createSection('Gameplay', 'Toggles that affect growth feedback.');
     const penaltiesRow = createToggleRow({
@@ -454,7 +484,7 @@ export function initSettingsModal(options: SettingsModalOptions) {
 
     hotkeys.append(hotkeyHint, resetHotkeys, hotkeyTable, conflictLabel);
 
-    body.append(audio, general, narrative, minimap, input, accessibility, cosmetics, hotkeys);
+    body.append(interfaceSection, audio, general, narrative, minimap, input, accessibility, cosmetics, hotkeys);
     modal.append(headerRow, body);
     backdrop.appendChild(modal);
     document.body.appendChild(backdrop);


### PR DESCRIPTION
Closes #63.

Part of the mobile web plan (epic #61) — Phase M0's settings/dev-override companion to #62 (M0-1's `initDeviceMode()` detection module).

## Summary

- **`app/src/game/gameState.ts`** — new `UiMode` (`'auto' | 'desktop' | 'mobile'`) and `UiSettings` type, `createDefaultUiSettings()` (defaults to `auto`), added to `GameSettings`/`createDefaultSettings()` following the existing nested-settings factory pattern
- **`app/src/game/persistence.ts`** — `deserialize` back-fills `ui` the same way as every other settings section, so saves that predate this field default to `auto`
- **`app/src/main.ts`** — `ensureSettingsShape` gains the same merge + enum guard as `minimap.mode`; a `?ui=desktop|mobile` query param (mirroring the existing `?bridge=` pattern) overrides `state.settings.ui.mode` for the load — note this mutates the persisted shape directly, so an explicit Save while the override is active persists it too, same as any other in-session settings change
- **`app/src/ui/settingsModal.ts`** — new "Interface" section with a `Display mode` select (Auto-detect / Desktop / Mobile), following the existing minimap-size select-row pattern

### User-facing changes

A new "Interface" section in Settings lets players force desktop or mobile mode instead of auto-detecting. Recommended default (`Auto-detect`) is unaffected for anyone who doesn't touch it.

### Known limitations

`auto` doesn't yet resolve against `initDeviceMode()`'s live detection anywhere — this ticket is settings/persistence/dev-param plumbing only, matching its DoD. M1-1 and the M2 compact-shell work are the actual consumers.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run test` — 138/138 non-`jsdom` tests pass locally (`src/ui/**` tests hit a machine-local jsdom/bun quirk unrelated to this change — see #92's history; CI is authoritative there)
- [x] Two new persistence tests: defaults `ui.mode` to `auto` on a pre-existing save, and preserves an explicit choice through a round-trip

