### PR TITLE
Resize contract hardening — toolbar height re-measures on rotation

### DIFF
--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -35,6 +35,7 @@ import { createHud } from './ui/hud';
 import { bindPersistenceControls, showManualModal, showToast } from './ui/dialogs';
 import { initDebugOverlay } from './ui/debugOverlay';
 import { initHotkeys, defaultHotkeys, type HotkeyAction, type HotkeyController } from './ui/hotkeys';
+import { initDeviceMode } from './ui/deviceMode';
 import { initToolbar, updateToolbar } from './ui/toolbar';
 import { createNotificationCenter } from './ui/notifications';
 import { initMinimap } from './ui/minimap';
@@ -777,6 +778,10 @@ function gameLoop(renderer: MapRenderer, hud: ReturnType<typeof createHud>) {
   syncToolbarHeights();
   window.addEventListener('resize', syncToolbarHeights);
   requestAnimationFrame(syncToolbarHeights);
+  // `resize` alone can lag or coalesce oddly around a mobile browser's own
+  // chrome/toolbar animation during rotation — layoutMode's matchMedia-driven
+  // change event is a more direct signal for the breakpoint actually flipping.
+  initDeviceMode({ onChange: syncToolbarHeights });
 
   bindPersistenceControls({
     saveBtn,


### PR DESCRIPTION
Closes #66.

Part of the mobile web plan (epic #61) — Phase M0's last item, closing out the phase entirely.

## Summary

- **`app/src/main.ts`** — wires `initDeviceMode()` (M0-1, unwired until now) so its `onChange` also triggers `syncToolbarHeights()`, alongside the existing `resize` listener. `layoutMode`'s own `matchMedia` change event is a more direct signal for the breakpoint actually flipping than the raw `resize` event, which can lag or coalesce oddly around a mobile browser's own chrome/toolbar animation during rotation.

### User-facing changes

None directly — this hardens an existing resize/rotation code path rather than adding new UI.

### Known limitations

The camera and canvas needed no code change: `screenToTile` and the renderer's draw loop already recompute from the canvas's live `getBoundingClientRect()`/dimensions on every call, and Pixi's `resizeTo` already keeps the canvas itself in sync — both were already resize-safe by construction, so this PR is scoped to the one real gap (toolbar-height CSS var re-measurement).

## Test plan

- [x] `bun run lint` clean
- [x] `bun run test` — 138/138 non-`jsdom` tests pass locally (pre-existing machine-local jsdom quirk, unrelated — see #92/#93 history; CI is authoritative there)
- [x] Verified with Playwright MCP against the dev server: resized a real Chromium page 390×844 → 844×390 → 390×844 (simulating a portrait↔landscape rotation round-trip) — zero console errors, canvas/tiles render without distortion in both orientations, the topbar's internal scroll (from #89) still reaches every HUD panel (confirmed scrolling to the Debug panel in landscape), and `--toolbar-base-height`/`--toolbar-visible-height` stay consistent across the resize
- [ ] Real on-device rotation (actual mobile browser chrome animating during the transition) not yet verified — worth a quick check on your phone if you want extra confidence, though the Playwright round-trip already covers the code path this PR touches
