### PR TITLE
Add Playwright MCP server for browser-driven testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ crates/*/target
 # wasm-pack output (generated — run `bun run build:wasm` to regenerate)
 pkg/
 app/src/wasm/
+
+# Playwright MCP session artifacts (screenshots, console logs, page snapshots)
+.playwright-mcp/

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,6 +4,10 @@
       "command": "bun",
       "args": ["run", "mcp"],
       "cwd": "/home/scott/source/city-sim-1000"
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@latest"]
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -7,7 +7,7 @@
     },
     "playwright": {
       "command": "npx",
-      "args": ["-y", "@playwright/mcp@latest"]
+      "args": ["-y", "@playwright/mcp@0.0.78"]
     }
   }
 }


### PR DESCRIPTION
## Summary

- **`.mcp.json`** — adds a `playwright` MCP server entry (`@playwright/mcp`), letting Claude Code drive a real browser (navigate, resize, screenshot, evaluate JS, read console output) instead of relying solely on manual phone testing or static code inspection. Used to verify #94's resize/rotation behaviour against an actual Chromium page (390×844 ↔ 844×390 round-trip, zero console errors, no layout distortion).
- **`.gitignore`** — ignores `.playwright-mcp/`, the tool's own session artifact directory (screenshots, console logs, page snapshots)

### Known limitations

The committed config uses `@playwright/mcp`'s default browser resolution, which targets the `chrome` channel (real Google Chrome) — installing that on Linux needs `sudo`/`apt` for system dependencies. On a machine without real Chrome, point the server at a bundled Playwright Chromium build instead (`npx playwright install chromium`, no sudo needed) via a **personal, local-only MCP override**, not this file — a machine-specific `--executable-path` here would break for anyone else who clones the repo, since that path is both username- and Playwright-version-specific.

## Test plan

- [x] Verified the MCP server connects and can navigate/resize/screenshot/evaluate against the local dev server (used live in #94's testing)
- [ ] No automated test applicable — this is dev tooling config, not application code
