### PR TITLE
Gesture disambiguation — one finger paints, two fingers pan the camera

### DIFF
--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -179,6 +179,10 @@ let pointerActive = false;
 let panStart = { x: 0, y: 0 };
 let cameraStart = { x: 0, y: 0 };
 let lastPainted: Position | null = null;
+// Live touch pointers keyed by pointerId, so a two-finger gesture can compute
+// a midpoint from both fingers' latest positions rather than just whichever
+// finger's pointermove happened to fire last.
+const activeTouchPointers = new Map<number, { x: number; y: number }>();
 let activeTool: Tool = Tool.Inspect;
 let selectedTool: Tool = Tool.Inspect;
 let temporaryTool: Tool | null = null;
@@ -406,9 +410,35 @@ function attachViewportEvents(canvas: HTMLCanvasElement) {
     });
   };
 
+  // Only ever called once at least two touch pointers are active.
+  const touchMidpoint = () => {
+    let x = 0;
+    let y = 0;
+    for (const p of activeTouchPointers.values()) {
+      x += p.x;
+      y += p.y;
+    }
+    return { x: x / activeTouchPointers.size, y: y / activeTouchPointers.size };
+  };
+
   wrapper.addEventListener('contextmenu', (e) => e.preventDefault());
 
   wrapper.addEventListener('pointerdown', (e) => {
+    if (e.pointerType === 'touch') {
+      activeTouchPointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+      if (activeTouchPointers.size >= 2) {
+        // A second finger always means camera control: cancel any in-progress
+        // paint before it can commit another tile, and start a pan gesture
+        // from the two fingers' midpoint. Pinch-zoom lands in a later ticket.
+        isPainting = false;
+        lastPainted = null;
+        hovered = null;
+        isPanning = true;
+        panStart = touchMidpoint();
+        cameraStart = { ...camera };
+        return;
+      }
+    }
     const tilePos = screenToTile(camera, TILE_SIZE, canvas, e.clientX, e.clientY);
     logPointerToTile('pointerdown', e, tilePos);
     hovered = isInBounds(tilePos) ? tilePos : null;
@@ -436,12 +466,21 @@ function attachViewportEvents(canvas: HTMLCanvasElement) {
   });
 
   wrapper.addEventListener('pointermove', (e) => {
+    if (e.pointerType === 'touch' && activeTouchPointers.has(e.pointerId)) {
+      activeTouchPointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    }
     pointerActive = e.buttons !== 0;
     if (isPanning) {
-      const dx = e.clientX - panStart.x;
-      const dy = e.clientY - panStart.y;
-      camera.x = cameraStart.x + dx;
-      camera.y = cameraStart.y + dy;
+      if (activeTouchPointers.size >= 2) {
+        const midpoint = touchMidpoint();
+        camera.x = cameraStart.x + (midpoint.x - panStart.x);
+        camera.y = cameraStart.y + (midpoint.y - panStart.y);
+      } else {
+        const dx = e.clientX - panStart.x;
+        const dy = e.clientY - panStart.y;
+        camera.x = cameraStart.x + dx;
+        camera.y = cameraStart.y + dy;
+      }
       return;
     }
     const tilePos = screenToTile(camera, TILE_SIZE, canvas, e.clientX, e.clientY);
@@ -469,7 +508,10 @@ function attachViewportEvents(canvas: HTMLCanvasElement) {
     }
   });
 
-  const stopPainting = () => {
+  const stopPainting = (e?: PointerEvent) => {
+    if (e?.pointerType === 'touch') {
+      activeTouchPointers.delete(e.pointerId);
+    }
     isPanning = false;
     isPainting = false;
     lastPainted = null;


### PR DESCRIPTION
Closes #67.

Part of the mobile web plan (epic #61) — Phase M1's first item.

## Summary

- **`app/src/main.ts`** — tracks live touch pointers by `pointerId` in `attachViewportEvents`. On a second touch pointer going down, any in-progress paint is cancelled immediately (`isPainting`/`lastPainted`/`hovered` reset) before it can commit another tile, and a pan gesture starts from the two fingers' midpoint. Subsequent moves of either finger recompute the midpoint and pan the camera by its delta from the gesture's start. Releasing any tracked pointer fully resets the gesture, matching the existing "any pointerup/cancel stops everything" behaviour already used for the mouse path.
- Mouse and pen input are unaffected — the new logic is gated entirely behind `pointerType === 'touch'`, so the existing button/altKey-driven mouse pan and drag-paint code paths run exactly as before.

### User-facing changes

On touch devices, starting a second finger while dragging a tool now cancels the paint and switches to panning the camera, instead of the second finger's touch racing the first finger's paint gesture (undefined/broken today, since all pointer state was previously shared globally with no per-pointer tracking). Pinch-zoom itself (scaling, not just panning) is out of scope here — that's #68.

### Known limitations

Lifting one of two fingers ends the whole gesture rather than gracefully continuing with the remaining finger (the user has to release both and restart). That's a reasonable simplification for this ticket; #68 (which needs its own two-pointer tracking for pinch-distance math) is a natural place to revisit it if it feels wrong on-device.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run test` — 138/138 non-`jsdom` tests pass locally (pre-existing machine-local jsdom quirk, unrelated — see #92/#93 history; CI is authoritative there)
- [x] Verified with Playwright MCP against the dev server, dispatching synthetic `PointerEvent`s on `#canvas-wrapper` (via the `city-sim` MCP bridge to read live tile/game state, not just visual inspection):
  - Single touch drag-paints a road across two tiles (baseline, unchanged).
  - A second touch pointer mid-drag stops painting immediately and pans the camera — confirmed both fronts: tile count stayed at exactly 2 despite the first finger continuing to move ~150px afterward (no stray tiles), and a screenshot before/after showed the rendered tiles shift on-screen consistent with the two-finger midpoint delta.
  - After releasing both touches, a fresh single touch paints normally again (state resets cleanly).
  - A mouse drag-paint dispatched immediately after (`pointerType: 'mouse'`) painted normally with zero console errors, confirming the mouse path is untouched.
- [ ] Real on-device two-finger gesture (actual touchscreen) not yet verified — worth trying on your phone: drag with one finger to paint, then touch down a second finger mid-drag and confirm it stops painting and pans instead, with no stray tiles left behind.
