### PR TITLE
Pinch-zoom + two-finger pan

### DIFF
--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -183,6 +183,9 @@ let lastPainted: Position | null = null;
 // a midpoint from both fingers' latest positions rather than just whichever
 // finger's pointermove happened to fire last.
 const activeTouchPointers = new Map<number, { x: number; y: number }>();
+let isPinching = false;
+let lastPinchMidpoint: { x: number; y: number } | null = null;
+let lastPinchDistance: number | null = null;
 let activeTool: Tool = Tool.Inspect;
 let selectedTool: Tool = Tool.Inspect;
 let temporaryTool: Tool | null = null;
@@ -410,7 +413,7 @@ function attachViewportEvents(canvas: HTMLCanvasElement) {
     });
   };
 
-  // Only ever called once at least two touch pointers are active.
+  // Both only ever called once at least two touch pointers are active.
   const touchMidpoint = () => {
     let x = 0;
     let y = 0;
@@ -420,6 +423,15 @@ function attachViewportEvents(canvas: HTMLCanvasElement) {
     }
     return { x: x / activeTouchPointers.size, y: y / activeTouchPointers.size };
   };
+  // Average distance from the midpoint, doubled so it equals the finger-to-finger
+  // distance in the common two-finger case (distance-from-centroid is half of that).
+  const touchSpread = (mid: { x: number; y: number }) => {
+    let total = 0;
+    for (const p of activeTouchPointers.values()) {
+      total += Math.hypot(p.x - mid.x, p.y - mid.y);
+    }
+    return (total / activeTouchPointers.size) * 2;
+  };
 
   wrapper.addEventListener('contextmenu', (e) => e.preventDefault());
 
@@ -428,14 +440,15 @@ function attachViewportEvents(canvas: HTMLCanvasElement) {
       activeTouchPointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
       if (activeTouchPointers.size >= 2) {
         // A second finger always means camera control: cancel any in-progress
-        // paint before it can commit another tile, and start a pan gesture
-        // from the two fingers' midpoint. Pinch-zoom lands in a later ticket.
+        // paint before it can commit another tile, and start a pinch-pan
+        // gesture from the fingers' midpoint/spread. Re-priming on a third
+        // finger joining (rather than requiring exactly two) avoids a jump.
         isPainting = false;
         lastPainted = null;
         hovered = null;
-        isPanning = true;
-        panStart = touchMidpoint();
-        cameraStart = { ...camera };
+        isPinching = true;
+        lastPinchMidpoint = touchMidpoint();
+        lastPinchDistance = touchSpread(lastPinchMidpoint);
         return;
       }
     }
@@ -470,17 +483,29 @@ function attachViewportEvents(canvas: HTMLCanvasElement) {
       activeTouchPointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
     }
     pointerActive = e.buttons !== 0;
-    if (isPanning) {
-      if (activeTouchPointers.size >= 2) {
-        const midpoint = touchMidpoint();
-        camera.x = cameraStart.x + (midpoint.x - panStart.x);
-        camera.y = cameraStart.y + (midpoint.y - panStart.y);
-      } else {
-        const dx = e.clientX - panStart.x;
-        const dy = e.clientY - panStart.y;
-        camera.x = cameraStart.x + dx;
-        camera.y = cameraStart.y + dy;
+    if (isPinching && lastPinchMidpoint && lastPinchDistance !== null) {
+      const midpoint = touchMidpoint();
+      camera.x += midpoint.x - lastPinchMidpoint.x;
+      camera.y += midpoint.y - lastPinchMidpoint.y;
+      const distance = touchSpread(midpoint);
+      if (lastPinchDistance > 0 && distance > 0) {
+        const inputSettings = state.settings.input;
+        const sensitivity = (ZOOM_STEPS[inputSettings.zoomSensitivity] ?? ZOOM_STEPS.normal) / ZOOM_STEPS.normal;
+        const factor = Math.pow(distance / lastPinchDistance, sensitivity);
+        const rect = canvas.getBoundingClientRect();
+        zoomAt(camera, midpoint.x - rect.left, midpoint.y - rect.top, factor);
       }
+      lastPinchMidpoint = midpoint;
+      if (distance > 0) {
+        lastPinchDistance = distance;
+      }
+      return;
+    }
+    if (isPanning) {
+      const dx = e.clientX - panStart.x;
+      const dy = e.clientY - panStart.y;
+      camera.x = cameraStart.x + dx;
+      camera.y = cameraStart.y + dy;
       return;
     }
     const tilePos = screenToTile(camera, TILE_SIZE, canvas, e.clientX, e.clientY);
@@ -513,6 +538,9 @@ function attachViewportEvents(canvas: HTMLCanvasElement) {
       activeTouchPointers.delete(e.pointerId);
     }
     isPanning = false;
+    isPinching = false;
+    lastPinchMidpoint = null;
+    lastPinchDistance = null;
     isPainting = false;
     lastPainted = null;
     pointerActive = false;

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -413,7 +413,7 @@ function attachViewportEvents(canvas: HTMLCanvasElement) {
     });
   };
 
-  // Both only ever called once at least two touch pointers are active.
+  // Both only ever called while at least two touch pointers are active.
   const touchMidpoint = () => {
     let x = 0;
     let y = 0;


### PR DESCRIPTION
Closes #68.

Part of the mobile web plan (epic #61) — Phase M1, building on #67's two-finger tracking.

## Summary

- **`app/src/main.ts`** — replaces the two-finger placeholder from #67 (which only panned, using an absolute delta from a fixed gesture-start reference) with a combined per-frame pinch-pan-zoom: each touch `pointermove` while 2+ fingers are down recomputes the fingers' midpoint and spread (distance), pans the camera by the midpoint's delta since the previous frame, then calls the existing `zoomAt()` (already used by wheel-zoom) anchored at the current midpoint with a factor derived from the spread ratio. This is a true per-frame incremental update rather than #67's single fixed-reference model, which is necessary once zoom is in the mix — `zoomAt` itself mutates `camera.x`/`camera.y` to keep its focus point stationary, which would fight an absolute-reference pan recomputed from a stale starting point every frame.
- The zoom factor exponentiates the raw distance ratio by `ZOOM_STEPS[zoomSensitivity] / ZOOM_STEPS.normal` — the same table the wheel handler already uses — so the `normal` preset pinches at a direct 1:1 physical ratio and `gentle`/`fast` scale it the same way they already scale wheel zoom, without needing a second tunable table.
- Mouse pan (`isPanning`) and wheel zoom are entirely untouched — gated behind `pointerType === 'touch'`, same as #67.

### User-facing changes

Two-finger touch now pinch-zooms (scaling the map in/out, anchored under the fingers) in addition to panning, instead of #67's pan-only placeholder.

### Known limitations

Same as #67: lifting one of two+ fingers ends the whole gesture (any pointerup/cancel fully resets pinch/pan/paint state) rather than gracefully continuing with the remaining finger(s).

## Test plan

- [x] `bun run lint` clean
- [x] `bun run test` — 138/138 non-`jsdom` tests pass locally (pre-existing machine-local jsdom quirk, unrelated — see #92/#93/#96 history; CI is authoritative there)
- [x] Verified with Playwright MCP against the dev server, dispatching synthetic `PointerEvent`/`WheelEvent`s:
  - Placed a road tile at a known screen coordinate, then pinched outward with the gesture symmetric around that same coordinate — the tile stayed pinned at the same screen position across the whole gesture while the surrounding map visibly scaled up, confirming no drift (the DoD's core requirement).
  - Desktop wheel zoom-in/out still works identically afterward, with zero console errors.
- [x] Confirmed on your phone (per your message during this session) that #67's two-finger pan already works correctly on-device — this PR layers zoom on top of that same gesture, so it's worth trying a real pinch next.
- [ ] Real on-device pinch (actual two-finger touchscreen gesture, which behaves slightly differently than synthetic dispatched events — e.g. actual finger jitter/timing) not yet verified — worth a try on your phone: pinch out/in on the map and confirm the point between your fingers stays put while it zooms.
