### PR TITLE
HUD status ribbon, speed dropdown with pause, and rebase fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Pointer/touch debugging: in a dev build, run `localStorage.setItem('debug-pointe
 - Pan: drag with mouse or use `WASD` / arrow keys; zoom with scroll/pinch.
 - Quick bulldoze: right-click to bulldoze the tile under your cursor, or hold and drag to clear a path. Middle-click or Alt-drag still pans. The Inspect tool does not bulldoze on right-click.
 - Tools: click toolbar buttons or hotkeys — Inspect (`I`), Raise (`E`), Lower (`Q`), Water paint (`F`), Trees (`T`), Road (`R`), Rail (`L`), Power Lines (`P`), Hydro (`H`), Pump (`U`), Tower (`Y`), Elementary School (`J`), High School (`N`), Residential (`Z`), Commercial (`X`), Industrial (`C`), Park (`K`), Bulldoze (`B`).
-- Speed: `1` Slow (0.5x), `2` Fast (1x), `3` Ludicrous (3x).
+- Speed: `1` Slow (0.5x), `2` Fast (1x), `3` Ludicrous (3x); `Space` toggles pause (resumes at the last-selected speed).
 - Inspector: select Inspect, click a tile to see utilities, status, and capacity; pin the tool info card to keep build stats visible.
 
 ## Offline & PWA

--- a/app/public/manual.html
+++ b/app/public/manual.html
@@ -121,7 +121,7 @@
     <ul>
       <li>The bar across the top shows treasury and monthly net, power and water balances, R/C/I demand columns, the calendar, and population/jobs.</li>
       <li>Hover any chip for details; the R/C/I columns rise with zone demand, SimCity-style.</li>
-      <li>Right side: simulation speed (▶ Slow, ⏩ Fast, ⚡ Ludicrous — hotkeys <code>1</code>/<code>2</code>/<code>3</code>), 📊 budget, 📜 bylaws, the 💾 saves menu, 📖 this manual, ⚙️ settings, and 🛠️ debug tools.</li>
+      <li>Right side: a speed menu (icon shows the active tier — 🐢 Slow, 🐇 Fast, ⚡ Ludicrous — hotkeys <code>1</code>/<code>2</code>/<code>3</code>), a ⏸ pause toggle (hotkey <code>Space</code>; picking a speed while paused resumes at that speed), 📊 budget, 📜 bylaws, the 💾 saves menu, 📖 this manual, ⚙️ settings, and 🛠️ debug tools.</li>
     </ul>
   </body>
 </html>

--- a/app/public/manual.html
+++ b/app/public/manual.html
@@ -121,7 +121,7 @@
     <ul>
       <li>The bar across the top shows treasury and monthly net, power and water balances, R/C/I demand columns, the calendar, and population/jobs.</li>
       <li>Hover any chip for details; the R/C/I columns rise with zone demand, SimCity-style.</li>
-      <li>Right side: simulation speed (▶ Slow, ⏩ Fast, ⚡ Ludicrous — hotkeys <code>1</code>/<code>2</code>/<code>3</code>), the 💾 saves menu, 📖 this manual, and 🛠️ debug tools.</li>
+      <li>Right side: simulation speed (▶ Slow, ⏩ Fast, ⚡ Ludicrous — hotkeys <code>1</code>/<code>2</code>/<code>3</code>), 📊 budget, 📜 bylaws, the 💾 saves menu, 📖 this manual, ⚙️ settings, and 🛠️ debug tools.</li>
     </ul>
   </body>
 </html>

--- a/app/public/manual.html
+++ b/app/public/manual.html
@@ -111,9 +111,17 @@
 
     <h2>Saving & backups</h2>
     <ul>
-      <li>Use <strong>Save to Browser</strong> to store your city in localStorage.</li>
-      <li><strong>Download Save</strong> exports a JSON file so you can back it up.</li>
-      <li><strong>Upload Save</strong> lets you restore any exported city.</li>
+      <li>Open the 💾 menu in the top status ribbon for all save actions.</li>
+      <li>Use <strong>Save</strong> to store your city in localStorage and <strong>Load</strong> to restore it.</li>
+      <li><strong>Download</strong> exports a JSON file so you can back it up.</li>
+      <li><strong>Upload</strong> lets you restore any exported city.</li>
+    </ul>
+
+    <h2>The status ribbon</h2>
+    <ul>
+      <li>The bar across the top shows treasury and monthly net, power and water balances, R/C/I demand columns, the calendar, and population/jobs.</li>
+      <li>Hover any chip for details; the R/C/I columns rise with zone demand, SimCity-style.</li>
+      <li>Right side: simulation speed (▶ Slow, ⏩ Fast, ⚡ Ludicrous — hotkeys <code>1</code>/<code>2</code>/<code>3</code>), the 💾 saves menu, 📖 this manual, and 🛠️ debug tools.</li>
     </ul>
   </body>
 </html>

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -59,14 +59,55 @@ if (!appRoot) {
 appRoot.innerHTML = `
   <div class="topbar">
     <div class="logo">🏙️ <span>City Sim 1000</span></div>
-    <div class="hud">
-      <div class="panel"><h4>Budget</h4><div id="money">$0</div><div id="budget-net" class="budget-net">+$0 / month</div><div id="power">⚡ 0 MW</div><div id="water">💧 0 m³</div></div>
-      <div class="panel"><h4>Demands</h4><div class="demand-rows"><div class="demand-row"><span class="demand-label">R</span><div class="demand-bar"><div id="res-bar" class="demand-fill" style="background:#7bffb7;width:30%"></div></div></div><div class="demand-row"><span class="demand-label">C</span><div class="demand-bar"><div id="com-bar" class="demand-fill" style="background:#5bc0eb;width:30%"></div></div></div><div class="demand-row"><span class="demand-label">I</span><div class="demand-bar"><div id="ind-bar" class="demand-fill" style="background:#f08c42;width:30%"></div></div></div></div></div>
-      <div class="panel"><h4>City</h4><div id="month">Month 1</div><div id="day">Day 1 of 30</div><div id="population">Population 0</div><div id="jobs">Jobs 0</div></div>
-      <div class="panel"><h4>Speed</h4><div class="controls-row"><button id="speed-slow" class="secondary">Slow</button><button id="speed-fast" class="secondary">Fast</button><button id="speed-ludicrous" class="secondary">Ludicrous</button></div><div class="panel-hint">Hotkeys: 1/2/3</div></div>
-      <div class="panel"><h4>Saves</h4><div class="controls-row"><button id="save-btn" class="secondary">Save</button><button id="load-btn" class="secondary">Load</button></div><div class="controls-row"><button id="download-btn" class="primary">Download</button><button id="upload-btn" class="secondary">Upload</button><input type="file" id="file-input" accept="application/json" style="display:none" /></div></div>
-      <div class="panel"><h4>Manual</h4><div class="controls-row"><button id="manual-btn" class="secondary">Open manual</button></div><div class="panel-hint">Opens the in-game guide in a popup.</div></div>
-      <div class="panel panel-right"><h4>Debug</h4><div class="controls-row"><button id="debug-overlay-btn" class="secondary">Show overlay</button><button id="debug-copy-btn" class="secondary">Copy state</button><button id="pending-penalty-btn" class="secondary">Penalties: On</button><button id="sim-bridge-btn" class="secondary">Sim: WASM</button></div><div class="panel-hint">Live stats and a clipboard snapshot.</div></div>
+    <div class="ribbon">
+      <div class="ribbon-chip" title="City treasury and monthly net">
+        <span id="money" class="ribbon-strong">$0</span>
+        <span id="budget-net" class="budget-net">+$0 / month</span>
+      </div>
+      <div class="ribbon-chip" title="Power and water balance">
+        <span id="power">⚡ 0 MW</span>
+        <span id="water">💧 0 m³</span>
+      </div>
+      <div class="ribbon-chip ribbon-rci" title="Zone demand — Residential / Commercial / Industrial">
+        <span class="rci-col"><span class="rci-track"><span id="res-bar" class="rci-fill" style="background:#7bffb7;height:30%"></span></span><span class="rci-label">R</span></span>
+        <span class="rci-col"><span class="rci-track"><span id="com-bar" class="rci-fill" style="background:#5bc0eb;height:30%"></span></span><span class="rci-label">C</span></span>
+        <span class="rci-col"><span class="rci-track"><span id="ind-bar" class="rci-fill" style="background:#f08c42;height:30%"></span></span><span class="rci-label">I</span></span>
+      </div>
+      <div class="ribbon-chip" title="Calendar">
+        <span id="month">Month 1</span>
+        <span id="day" class="ribbon-dim">Day 1/30</span>
+      </div>
+      <div class="ribbon-chip" title="Population and jobs">
+        <span id="population">👥 0</span>
+        <span id="jobs">💼 0</span>
+      </div>
+    </div>
+    <div class="ribbon-controls">
+      <div class="ribbon-chip ribbon-btn-group" role="group" aria-label="Simulation speed">
+        <button id="speed-slow" class="ribbon-btn" title="Slow (hotkey 1)" aria-label="Slow speed">▶</button>
+        <button id="speed-fast" class="ribbon-btn" title="Fast (hotkey 2)" aria-label="Fast speed">⏩</button>
+        <button id="speed-ludicrous" class="ribbon-btn" title="Ludicrous (hotkey 3)" aria-label="Ludicrous speed">⚡</button>
+      </div>
+      <details class="ribbon-menu">
+        <summary class="ribbon-btn" title="Saves — save, load, download, upload" aria-label="Saves menu">💾</summary>
+        <div class="ribbon-menu-panel">
+          <button id="save-btn" class="secondary">Save</button>
+          <button id="load-btn" class="secondary">Load</button>
+          <button id="download-btn" class="primary">Download</button>
+          <button id="upload-btn" class="secondary">Upload</button>
+          <input type="file" id="file-input" accept="application/json" style="display:none" />
+        </div>
+      </details>
+      <button id="manual-btn" class="ribbon-btn" title="Open the in-game manual" aria-label="Open manual">📖</button>
+      <details class="ribbon-menu">
+        <summary class="ribbon-btn" title="Debug — overlay, state snapshot, penalties, sim engine" aria-label="Debug menu">🛠️</summary>
+        <div class="ribbon-menu-panel">
+          <button id="debug-overlay-btn" class="secondary">Show overlay</button>
+          <button id="debug-copy-btn" class="secondary">Copy state</button>
+          <button id="pending-penalty-btn" class="secondary">Penalties: On</button>
+          <button id="sim-bridge-btn" class="secondary">Sim: WASM</button>
+        </div>
+      </details>
     </div>
   </div>
   <div class="news-ticker news-ticker-hidden" id="news-ticker">
@@ -121,6 +162,36 @@ const debugCopyBtn = requireElement<HTMLButtonElement>('#debug-copy-btn');
 const pendingPenaltyBtn = requireElement<HTMLButtonElement>('#pending-penalty-btn');
 const simBridgeBtn = requireElement<HTMLButtonElement>('#sim-bridge-btn');
 const newsTickerEl = requireElement<HTMLDivElement>('#news-ticker');
+
+// Ribbon dropdowns (<details>): only one open at a time, close on outside
+// click or Escape, and close the saves menu after an action is chosen.
+const ribbonMenus = [...document.querySelectorAll<HTMLDetailsElement>('details.ribbon-menu')];
+for (const menu of ribbonMenus) {
+  menu.addEventListener('toggle', () => {
+    if (!menu.open) return;
+    for (const other of ribbonMenus) {
+      if (other !== menu) other.open = false;
+    }
+  });
+}
+document.addEventListener('pointerdown', (e) => {
+  for (const menu of ribbonMenus) {
+    if (menu.open && !menu.contains(e.target as Node)) menu.open = false;
+  }
+});
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') {
+    for (const menu of ribbonMenus) menu.open = false;
+  }
+});
+// Save/Load/Download/Upload are one-shot actions — collapse after use. The
+// debug menu stays open because its buttons are stateful toggles.
+const savesMenu = ribbonMenus.find((m) => m.querySelector('#save-btn'));
+savesMenu?.querySelectorAll('button').forEach((btn) => {
+  btn.addEventListener('click', () => {
+    savesMenu.open = false;
+  });
+});
 
 const syncToolbarHeights = () => {
   const rect = toolbar.getBoundingClientRect();

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -60,26 +60,28 @@ appRoot.innerHTML = `
   <div class="topbar">
     <div class="logo">🏙️ <span>City Sim 1000</span></div>
     <div class="ribbon">
-      <div class="ribbon-chip" title="City treasury and monthly net">
-        <span id="money" class="ribbon-strong">$0</span>
-        <span id="budget-net" class="budget-net">+$0 / month</span>
-      </div>
-      <div class="ribbon-chip" title="Power and water balance">
-        <span id="power">⚡ 0 MW</span>
-        <span id="water">💧 0 m³</span>
+      <div class="ribbon-chip" title="City treasury, monthly net, and utility balances">
+        <div class="ribbon-line">
+          <span id="money" class="ribbon-strong">$0</span>
+          <span id="budget-net" class="budget-net">+$0 / month</span>
+        </div>
+        <div class="ribbon-line">
+          <span id="power">⚡ 0 MW</span>
+          <span id="water">💧 0 m³</span>
+        </div>
       </div>
       <div class="ribbon-chip ribbon-rci" title="Zone demand — Residential / Commercial / Industrial">
-        <span class="rci-col"><span class="rci-track"><span id="res-bar" class="rci-fill" style="background:#7bffb7;height:30%"></span></span><span class="rci-label">R</span></span>
-        <span class="rci-col"><span class="rci-track"><span id="com-bar" class="rci-fill" style="background:#5bc0eb;height:30%"></span></span><span class="rci-label">C</span></span>
-        <span class="rci-col"><span class="rci-track"><span id="ind-bar" class="rci-fill" style="background:#f08c42;height:30%"></span></span><span class="rci-label">I</span></span>
+        <span class="rci-row"><span class="rci-label">R</span><span class="rci-track"><span id="res-bar" class="rci-fill" style="background:#7bffb7;width:30%"></span></span></span>
+        <span class="rci-row"><span class="rci-label">C</span><span class="rci-track"><span id="com-bar" class="rci-fill" style="background:#5bc0eb;width:30%"></span></span></span>
+        <span class="rci-row"><span class="rci-label">I</span><span class="rci-track"><span id="ind-bar" class="rci-fill" style="background:#f08c42;width:30%"></span></span></span>
       </div>
       <div class="ribbon-chip" title="Calendar">
-        <span id="month">Month 1</span>
-        <span id="day" class="ribbon-dim">Day 1/30</span>
+        <div class="ribbon-line"><span id="month">Month 1</span></div>
+        <div class="ribbon-line"><span id="day" class="ribbon-dim">Day 1/30</span></div>
       </div>
       <div class="ribbon-chip" title="Population and jobs">
-        <span id="population">👥 0</span>
-        <span id="jobs">💼 0</span>
+        <div class="ribbon-line"><span id="population">👥 0</span></div>
+        <div class="ribbon-line"><span id="jobs">💼 0</span></div>
       </div>
     </div>
     <div class="ribbon-controls">

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -60,7 +60,7 @@ appRoot.innerHTML = `
   <div class="topbar">
     <div class="logo">🏙️ <span>City Sim 1000</span></div>
     <div class="ribbon">
-      <div class="ribbon-chip" title="City treasury, monthly net, and utility balances">
+      <button type="button" id="treasury-chip" class="ribbon-chip ribbon-chip-button" title="City treasury and utilities — click to open the budget screen">
         <div class="ribbon-line">
           <span id="money" class="ribbon-strong">$0</span>
           <span id="budget-net" class="budget-net">+$0 / month</span>
@@ -69,7 +69,7 @@ appRoot.innerHTML = `
           <span id="power">⚡ 0 MW</span>
           <span id="water">💧 0 m³</span>
         </div>
-      </div>
+      </button>
       <div class="ribbon-chip ribbon-rci" title="Zone demand — Residential / Commercial / Industrial">
         <span class="rci-row"><span class="rci-label">R</span><span class="rci-track"><span id="res-bar" class="rci-fill" style="background:#7bffb7;width:30%"></span></span></span>
         <span class="rci-row"><span class="rci-label">C</span><span class="rci-track"><span id="com-bar" class="rci-fill" style="background:#5bc0eb;width:30%"></span></span></span>
@@ -162,6 +162,7 @@ const downloadBtn = requireElement<HTMLButtonElement>('#download-btn');
 const uploadBtn = requireElement<HTMLButtonElement>('#upload-btn');
 const fileInput = requireElement<HTMLInputElement>('#file-input');
 const manualBtn = requireElement<HTMLButtonElement>('#manual-btn');
+const treasuryChip = requireElement<HTMLButtonElement>('#treasury-chip');
 const budgetModalBtn = requireElement<HTMLButtonElement>('#budget-modal-btn');
 const bylawsModalBtn = requireElement<HTMLButtonElement>('#bylaws-modal-btn');
 const settingsBtn = requireElement<HTMLButtonElement>('#settings-btn');
@@ -938,6 +939,7 @@ function gameLoop(renderer: MapRenderer, hud: ReturnType<typeof createHud>) {
     onApply: (next) => applySettings(next)
   });
 
+  treasuryChip.addEventListener('click', () => budgetModal.open());
   budgetModalBtn.addEventListener('click', () => budgetModal.open());
   bylawsModalBtn.addEventListener('click', () => bylawsModal.open());
   settingsBtn.addEventListener('click', () => settingsModal?.open());

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -90,6 +90,8 @@ appRoot.innerHTML = `
         <button id="speed-fast" class="ribbon-btn" title="Fast (hotkey 2)" aria-label="Fast speed">⏩</button>
         <button id="speed-ludicrous" class="ribbon-btn" title="Ludicrous (hotkey 3)" aria-label="Ludicrous speed">⚡</button>
       </div>
+      <button id="budget-modal-btn" class="ribbon-btn" title="Open the budget screen" aria-label="Open budget">📊</button>
+      <button id="bylaws-modal-btn" class="ribbon-btn" title="Open city bylaws" aria-label="Open bylaws">📜</button>
       <details class="ribbon-menu">
         <summary class="ribbon-btn" title="Saves — save, load, download, upload" aria-label="Saves menu">💾</summary>
         <div class="ribbon-menu-panel">
@@ -101,6 +103,7 @@ appRoot.innerHTML = `
         </div>
       </details>
       <button id="manual-btn" class="ribbon-btn" title="Open the in-game manual" aria-label="Open manual">📖</button>
+      <button id="settings-btn" class="ribbon-btn" title="Open settings" aria-label="Open settings">⚙️</button>
       <details class="ribbon-menu">
         <summary class="ribbon-btn" title="Debug — overlay, state snapshot, penalties, sim engine" aria-label="Debug menu">🛠️</summary>
         <div class="ribbon-menu-panel">
@@ -159,6 +162,9 @@ const downloadBtn = requireElement<HTMLButtonElement>('#download-btn');
 const uploadBtn = requireElement<HTMLButtonElement>('#upload-btn');
 const fileInput = requireElement<HTMLInputElement>('#file-input');
 const manualBtn = requireElement<HTMLButtonElement>('#manual-btn');
+const budgetModalBtn = requireElement<HTMLButtonElement>('#budget-modal-btn');
+const bylawsModalBtn = requireElement<HTMLButtonElement>('#bylaws-modal-btn');
+const settingsBtn = requireElement<HTMLButtonElement>('#settings-btn');
 const debugOverlayBtn = requireElement<HTMLButtonElement>('#debug-overlay-btn');
 const debugCopyBtn = requireElement<HTMLButtonElement>('#debug-copy-btn');
 const pendingPenaltyBtn = requireElement<HTMLButtonElement>('#pending-penalty-btn');
@@ -932,6 +938,10 @@ function gameLoop(renderer: MapRenderer, hud: ReturnType<typeof createHud>) {
     onApply: (next) => applySettings(next)
   });
 
+  budgetModalBtn.addEventListener('click', () => budgetModal.open());
+  bylawsModalBtn.addEventListener('click', () => bylawsModal.open());
+  settingsBtn.addEventListener('click', () => settingsModal?.open());
+
   const toolbarControllers = initToolbar(
     toolbar,
     (nextTool) => {
@@ -939,9 +949,6 @@ function gameLoop(renderer: MapRenderer, hud: ReturnType<typeof createHud>) {
     },
     activeTool,
     {
-      onOpenBudget: () => budgetModal.open(),
-      onOpenBylaws: () => bylawsModal.open(),
-      onOpenSettings: () => settingsModal?.open(),
       radioVolume: state.settings.audio.radioVolume
     }
   );

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -85,11 +85,15 @@ appRoot.innerHTML = `
       </div>
     </div>
     <div class="ribbon-controls">
-      <div class="ribbon-chip ribbon-btn-group" role="group" aria-label="Simulation speed">
-        <button id="speed-slow" class="ribbon-btn" title="Slow (hotkey 1)" aria-label="Slow speed">▶</button>
-        <button id="speed-fast" class="ribbon-btn" title="Fast (hotkey 2)" aria-label="Fast speed">⏩</button>
-        <button id="speed-ludicrous" class="ribbon-btn" title="Ludicrous (hotkey 3)" aria-label="Ludicrous speed">⚡</button>
-      </div>
+      <details class="ribbon-menu">
+        <summary id="speed-summary" class="ribbon-btn" title="Simulation speed" aria-label="Speed menu">🐇</summary>
+        <div class="ribbon-menu-panel">
+          <button id="speed-slow" class="secondary" title="Slow — 0.5x (hotkey 1)">🐢 Slow (0.5x)</button>
+          <button id="speed-fast" class="secondary" title="Fast — 1x (hotkey 2)">🐇 Fast (1x)</button>
+          <button id="speed-ludicrous" class="secondary" title="Ludicrous — 3x (hotkey 3)">⚡ Ludicrous (3x)</button>
+        </div>
+      </details>
+      <button id="pause-btn" class="ribbon-btn" title="Pause (hotkey Space)" aria-label="Pause">⏸</button>
       <button id="budget-modal-btn" class="ribbon-btn" title="Open the budget screen" aria-label="Open budget">📊</button>
       <button id="bylaws-modal-btn" class="ribbon-btn" title="Open city bylaws" aria-label="Open bylaws">📜</button>
       <details class="ribbon-menu">
@@ -156,6 +160,8 @@ const dayEl = requireElement<HTMLDivElement>('#day');
 const speedSlowBtn = requireElement<HTMLButtonElement>('#speed-slow');
 const speedFastBtn = requireElement<HTMLButtonElement>('#speed-fast');
 const speedLudicrousBtn = requireElement<HTMLButtonElement>('#speed-ludicrous');
+const speedSummaryEl = requireElement<HTMLElement>('#speed-summary');
+const pauseBtn = requireElement<HTMLButtonElement>('#pause-btn');
 const saveBtn = requireElement<HTMLButtonElement>('#save-btn');
 const loadBtn = requireElement<HTMLButtonElement>('#load-btn');
 const downloadBtn = requireElement<HTMLButtonElement>('#download-btn');
@@ -207,6 +213,13 @@ const savesMenu = ribbonMenus.find((m) => m.querySelector('#save-btn'));
 savesMenu?.querySelectorAll('button').forEach((btn) => {
   btn.addEventListener('click', () => {
     savesMenu.open = false;
+  });
+});
+// Picking a speed tier is a one-shot choice too — collapse after use.
+const speedMenu = ribbonMenus.find((m) => m.querySelector('#speed-slow'));
+speedMenu?.querySelectorAll('button').forEach((btn) => {
+  btn.addEventListener('click', () => {
+    speedMenu.open = false;
   });
 });
 
@@ -375,8 +388,14 @@ const simSpeeds = {
   fast: 1,
   ludicrous: 3
 } as const;
+const SPEED_ICONS: Record<SimSpeedKey, string> = {
+  slow: '🐢',
+  fast: '🐇',
+  ludicrous: '⚡'
+};
 type SimSpeedKey = keyof typeof simSpeeds;
 let simSpeed: SimSpeedKey = 'fast';
+let isPaused = false;
 let lastNarrativeMonth = getCalendarPosition(state.day).month;
 let lastNarrativeGc = Date.now();
 let lastPlayerEventAt = 0;
@@ -802,15 +821,31 @@ function gameLoop(renderer: MapRenderer, hud: ReturnType<typeof createHud>) {
 
   const setSimSpeed = (speed: SimSpeedKey, opts: { silent?: boolean } = {}) => {
     simSpeed = speed;
+    isPaused = false;
     bridge.setSpeed(simSpeeds[speed]);
     speedSlowBtn.classList.toggle('active', speed === 'slow');
     speedFastBtn.classList.toggle('active', speed === 'fast');
     speedLudicrousBtn.classList.toggle('active', speed === 'ludicrous');
+    speedSummaryEl.textContent = SPEED_ICONS[speed];
+    pauseBtn.textContent = '⏸';
+    pauseBtn.title = 'Pause (hotkey Space)';
+    pauseBtn.setAttribute('aria-label', 'Pause');
+    pauseBtn.classList.remove('active');
     if (!opts.silent) {
       showToast(
         `Speed: ${speed === 'slow' ? 'Slow (0.5x)' : speed === 'fast' ? 'Fast (1x)' : 'Ludicrous (3x)'}`
       );
     }
+  };
+
+  const togglePause = () => {
+    isPaused = !isPaused;
+    bridge.setSpeed(isPaused ? 0 : simSpeeds[simSpeed]);
+    pauseBtn.textContent = isPaused ? '▶' : '⏸';
+    pauseBtn.title = isPaused ? 'Resume (hotkey Space)' : 'Pause (hotkey Space)';
+    pauseBtn.setAttribute('aria-label', isPaused ? 'Resume' : 'Pause');
+    pauseBtn.classList.toggle('active', isPaused);
+    showToast(isPaused ? 'Paused' : 'Resumed');
   };
 
   const updatePendingPenaltyBtn = () => {
@@ -883,6 +918,9 @@ function gameLoop(renderer: MapRenderer, hud: ReturnType<typeof createHud>) {
         return;
       case 'speedLudicrous':
         setSimSpeed('ludicrous');
+        return;
+      case 'togglePause':
+        togglePause();
         return;
       case 'toggleMinimap':
         minimap?.toggleOpen();
@@ -1012,6 +1050,7 @@ function gameLoop(renderer: MapRenderer, hud: ReturnType<typeof createHud>) {
   speedSlowBtn.addEventListener('click', () => setSimSpeed('slow'));
   speedFastBtn.addEventListener('click', () => setSimSpeed('fast'));
   speedLudicrousBtn.addEventListener('click', () => setSimSpeed('ludicrous'));
+  pauseBtn.addEventListener('click', () => togglePause());
   setSimSpeed(simSpeed, { silent: true });
   updatePendingPenaltyBtn();
 

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -181,6 +181,14 @@ for (const menu of ribbonMenus) {
     for (const other of ribbonMenus) {
       if (other !== menu) other.open = false;
     }
+    // The panel is position: fixed (see style.css), so it isn't placed by
+    // the normal flow — anchor it under this menu's own button each time.
+    const panel = menu.querySelector<HTMLElement>('.ribbon-menu-panel');
+    if (panel) {
+      const rect = menu.getBoundingClientRect();
+      panel.style.top = `${rect.bottom + 6}px`;
+      panel.style.right = `${window.innerWidth - rect.right}px`;
+    }
   });
 }
 document.addEventListener('pointerdown', (e) => {

--- a/app/src/style.css
+++ b/app/src/style.css
@@ -1832,17 +1832,31 @@ footer {
   body {
     font-size: 12px;
   }
-  #app {
-    /* The stacked HUD panels can outgrow one screen on phone widths — cap
-       the topbar's row and let it scroll internally instead of overflowing
-       the fixed-height app shell. */
-    grid-template-rows: minmax(0, 40dvh) auto minmax(0, 1fr) auto;
-  }
   .topbar {
     /* A centered flex item that overflows its box can leave the start-side
        content unreachable by scroll — align to the top instead so nothing
        above the fold gets stranded. */
     align-items: flex-start;
+    /* Stats and controls no longer fit on one line at phone widths — wrap
+       into two: logo + ribbon on the first, controls on their own second
+       line, instead of squeezing/scrolling everything into a single row. */
+    flex-wrap: wrap;
+    /* Capped on the element itself, not the #app grid row: a grid track's
+       minmax(0, <length>) gets inflated to fill leftover space during grid
+       track sizing even when content is much shorter (unlike an auto track),
+       which left a large dead gap below the ribbon's own two lines. Capping
+       height here instead means the row sizes to actual content, while this
+       still scrolls internally (overflow-y: auto, from the base rule above)
+       if the HUD ever does grow past 40dvh. */
+    max-height: 40dvh;
+  }
+  .ribbon-controls {
+    /* flex-basis: 100% forces this onto its own line in the wrapping topbar
+       above, regardless of how much room is left on the first line. */
+    flex-basis: 100%;
+    justify-content: flex-end;
+    /* Safety net if the controls still don't fit their own full-width line. */
+    overflow-x: auto;
   }
   .canvas-wrapper {
     height: 60vh;

--- a/app/src/style.css
+++ b/app/src/style.css
@@ -199,6 +199,18 @@ select {
   gap: 12px;
 }
 
+/* A chip that doubles as a button (treasury → budget screen). */
+.ribbon-chip-button {
+  cursor: pointer;
+  font-family: inherit;
+  color: var(--text);
+  text-align: left;
+}
+
+.ribbon-chip-button:hover {
+  border-color: var(--accent);
+}
+
 .ribbon-strong {
   color: #fff;
   font-weight: bold;

--- a/app/src/style.css
+++ b/app/src/style.css
@@ -57,7 +57,8 @@ select {
 
 .topbar {
   display: flex;
-  align-items: center;
+  /* Stretch so the controls cluster matches the stat chips' height. */
+  align-items: stretch;
   gap: 12px;
   min-height: 0;
   /* Safety net for any width: if the HUD ever grows taller than the
@@ -175,18 +176,27 @@ select {
   padding-bottom: 4px;
 }
 
+/* Two-line chips: related stats stack (money over power/water, month over
+   day) so the ribbon stays one chip tall but carries more per chip. */
 .ribbon-chip {
   flex: 0 0 auto;
   display: flex;
-  align-items: center;
-  gap: 10px;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
   white-space: nowrap;
   background: var(--panel);
   border: 2px solid #223557;
   border-radius: 10px;
-  padding: 6px 10px;
+  padding: 7px 10px;
   box-shadow: 0 4px 0 #0a1020;
   font-size: 12px;
+}
+
+.ribbon-line {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .ribbon-strong {
@@ -198,38 +208,37 @@ select {
   color: #9fb2d1;
 }
 
-/* Vertical RCI demand columns (SimCity-style). */
+/* Compact horizontal RCI demand meters. */
 .ribbon-rci {
-  gap: 6px;
+  gap: 4px;
+  justify-content: center;
 }
 
-.rci-col {
+.rci-row {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 2px;
+  gap: 5px;
 }
 
 .rci-track {
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  width: 10px;
-  height: 22px;
+  width: 88px;
+  height: 8px;
   background: #0c1425;
   border: 1px solid #1f2c4b;
-  border-radius: 3px;
+  border-radius: 4px;
   overflow: hidden;
 }
 
 .rci-fill {
-  width: 100%;
-  transition: height 0.2s ease;
+  display: block;
+  height: 100%;
+  transition: width 0.2s ease;
 }
 
 .rci-label {
   font-size: 9px;
   color: #9fb2d1;
+  width: 8px;
 }
 
 /* Icon buttons (speed segmented control, manual, menu summaries). */
@@ -261,6 +270,8 @@ select {
 
 /* Speed buttons live inside one chip as a segmented control. */
 .ribbon-btn-group {
+  flex-direction: row;
+  align-items: stretch;
   padding: 0;
   background: none;
   border: none;

--- a/app/src/style.css
+++ b/app/src/style.css
@@ -311,9 +311,11 @@ select {
 }
 
 .ribbon-menu-panel {
-  position: absolute;
-  top: calc(100% + 6px);
-  right: 0;
+  /* Fixed, not absolute: the topbar clips overflowing descendants (its own
+     overflow-y: auto safety net), so an absolutely-positioned panel would be
+     clipped the instant it extends past the topbar's own box. Fixed escapes
+     that entirely; JS sets top/right to track the trigger button on open. */
+  position: fixed;
   display: grid;
   gap: 6px;
   padding: 10px;
@@ -1841,14 +1843,6 @@ footer {
        content unreachable by scroll — align to the top instead so nothing
        above the fold gets stranded. */
     align-items: flex-start;
-  }
-  .logo {
-    /* Re-centre just the logo against the (tall) HUD next to it — only the
-       HUD needs flex-start, for scroll reachability. */
-    align-self: center;
-  }
-  .hud {
-    grid-template-columns: repeat(2, minmax(120px, 1fr));
   }
   .canvas-wrapper {
     height: 60vh;

--- a/app/src/style.css
+++ b/app/src/style.css
@@ -149,50 +149,160 @@ select {
   gap: 8px;
   align-items: center;
   font-weight: bold;
+  white-space: nowrap;
 }
 
-/* Single-row strip: cards keep their natural width and the row scrolls
-   horizontally when it runs out of room (same interaction as the tool
-   picker below) instead of cards painting over their neighbours. Height
-   never grows, so the play area keeps its screen real estate. */
-.hud {
+/* Status ribbon: one slim line of stat chips. The stats section scrolls
+   horizontally if it ever runs out of room; the controls cluster on the
+   right never scrolls, so speed/saves/manual/debug stay reachable. */
+.ribbon {
   flex: 1;
   display: flex;
   align-items: stretch;
-  gap: 10px;
+  gap: 8px;
   min-width: 0;
   overflow-x: auto;
   scrollbar-width: thin;
-  /* Keep the panels' drop shadow inside the scroll clip. */
-  padding-bottom: 6px;
+  /* Keep the chips' drop shadow inside the scroll clip. */
+  padding-bottom: 4px;
 }
 
-.panel {
+.ribbon-controls {
+  display: flex;
+  align-items: stretch;
+  gap: 8px;
   flex: 0 0 auto;
+  padding-bottom: 4px;
+}
+
+.ribbon-chip {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  white-space: nowrap;
   background: var(--panel);
   border: 2px solid #223557;
   border-radius: 10px;
-  padding: 8px 10px;
-  box-shadow: 0 6px 0 #0a1020;
-}
-
-.panel.panel-right {
-  margin-left: auto;
-}
-
-.panel h4 {
-  margin: 0 0 8px 0;
+  padding: 6px 10px;
+  box-shadow: 0 4px 0 #0a1020;
   font-size: 12px;
-  letter-spacing: 0.5px;
-  color: var(--accent);
 }
 
-.panel strong {
+.ribbon-strong {
   color: #fff;
+  font-weight: bold;
+}
+
+.ribbon-dim {
+  color: #9fb2d1;
+}
+
+/* Vertical RCI demand columns (SimCity-style). */
+.ribbon-rci {
+  gap: 6px;
+}
+
+.rci-col {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.rci-track {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  width: 10px;
+  height: 22px;
+  background: #0c1425;
+  border: 1px solid #1f2c4b;
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.rci-fill {
+  width: 100%;
+  transition: height 0.2s ease;
+}
+
+.rci-label {
+  font-size: 9px;
+  color: #9fb2d1;
+}
+
+/* Icon buttons (speed segmented control, manual, menu summaries). */
+.ribbon-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 34px;
+  padding: 6px 8px;
+  background: #132644;
+  border: 2px solid #223557;
+  border-radius: 10px;
+  color: var(--text);
+  font-family: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  box-shadow: 0 4px 0 #0a1020;
+  list-style: none;
+}
+
+.ribbon-btn:hover {
+  border-color: var(--accent);
+}
+
+.ribbon-btn.active {
+  border-color: var(--accent);
+  box-shadow: 0 4px 0 #0a1020, 0 0 10px rgba(123, 255, 183, 0.25);
+}
+
+/* Speed buttons live inside one chip as a segmented control. */
+.ribbon-btn-group {
+  padding: 0;
+  background: none;
+  border: none;
+  box-shadow: none;
+  gap: 4px;
+}
+
+/* Dropdowns for Saves and Debug. */
+.ribbon-menu {
+  position: relative;
+  flex: 0 0 auto;
+  display: flex;
+}
+
+.ribbon-menu > summary {
+  display: flex;
+}
+
+.ribbon-menu > summary::-webkit-details-marker {
+  display: none;
+}
+
+.ribbon-menu[open] > summary {
+  border-color: var(--accent);
+}
+
+.ribbon-menu-panel {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  display: grid;
+  gap: 6px;
+  padding: 10px;
+  background: #0f1d34;
+  border: 2px solid #223557;
+  border-radius: 12px;
+  box-shadow: 0 10px 18px rgba(0, 0, 0, 0.55);
+  min-width: max-content;
+  z-index: 3000;
 }
 
 .budget-net {
-  margin-top: 4px;
   font-weight: bold;
 }
 
@@ -814,36 +924,9 @@ select {
   font-size: 12px;
 }
 
-.demand-bar {
-  /* Fixed width — the card is content-sized, so the bar can't derive a
-     width from it. */
-  width: 140px;
-  height: 12px;
-  background: #0c1425;
-  border: 1px solid #1f2c4b;
-  border-radius: 6px;
-  overflow: hidden;
-}
-
-.demand-fill {
-  height: 100%;
-  transition: width 0.2s ease;
-}
-
 .map-stats {
   font-size: 11px;
   color: #9fb2d1;
-}
-
-.panel-hint {
-  margin-top: 6px;
-  color: #9fb2d1;
-  font-size: 11px;
-}
-
-.controls-row {
-  display: flex;
-  gap: 8px;
 }
 
 button.primary {
@@ -977,24 +1060,6 @@ button.secondary.active {
 
 .tool-hints.subtle {
   opacity: 0.9;
-}
-
-.demand-rows {
-  display: grid;
-  gap: 6px;
-  margin-top: 4px;
-}
-
-.demand-row {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  align-items: center;
-  gap: 6px;
-}
-
-.demand-label {
-  font-size: 11px;
-  color: #9fb2d1;
 }
 
 footer {
@@ -1725,6 +1790,21 @@ footer {
 .hotkey-row-header {
   color: #9fb2d1;
   font-size: 12px;
+}
+
+@media (max-width: 1180px) {
+  .ribbon-chip {
+    font-size: 10px;
+    gap: 6px;
+    padding: 5px 8px;
+  }
+  .ribbon,
+  .ribbon-controls {
+    gap: 6px;
+  }
+  .logo span {
+    display: none;
+  }
 }
 
 @media (max-width: 900px) {

--- a/app/src/style.css
+++ b/app/src/style.css
@@ -40,6 +40,10 @@ select {
 
 #app {
   display: grid;
+  /* minmax(0, 1fr) column: an auto column would size to the topbar's
+     max-content (all HUD cards in a row) and push the whole page wider
+     than the window instead of letting the HUD strip scroll. */
+  grid-template-columns: minmax(0, 1fr);
   grid-template-rows: auto auto minmax(0, 1fr) auto;
   height: 100vh;
   height: 100dvh;
@@ -147,23 +151,33 @@ select {
   font-weight: bold;
 }
 
+/* Single-row strip: cards keep their natural width and the row scrolls
+   horizontally when it runs out of room (same interaction as the tool
+   picker below) instead of cards painting over their neighbours. Height
+   never grows, so the play area keeps its screen real estate. */
 .hud {
   flex: 1;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  display: flex;
+  align-items: stretch;
   gap: 10px;
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  /* Keep the panels' drop shadow inside the scroll clip. */
+  padding-bottom: 6px;
 }
 
 .panel {
+  flex: 0 0 auto;
   background: var(--panel);
   border: 2px solid #223557;
   border-radius: 10px;
-  padding: 10px;
+  padding: 8px 10px;
   box-shadow: 0 6px 0 #0a1020;
 }
 
 .panel.panel-right {
-  justify-self: end;
+  margin-left: auto;
 }
 
 .panel h4 {
@@ -676,6 +690,9 @@ select {
   position: absolute;
   right: calc(12px + env(safe-area-inset-right, 0px));
   bottom: calc(12px + env(safe-area-inset-bottom, 0px));
+  /* Never grow past the canvas area up beneath the toolbar. */
+  max-height: calc(100% - 24px);
+  overflow-y: auto;
   background: rgba(12, 20, 40, 0.9);
   border: 2px solid #223557;
   border-radius: 12px;
@@ -798,6 +815,9 @@ select {
 }
 
 .demand-bar {
+  /* Fixed width — the card is content-sized, so the bar can't derive a
+     width from it. */
+  width: 140px;
   height: 12px;
   background: #0c1425;
   border: 1px solid #1f2c4b;

--- a/app/src/style.css
+++ b/app/src/style.css
@@ -358,10 +358,6 @@ select {
   flex: 1;
 }
 
-.budget-button {
-  margin-left: auto;
-}
-
 .toolbar-sub {
   position: fixed;
   left: 0;

--- a/app/src/style.css
+++ b/app/src/style.css
@@ -280,17 +280,6 @@ select {
   box-shadow: 0 4px 0 #0a1020, 0 0 10px rgba(123, 255, 183, 0.25);
 }
 
-/* Speed buttons live inside one chip as a segmented control. */
-.ribbon-btn-group {
-  flex-direction: row;
-  align-items: stretch;
-  padding: 0;
-  background: none;
-  border: none;
-  box-shadow: none;
-  gap: 4px;
-}
-
 /* Dropdowns for Saves and Debug. */
 .ribbon-menu {
   position: relative;

--- a/app/src/ui/hotkeys.ts
+++ b/app/src/ui/hotkeys.ts
@@ -24,6 +24,7 @@ export type HotkeyAction =
   | 'speedSlow'
   | 'speedFast'
   | 'speedLudicrous'
+  | 'togglePause'
   | 'toggleMinimap';
 
 export type HotkeyBindings = Record<HotkeyAction, string[]>;
@@ -54,6 +55,7 @@ export const defaultHotkeys: HotkeyBindings = {
   speedSlow: ['Digit1'],
   speedFast: ['Digit2'],
   speedLudicrous: ['Digit3'],
+  togglePause: ['Space'],
   toggleMinimap: ['KeyM']
 };
 

--- a/app/src/ui/hud.ts
+++ b/app/src/ui/hud.ts
@@ -69,10 +69,9 @@ export function createHud(elements: HudElements) {
     elements.budgetNetEl.className = `budget-net ${netClass}`;
     elements.powerEl.textContent = `⚡ ${state.utilities.power.toFixed(1)} MW`;
     elements.waterEl.textContent = `💧 ${state.utilities.water.toFixed(1)} m³`;
-    // Vertical RCI demand columns — fill rises from the bottom of the track.
-    elements.resBar.style.height = `${state.demand.residential}%`;
-    elements.comBar.style.height = `${state.demand.commercial}%`;
-    elements.indBar.style.height = `${state.demand.industrial}%`;
+    elements.resBar.style.width = `${state.demand.residential}%`;
+    elements.comBar.style.width = `${state.demand.commercial}%`;
+    elements.indBar.style.width = `${state.demand.industrial}%`;
     const population = Math.floor(state.population).toLocaleString();
     const jobs = Math.floor(state.jobs).toLocaleString();
     elements.popEl.textContent = `👥 ${population}`;

--- a/app/src/ui/hud.ts
+++ b/app/src/ui/hud.ts
@@ -1,3 +1,8 @@
+// hud.ts — live top-bar ribbon values and the tool/tile info overlay.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
 import { BuildingStatus } from '../game/buildings/state';
 import { getBuildingTemplate } from '../game/buildings/templates';
 import { GameState, getTile } from '../game/gameState';
@@ -64,14 +69,19 @@ export function createHud(elements: HudElements) {
     elements.budgetNetEl.className = `budget-net ${netClass}`;
     elements.powerEl.textContent = `⚡ ${state.utilities.power.toFixed(1)} MW`;
     elements.waterEl.textContent = `💧 ${state.utilities.water.toFixed(1)} m³`;
-    elements.resBar.style.width = `${state.demand.residential}%`;
-    elements.comBar.style.width = `${state.demand.commercial}%`;
-    elements.indBar.style.width = `${state.demand.industrial}%`;
-    elements.popEl.textContent = `Population ${Math.floor(state.population)}`;
-    elements.jobsEl.textContent = `Jobs ${Math.floor(state.jobs)}`;
+    // Vertical RCI demand columns — fill rises from the bottom of the track.
+    elements.resBar.style.height = `${state.demand.residential}%`;
+    elements.comBar.style.height = `${state.demand.commercial}%`;
+    elements.indBar.style.height = `${state.demand.industrial}%`;
+    const population = Math.floor(state.population).toLocaleString();
+    const jobs = Math.floor(state.jobs).toLocaleString();
+    elements.popEl.textContent = `👥 ${population}`;
+    elements.popEl.title = `Population ${population}`;
+    elements.jobsEl.textContent = `💼 ${jobs}`;
+    elements.jobsEl.title = `Jobs ${jobs}`;
     const calendar = getCalendarPosition(state.day);
     elements.monthEl.textContent = `Month ${calendar.month}`;
-    elements.dayEl.textContent = `Day ${calendar.dayOfMonth} of ${DAYS_PER_MONTH}`;
+    elements.dayEl.textContent = `Day ${calendar.dayOfMonth}/${DAYS_PER_MONTH}`;
   };
 
   const renderOverlays = (state: GameState, selected: Position | null, activeTool: Tool) => {

--- a/app/src/ui/settingsModal.ts
+++ b/app/src/ui/settingsModal.ts
@@ -50,6 +50,7 @@ const HOTKEY_LABELS: Record<HotkeyAction, string> = {
   speedSlow: 'Speed: Slow',
   speedFast: 'Speed: Fast',
   speedLudicrous: 'Speed: Ludicrous',
+  togglePause: 'Pause / resume',
   toggleMinimap: 'Toggle minimap'
 };
 

--- a/app/src/ui/toolbar.ts
+++ b/app/src/ui/toolbar.ts
@@ -1,3 +1,8 @@
+// toolbar.ts — tool palette, submenus, and the radio widget.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
 import { Tool } from '../game/toolTypes';
 import { getToolHotkey, primaryLabelOverrides, toolLabels } from './toolInfo';
 import { initRadioWidget, type RadioWidget } from './radio';
@@ -15,9 +20,6 @@ const waterOptions: Tool[] = [Tool.WaterPipe, Tool.WaterPump, Tool.WaterTower];
 const educationOptions: Tool[] = [Tool.ElementarySchool, Tool.HighSchool];
 
 interface ToolbarOptions {
-  onOpenBudget?: () => void;
-  onOpenBylaws?: () => void;
-  onOpenSettings?: () => void;
   radioVolume?: number;
   radioStationId?: string;
   onRadioStationChange?: (stationId: string) => void;
@@ -35,7 +37,7 @@ export function initToolbar(
   options: ToolbarOptions = {}
 ): ToolbarControllers {
   toolbar.innerHTML = '';
-  const { onOpenBudget, onOpenBylaws, onOpenSettings, radioVolume, radioStationId, onRadioStationChange } = options;
+  const { radioVolume, radioStationId, onRadioStationChange } = options;
 
   const primaryRow = document.createElement('div');
   primaryRow.className = 'toolbar-row';
@@ -104,51 +106,6 @@ export function initToolbar(
   radioGroup.appendChild(radioHost);
   radioGroup.appendChild(radioStationHost);
   trailingCluster.appendChild(radioGroup);
-
-  const adminGroup = document.createElement('div');
-  adminGroup.className = 'toolbar-group toolbar-group-admin';
-  let hasAdminButtons = false;
-
-  if (onOpenSettings) {
-    const settingsBtn = document.createElement('button');
-    settingsBtn.type = 'button';
-    settingsBtn.className = 'tool-button';
-    settingsBtn.textContent = '⚙️ Settings';
-    settingsBtn.title = 'Open settings';
-    settingsBtn.addEventListener('click', () => onOpenSettings());
-    adminGroup.appendChild(settingsBtn);
-    hasAdminButtons = true;
-  }
-
-  if (onOpenBylaws) {
-    const bylawsBtn = document.createElement('button');
-    bylawsBtn.type = 'button';
-    bylawsBtn.id = 'bylaws-modal-btn';
-    bylawsBtn.className = 'tool-button';
-    bylawsBtn.textContent = '📜 Bylaws';
-    bylawsBtn.title = 'Open bylaws screen';
-    bylawsBtn.addEventListener('click', () => onOpenBylaws());
-    adminGroup.appendChild(bylawsBtn);
-    hasAdminButtons = true;
-  }
-
-  if (onOpenBudget) {
-    const budgetBtn = document.createElement('button');
-    budgetBtn.type = 'button';
-    budgetBtn.id = 'budget-modal-btn';
-    budgetBtn.className = 'tool-button budget-button';
-    budgetBtn.textContent = '📊 Budget';
-    budgetBtn.title = 'Open budget screen';
-    budgetBtn.addEventListener('click', () => onOpenBudget());
-    adminGroup.appendChild(budgetBtn);
-    hasAdminButtons = true;
-  }
-
-  if (hasAdminButtons) {
-    adminGroup.setAttribute('role', 'group');
-    adminGroup.setAttribute('aria-label', 'City admin tools');
-    trailingCluster.appendChild(adminGroup);
-  }
 
   const createSubButton = (row: HTMLElement, key: Tool, labelOverride?: string) => {
     const button = document.createElement('button');

--- a/app/src/ui/toolbar.ts
+++ b/app/src/ui/toolbar.ts
@@ -203,9 +203,15 @@ export function initToolbar(
   const positionStationMenu = () => {
     const rect = stationButton.getBoundingClientRect();
     const margin = 8;
-    stationMenu.style.left = `${Math.round(rect.left + window.scrollX)}px`;
+    const menuWidth = Math.max(rect.width, 220);
+    // Anchor to the button's left edge, but never let the menu run past the
+    // right edge of the viewport — the radio widget sits at the trailing end
+    // of the toolbar, close enough to the edge that it otherwise would.
+    const maxLeft = window.innerWidth - menuWidth - margin;
+    const left = Math.min(rect.left, Math.max(margin, maxLeft));
+    stationMenu.style.left = `${Math.round(left + window.scrollX)}px`;
     stationMenu.style.top = `${Math.round(rect.bottom + margin + window.scrollY)}px`;
-    stationMenu.style.minWidth = `${Math.max(rect.width, 220)}px`;
+    stationMenu.style.minWidth = `${menuWidth}px`;
   };
 
   const openStationMenu = () => {

--- a/docs/game-parameters.md
+++ b/docs/game-parameters.md
@@ -105,6 +105,7 @@
 - Zoning & Amenities: Residential `Z`, Commercial `X`, Industrial `C`, Park `K`.
 - Bulldoze: `B`.
 - Simulation Speed: `1` Slow (0.5x), `2` Fast (1x), `3` Ludicrous (3x).
+- Pause: `Space` toggles pause/resume; resumes at the last-selected speed.
 
 ### Settings Backlog (Input)
 - A settings modal now exists (gear button in the toolbar) with the over-zoning penalty toggle, minimap controls, pan inversion/pan speed presets, Shift+scroll-to-pan, zoom sensitivity, radio volume, and a Gemini sprite toggle (off by default). Edge scroll, hotkey remapping UX, higher-contrast/reduced-motion, and SFX are stubbed but not wired yet.


### PR DESCRIPTION
## Summary

This branch was originally written on another machine on 2026-07-06, before this session's mobile-web migration work existed, and never got pushed or opened as a PR. It's the first of a chain (`ui/hud-top-bar-cleanup` → `feat/budget-policy` → `feat/wilderness-score`) recovered and rebased onto current `main` in this session, plus follow-up work landed on top to fix what the rebase and further review surfaced.

- **Replaces the HUD card row with a compact one-line status ribbon** — money/power/water, RCI demand, calendar, and population/jobs each become a `ribbon-chip`, with the treasury chip doubling as a button that opens the budget screen. Budget, Bylaws, and Settings are promoted from buried menus to the ribbon itself.
- **Speed control redesign**: the three always-visible Slow/Fast/Ludicrous buttons become a single dropdown (icon reflects the active tier — 🐢/🐇/⚡; opening it lists plain-language options), plus a separate ⏸/▶ Pause toggle (click or the Space hotkey) — pausing is a different action from choosing a tier, so it isn't folded into tier selection. Picking a tier while paused resumes at that tier.
- **Fixes uncovered by the rebase** (combining this branch's history with three weeks of independently-evolved mobile-web work on `main`):
  - Stale `.logo`/`.hud` compact-mode CSS, written for the old card grid this branch replaces, was detaching the logo and (via dead `.hud` selectors) doing nothing.
  - All three ribbon dropdowns (Saves, Debug, the new Speed one) were being invisibly clipped by the topbar's `overflow-y: auto` safety net, since their panels were `position: absolute` and extended past the topbar's own box. Switched to `position: fixed`, computed relative to the viewport.
  - The topbar didn't fit on a phone-width screen — reflows to two lines (stats, then controls) instead of squeezing/scrolling everything into one row.
  - A CSS Grid quirk: `#app`'s compact-mode row used `minmax(0, 40dvh)` to cap the topbar's height, but a grid track with a definite (non-auto) max gets inflated to fill leftover space during track sizing, unlike the auto-sized rows around it — so the topbar stretched to a full 337px against ~130px of real content, leaving a dead gap above the canvas. Capping `max-height` on `.topbar` itself instead sizes the grid row to actual content.
  - The radio station menu (pre-existing, unrelated to the ribbon work) could render past the right edge of the viewport, since it always anchored to its button's left edge with a fixed minimum width — clamped it to stay on-screen.

### User-facing changes

The HUD is now a slim horizontal ribbon instead of a grid of cards. Speed selection is a dropdown instead of three buttons, with a new Pause button/hotkey. On phone-width screens, the topbar wraps to two lines and no longer wastes vertical space above the canvas. The radio station picker no longer renders off-screen.

### Known limitations

Lifting a two-finger touch gesture mid-pinch/pan (from earlier merged mobile-web work) is unrelated and unaffected by this PR. The compact-mode reflow here hasn't been tried on a real device yet — see test plan.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run test` — 138/138 non-`jsdom` tests pass locally (pre-existing machine-local jsdom quirk, unrelated — see #92/#93/#96/#97/#98 history; CI is authoritative there)
- [x] Verified with Playwright MCP against the dev server at both a desktop width (1280px) and a true phone width (390px):
  - Desktop: ribbon renders in one line as before, no scrolling needed, dropdowns (Saves/Debug/Speed) all render fully visible below the topbar.
  - Phone width: topbar reflows to two lines (stats, then controls), sized to ~130px instead of stretching to a 337px dead-space cap; both lines' overflow-x scrolls remain reachable.
  - Pause: toggling actually stops/resumes simulation ticks (checked via the `city-sim` MCP bridge's live tick counter, not just the button's visual state), and Space triggers it.
  - Radio station menu: confirmed it previously rendered ~188px past the viewport's right edge, and now clamps fully on-screen.
- [ ] Real on-device testing not yet done — worth trying on your phone: the two-line topbar reflow at your actual screen width, the pause/speed dropdown, and the radio station picker.
