### PR TITLE
Compact toolbar shell (M2-1) and phone-landscape detection fix

### DIFF
--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -36,7 +36,7 @@ import { bindPersistenceControls, showManualModal, showToast } from './ui/dialog
 import { initDebugOverlay } from './ui/debugOverlay';
 import { initHotkeys, defaultHotkeys, type HotkeyAction, type HotkeyController } from './ui/hotkeys';
 import { initDeviceMode } from './ui/deviceMode';
-import { initToolbar, updateToolbar } from './ui/toolbar';
+import { initToolbar, updateToolbar, type ToolbarControllers } from './ui/toolbar';
 import { createNotificationCenter } from './ui/notifications';
 import { initMinimap } from './ui/minimap';
 import { initBudgetModal } from './ui/budgetModal';
@@ -230,6 +230,14 @@ speedMenu?.querySelectorAll('button').forEach((btn) => {
 });
 
 const syncToolbarHeights = () => {
+  // The compact shell has no top-anchored row at all — everything lives in a
+  // position: fixed dock/sheet at the bottom — so #viewport shouldn't reserve
+  // any top padding for it the way it does for the full desktop toolbar row.
+  if (toolbar.dataset.layoutMode === 'compact') {
+    viewport.style.setProperty('--toolbar-base-height', '0px');
+    viewport.style.setProperty('--toolbar-visible-height', '0px');
+    return;
+  }
   const rect = toolbar.getBoundingClientRect();
   const styles = getComputedStyle(toolbar);
   const paddingTop = parseFloat(styles.paddingTop) || 0;
@@ -757,17 +765,32 @@ function gameLoop(renderer: MapRenderer, hud: ReturnType<typeof createHud>) {
   ]);
   console.log('Palette texture loaded', paletteTexture);
 
-  const renderer = new MapRenderer(wrapper, camera, TILE_SIZE, palette, tileTextures);
-  await renderer.init(wrapper);
   // `resize` alone can lag or coalesce oddly around a mobile browser's own
   // chrome/toolbar animation during rotation — layoutMode's matchMedia-driven
   // change event is a more direct signal for the breakpoint actually flipping.
-  const deviceMode = initDeviceMode({ onChange: syncToolbarHeights });
+  // Reassigned once the toolbar is set up below, so a live layoutMode flip
+  // (rotation across the compact/full breakpoint) can rebuild its shell too.
+  let handleDeviceModeChange = () => syncToolbarHeights();
+  const deviceMode = initDeviceMode({ onChange: () => handleDeviceModeChange() });
   if (deviceMode.getMode().layoutMode === 'compact') {
     // Deeper default zoom so tiles are a comfortable touch target on a small
     // screen, rather than starting at the same density as a full desktop view.
     camera.scale = COMPACT_DEFAULT_ZOOM;
+    // Set this before the renderer first measures canvas-wrapper below,
+    // rather than leaving it to syncToolbarHeights() afterward — Pixi's
+    // resizeTo does resize its internal screen/canvas dimensions correctly
+    // in response to a later CSS-only size change (confirmed), but the
+    // canvas doesn't actually draw into the newly-available area regardless,
+    // for reasons that didn't resolve with a manual app.resize() call either.
+    // Simplest fix: never let the size change out from under it in the first
+    // place. The compact shell has no top-anchored content, so this is 0
+    // unconditionally, unlike the full shell's real .toolbar-row height.
+    viewport.style.setProperty('--toolbar-base-height', '0px');
+    viewport.style.setProperty('--toolbar-visible-height', '0px');
   }
+
+  const renderer = new MapRenderer(wrapper, camera, TILE_SIZE, palette, tileTextures);
+  await renderer.init(wrapper);
   centerCamera(state, wrapper, TILE_SIZE, camera);
 
   const hud = createHud({
@@ -1006,21 +1029,51 @@ function gameLoop(renderer: MapRenderer, hud: ReturnType<typeof createHud>) {
   bylawsModalBtn.addEventListener('click', () => bylawsModal.open());
   settingsBtn.addEventListener('click', () => settingsModal?.open());
 
-  const toolbarControllers = initToolbar(
-    toolbar,
-    (nextTool) => {
-      setTool(nextTool);
-    },
-    activeTool,
-    {
-      radioVolume: state.settings.audio.radioVolume
+  let toolbarControllers: ToolbarControllers;
+  const setupToolbar = () => {
+    const previousStationId = toolbarControllers?.getActiveStationId();
+    toolbarControllers = initToolbar(
+      toolbar,
+      (nextTool) => {
+        setTool(nextTool);
+      },
+      activeTool,
+      {
+        layoutMode: deviceMode.getMode().layoutMode,
+        radioVolume: state.settings.audio.radioVolume,
+        radioStationId: previousStationId
+      }
+    );
+    radioController = toolbarControllers.radio;
+  };
+  setupToolbar();
+  handleDeviceModeChange = () => {
+    // Rebuild the toolbar shell first (if the mode actually flipped) so
+    // syncToolbarHeights below reads the freshly-updated layoutMode instead
+    // of the stale one — otherwise --toolbar-base-height stays wrong until
+    // some unrelated resize/rAF happens to recompute it.
+    if (toolbar.dataset.layoutMode !== deviceMode.getMode().layoutMode) {
+      setupToolbar();
     }
-  );
-  radioController = toolbarControllers.radio;
+    syncToolbarHeights();
+    // See the matching comment below: force Pixi to pick up canvas-wrapper's
+    // new size, since `resizeTo`'s own auto-resize doesn't reliably do so
+    // within the same tick as the CSS change that caused it.
+    renderer.app.resize();
+  };
   applySettings(state.settings);
   syncToolbarHeights();
   window.addEventListener('resize', syncToolbarHeights);
   requestAnimationFrame(syncToolbarHeights);
+  // syncToolbarHeights() may have just changed --toolbar-base-height from
+  // its CSS fallback to the real computed full-shell .toolbar-row height.
+  // Pixi's `resizeTo` is known not to reliably respond to a layout-only
+  // resize like this (https://github.com/pixijs/pixijs/issues/11427) — only
+  // to an actual window resize event — so nudge it explicitly. (Compact mode
+  // avoids ever needing this for the initial load by setting the height
+  // before the renderer first initializes, above; this remains a best-effort
+  // catch-all for the full shell and any other future case.)
+  renderer.app.resize();
 
   bindPersistenceControls({
     saveBtn,

--- a/app/src/style.css
+++ b/app/src/style.css
@@ -2252,10 +2252,11 @@ footer {
     flex: 1 1 200px;
   }
   .ribbon-controls {
-    justify-content: flex-end;
     /* Deliberately no flex-basis: 100% here — let flex-wrap decide: share
        line one with the ribbon when there's room (phone landscape), only
-       drop to its own second line when there truly isn't (phone portrait). */
+       drop to its own second line when there truly isn't (phone portrait).
+       Sized to its own content (not stretched), so it naturally sits at the
+       start of that line rather than needing an explicit left-align. */
     flex: 0 0 auto;
     /* Safety net if the controls still don't fit their own full-width line. */
     overflow-x: auto;

--- a/app/src/style.css
+++ b/app/src/style.css
@@ -2237,11 +2237,26 @@ footer {
        if the HUD ever does grow past 40dvh. */
     max-height: 40dvh;
   }
+  .logo {
+    /* The ribbon chips it shares a line with are much taller (two stacked
+       lines of text); flex-start alignment above otherwise leaves the logo
+       stranded at the top of that row instead of centred against it. */
+    align-self: center;
+  }
+  .ribbon {
+    /* A real basis (rather than the base rule's flex: 1, i.e. basis 0%) so
+       flex-wrap below has an actual size to compare against the controls'
+       width — with basis 0% the ribbon always claims 100% of line one first,
+       forcing the controls to wrap even when a wide-but-short viewport
+       (phone landscape) has plenty of room for both on one line. */
+    flex: 1 1 200px;
+  }
   .ribbon-controls {
-    /* flex-basis: 100% forces this onto its own line in the wrapping topbar
-       above, regardless of how much room is left on the first line. */
-    flex-basis: 100%;
     justify-content: flex-end;
+    /* Deliberately no flex-basis: 100% here — let flex-wrap decide: share
+       line one with the ribbon when there's room (phone landscape), only
+       drop to its own second line when there truly isn't (phone portrait). */
+    flex: 0 0 auto;
     /* Safety net if the controls still don't fit their own full-width line. */
     overflow-x: auto;
   }

--- a/app/src/style.css
+++ b/app/src/style.css
@@ -2209,7 +2209,13 @@ footer {
   }
 }
 
-@media (max-width: 900px) {
+/* Matches deviceMode.ts's DEFAULT_COMPACT_BREAKPOINT_PX/
+   DEFAULT_COMPACT_HEIGHT_BREAKPOINT_PX — keep the two in sync, or CSS layout
+   and the JS-derived layoutMode can disagree. Comma = OR: a phone in
+   landscape is comfortably wider than 900px but short enough that a full
+   desktop shell leaves little to no canvas, so compact triggers on either
+   dimension being small, not just width. */
+@media (max-width: 900px), (max-height: 500px) {
   body {
     font-size: 12px;
   }

--- a/app/src/style.css
+++ b/app/src/style.css
@@ -361,6 +361,132 @@ select {
   flex: 1;
 }
 
+/* Compact toolbar shell (layoutMode: 'compact') — a thumb-zone current-tool
+   button that opens a bottom sheet, instead of the full desktop row. All of
+   it is position: fixed against the viewport, not `.toolbar`'s own
+   top-anchored box, since it belongs at the bottom of the screen. */
+.toolbar-compact-dock {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  padding-bottom: calc(12px + env(safe-area-inset-bottom, 0px));
+  padding-left: calc(16px + env(safe-area-inset-left, 0px));
+  padding-right: calc(16px + env(safe-area-inset-right, 0px));
+  z-index: 3000;
+  /* Let clicks in the empty middle area pass through to the canvas. */
+  pointer-events: none;
+}
+
+.toolbar-compact-dock > * {
+  pointer-events: auto;
+}
+
+.toolbar-current-tool-btn {
+  background: #132644;
+  border: 2px solid var(--accent);
+  border-radius: 999px;
+  color: var(--text);
+  padding: 14px 22px;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: bold;
+  cursor: pointer;
+  box-shadow: 0 4px 0 #0a1020, 0 0 12px rgba(123, 255, 183, 0.25);
+}
+
+.tool-sheet-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(4, 8, 16, 0.6);
+  z-index: 3500;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+.tool-sheet-backdrop.open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.tool-sheet {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  max-height: 60vh;
+  max-height: 60dvh;
+  overflow-y: auto;
+  background: #0d1a2f;
+  border-top: 2px solid #1f2c4b;
+  border-radius: 16px 16px 0 0;
+  padding: 16px;
+  padding-bottom: calc(16px + env(safe-area-inset-bottom, 0px));
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  z-index: 3501;
+  transform: translateY(100%);
+  transition: transform 0.25s ease;
+}
+
+.tool-sheet.open {
+  transform: translateY(0);
+}
+
+.tool-sheet-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid #1f2c4b;
+}
+
+.tool-sheet-group:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.tool-sheet-button {
+  background: #132644;
+  border: 2px solid #223557;
+  border-radius: 12px;
+  color: var(--text);
+  padding: 10px 14px;
+  min-width: 64px;
+  min-height: 48px;
+  font-family: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  box-shadow: 0 4px 0 #0a1020;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+/* The full radio widget (flex-basis 360px, marquee + cover art) is sized for
+   the spacious desktop trailing cluster and alone would overflow the whole
+   compact dock. Collapse it to just its icon buttons + station picker here;
+   hover/focus's existing popover still surfaces the track/cover details. */
+.toolbar-compact-dock .radio-widget {
+  flex: 0 0 auto;
+}
+
+.toolbar-compact-dock .radio-marquee-viewport,
+.toolbar-compact-dock .radio-cover {
+  display: none;
+}
+
+.tool-sheet-button.active {
+  border-color: var(--accent);
+}
+
 .toolbar-sub {
   position: fixed;
   left: 0;

--- a/app/src/style.css
+++ b/app/src/style.css
@@ -487,6 +487,8 @@ select {
   border-color: var(--accent);
 }
 
+}
+
 .toolbar-sub {
   position: fixed;
   left: 0;

--- a/app/src/ui/deviceMode.test.ts
+++ b/app/src/ui/deviceMode.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { DEFAULT_COMPACT_BREAKPOINT_PX, initDeviceMode } from './deviceMode';
+import { DEFAULT_COMPACT_BREAKPOINT_PX, DEFAULT_COMPACT_HEIGHT_BREAKPOINT_PX, initDeviceMode } from './deviceMode';
 
 // A minimal MediaQueryList stand-in with a `set` helper to fire the same
 // 'change' event a real browser fires when the query's match state flips
@@ -31,6 +31,7 @@ interface FakeWindowOptions {
   compact: boolean;
   maxTouchPoints?: number;
   innerWidth?: number;
+  innerHeight?: number;
   matchMediaSupported?: boolean;
 }
 
@@ -46,6 +47,7 @@ function fakeWindow(options: FakeWindowOptions) {
   const win = {
     navigator: { maxTouchPoints: options.maxTouchPoints ?? 0 },
     innerWidth: options.innerWidth ?? 1200,
+    innerHeight: options.innerHeight ?? 800,
     matchMedia,
     addEventListener: (type: string, listener: () => void) => {
       if (type === 'resize') resizeListeners.add(listener);
@@ -146,6 +148,28 @@ describe('initDeviceMode — fallback without matchMedia', () => {
     expect(initDeviceMode({ window: win }).getMode().layoutMode).toBe('compact');
   });
 
+  it('derives layoutMode from innerHeight against the height breakpoint, even when wide', () => {
+    const { win } = fakeWindow({
+      pointerCoarse: false,
+      compact: false,
+      matchMediaSupported: false,
+      innerWidth: 1200,
+      innerHeight: DEFAULT_COMPACT_HEIGHT_BREAKPOINT_PX
+    });
+    expect(initDeviceMode({ window: win }).getMode().layoutMode).toBe('compact');
+  });
+
+  it('treats a phone in landscape (wide but short) as compact', () => {
+    const { win } = fakeWindow({
+      pointerCoarse: true,
+      compact: false,
+      matchMediaSupported: false,
+      innerWidth: 926,
+      innerHeight: 428
+    });
+    expect(initDeviceMode({ window: win }).getMode().layoutMode).toBe('compact');
+  });
+
   it('re-evaluates layoutMode on resize', () => {
     const { win, fireResize } = fakeWindow({
       pointerCoarse: false,
@@ -167,5 +191,16 @@ describe('initDeviceMode — custom breakpoint', () => {
   it('honours a caller-supplied compactBreakpointPx', () => {
     const { win } = fakeWindow({ pointerCoarse: false, compact: false, matchMediaSupported: false, innerWidth: 500 });
     expect(initDeviceMode({ window: win, compactBreakpointPx: 400 }).getMode().layoutMode).toBe('full');
+  });
+
+  it('honours a caller-supplied compactHeightBreakpointPx', () => {
+    const { win } = fakeWindow({
+      pointerCoarse: false,
+      compact: false,
+      matchMediaSupported: false,
+      innerWidth: 1200,
+      innerHeight: 450
+    });
+    expect(initDeviceMode({ window: win, compactHeightBreakpointPx: 400 }).getMode().layoutMode).toBe('full');
   });
 });

--- a/app/src/ui/deviceMode.ts
+++ b/app/src/ui/deviceMode.ts
@@ -1,5 +1,5 @@
 // Derives touch/mouse input mode and compact/full layout mode from pointer
-// capability and viewport width, re-evaluating live as either changes.
+// capability and viewport width/height, re-evaluating live as any change.
 //
 // (c) Copyright 2026 Liminal HQ, Scott Morris
 // SPDX-License-Identifier: MIT
@@ -12,13 +12,19 @@ export interface DeviceMode {
   layoutMode: LayoutMode;
 }
 
-// Matches the `@media (max-width: 900px)` breakpoint in style.css — keep the
-// two in sync, or layout and JS-derived mode can disagree.
+// Matches the `@media (max-width: 900px), (max-height: 500px)` breakpoint in
+// style.css — keep the two in sync, or layout and JS-derived mode can
+// disagree. Width alone misses a phone in landscape: it's comfortably wider
+// than 900px on most devices, but short enough that a full desktop shell
+// (topbar + toolbar both sized for a tall viewport) leaves little to no
+// canvas — so compact triggers on EITHER dimension being small, not just width.
 export const DEFAULT_COMPACT_BREAKPOINT_PX = 900;
+export const DEFAULT_COMPACT_HEIGHT_BREAKPOINT_PX = 500;
 
 export interface DeviceModeOptions {
   window?: Window;
   compactBreakpointPx?: number;
+  compactHeightBreakpointPx?: number;
   onChange?: (mode: DeviceMode) => void;
 }
 
@@ -41,30 +47,33 @@ function deriveInputMode(win: Window, pointerQuery: MediaQueryList | undefined):
 function deriveLayoutMode(
   win: Window,
   layoutQuery: MediaQueryList | undefined,
-  breakpointPx: number
+  breakpointPx: number,
+  heightBreakpointPx: number
 ): LayoutMode {
   if (layoutQuery) {
     return layoutQuery.matches ? 'compact' : 'full';
   }
-  return win.innerWidth <= breakpointPx ? 'compact' : 'full';
+  return win.innerWidth <= breakpointPx || win.innerHeight <= heightBreakpointPx ? 'compact' : 'full';
 }
 
 export function initDeviceMode(options: DeviceModeOptions = {}): DeviceModeController {
   const win = options.window ?? window;
   const breakpointPx = options.compactBreakpointPx ?? DEFAULT_COMPACT_BREAKPOINT_PX;
+  const heightBreakpointPx = options.compactHeightBreakpointPx ?? DEFAULT_COMPACT_HEIGHT_BREAKPOINT_PX;
 
   const pointerQuery = win.matchMedia?.('(pointer: coarse)');
-  const layoutQuery = win.matchMedia?.(`(max-width: ${breakpointPx}px)`);
+  // Comma = OR in a media query list, matching deriveLayoutMode's fallback.
+  const layoutQuery = win.matchMedia?.(`(max-width: ${breakpointPx}px), (max-height: ${heightBreakpointPx}px)`);
 
   let mode: DeviceMode = {
     inputMode: deriveInputMode(win, pointerQuery),
-    layoutMode: deriveLayoutMode(win, layoutQuery, breakpointPx)
+    layoutMode: deriveLayoutMode(win, layoutQuery, breakpointPx, heightBreakpointPx)
   };
 
   const reevaluate = () => {
     const next: DeviceMode = {
       inputMode: deriveInputMode(win, pointerQuery),
-      layoutMode: deriveLayoutMode(win, layoutQuery, breakpointPx)
+      layoutMode: deriveLayoutMode(win, layoutQuery, breakpointPx, heightBreakpointPx)
     };
     if (next.inputMode === mode.inputMode && next.layoutMode === mode.layoutMode) {
       return;

--- a/app/src/ui/toolbar.ts
+++ b/app/src/ui/toolbar.ts
@@ -39,6 +39,12 @@ interface ToolbarOptions {
   onRadioStationChange?: (stationId: string) => void;
 }
 
+// initToolbar can now be called more than once per page load (a live
+// layoutMode flip re-runs it to rebuild the shell) — it always adds its
+// document/window-level listeners fresh, so without this they'd accumulate
+// one extra (harmless but leaked) copy per flip for the life of the page.
+const toolbarCleanups = new WeakMap<HTMLElement, () => void>();
+
 export interface ToolbarControllers {
   radio: RadioWidget;
   setRadioStation: (stationId?: string, opts?: { triggerChange?: boolean }) => void;
@@ -51,6 +57,7 @@ export function initToolbar(
   initial: Tool,
   options: ToolbarOptions = {}
 ): ToolbarControllers {
+  toolbarCleanups.get(toolbar)?.();
   toolbar.innerHTML = '';
   const { layoutMode = 'full', radioVolume, radioStationId, onRadioStationChange } = options;
   toolbar.dataset.layoutMode = layoutMode;
@@ -81,6 +88,7 @@ export function initToolbar(
 
   let radioHost: HTMLElement;
   let radioStationHost: HTMLElement;
+  let closeSheetOnEscape: ((e: KeyboardEvent) => void) | null = null;
 
   if (layoutMode === 'compact') {
     // --- Compact shell: a thumb-zone current-tool button that opens a
@@ -146,9 +154,10 @@ export function initToolbar(
       else openSheet();
     });
     sheetBackdrop.addEventListener('click', closeSheet);
-    document.addEventListener('keydown', (e) => {
+    closeSheetOnEscape = (e) => {
       if (e.key === 'Escape') closeSheet();
-    });
+    };
+    document.addEventListener('keydown', closeSheetOnEscape);
   } else {
     // --- Full desktop shell: unchanged from before the compact shell. ---
     const primaryRow = document.createElement('div');
@@ -392,6 +401,15 @@ export function initToolbar(
   };
   toolbar.addEventListener('scroll', restyleSubmenus);
   window.addEventListener('resize', restyleSubmenus);
+
+  toolbarCleanups.set(toolbar, () => {
+    if (closeSheetOnEscape) document.removeEventListener('keydown', closeSheetOnEscape);
+    document.removeEventListener('click', handleDocumentClick);
+    document.removeEventListener('keydown', handleDocumentKeydown);
+    window.removeEventListener('resize', positionStationMenu);
+    toolbar.removeEventListener('scroll', restyleSubmenus);
+    window.removeEventListener('resize', restyleSubmenus);
+  });
 
   return { radio, setRadioStation, getActiveStationId: () => activeStationId ?? undefined };
 }

--- a/app/src/ui/toolbar.ts
+++ b/app/src/ui/toolbar.ts
@@ -7,6 +7,7 @@ import { Tool } from '../game/toolTypes';
 import { getToolHotkey, primaryLabelOverrides, toolLabels } from './toolInfo';
 import { initRadioWidget, type RadioWidget } from './radio';
 import { fetchRadioStations, type RadioStation } from './radioStations';
+import type { LayoutMode } from './deviceMode';
 
 const powerOptions: Tool[] = [
   Tool.PowerLine,
@@ -19,7 +20,20 @@ const powerOptions: Tool[] = [
 const waterOptions: Tool[] = [Tool.WaterPipe, Tool.WaterPump, Tool.WaterTower];
 const educationOptions: Tool[] = [Tool.ElementarySchool, Tool.HighSchool];
 
+// Maps a group's "representative" tool — the one shown collapsed on the full
+// desktop shell, with the rest revealed via its anchored popup submenu — to
+// the full set of tools in that submenu. The compact shell has no anchored
+// popups (everything scrolls in one sheet), so it flattens these in place of
+// the representative tool instead. Single source of truth: add a tool to
+// groupedTools or one of these arrays and both shells pick it up.
+const submenuSources: Partial<Record<Tool, Tool[]>> = {
+  [Tool.PowerLine]: powerOptions,
+  [Tool.WaterPipe]: waterOptions,
+  [Tool.ElementarySchool]: educationOptions
+};
+
 interface ToolbarOptions {
+  layoutMode?: LayoutMode;
   radioVolume?: number;
   radioStationId?: string;
   onRadioStationChange?: (stationId: string) => void;
@@ -28,6 +42,7 @@ interface ToolbarOptions {
 export interface ToolbarControllers {
   radio: RadioWidget;
   setRadioStation: (stationId?: string, opts?: { triggerChange?: boolean }) => void;
+  getActiveStationId: () => string | undefined;
 }
 
 export function initToolbar(
@@ -37,23 +52,8 @@ export function initToolbar(
   options: ToolbarOptions = {}
 ): ToolbarControllers {
   toolbar.innerHTML = '';
-  const { radioVolume, radioStationId, onRadioStationChange } = options;
-
-  const primaryRow = document.createElement('div');
-  primaryRow.className = 'toolbar-row';
-  const powerRow = document.createElement('div');
-  powerRow.className = 'toolbar-sub';
-  powerRow.dataset.submenu = 'power';
-  const waterRow = document.createElement('div');
-  waterRow.className = 'toolbar-sub';
-  waterRow.dataset.submenu = 'water';
-  const educationRow = document.createElement('div');
-  educationRow.className = 'toolbar-sub';
-  educationRow.dataset.submenu = 'education';
-  toolbar.appendChild(primaryRow);
-  toolbar.appendChild(powerRow);
-  toolbar.appendChild(waterRow);
-  toolbar.appendChild(educationRow);
+  const { layoutMode = 'full', radioVolume, radioStationId, onRadioStationChange } = options;
+  toolbar.dataset.layoutMode = layoutMode;
 
   const groupedTools: Tool[][] = [
     [Tool.Inspect, Tool.TerraformRaise, Tool.TerraformLower, Tool.Water, Tool.Tree],
@@ -65,9 +65,9 @@ export function initToolbar(
     [Tool.Bulldoze]
   ];
 
-  const createPrimaryButton = (key: Tool) => {
+  const createToolButton = (key: Tool, className: string) => {
     const button = document.createElement('button');
-    button.className = 'tool-button';
+    button.className = className;
     button.textContent = primaryLabelOverrides[key] ?? toolLabels[key];
     const hotkey = getToolHotkey(key);
     button.title = hotkey ? `${toolLabels[key]} (${hotkey})` : toolLabels[key];
@@ -79,53 +79,139 @@ export function initToolbar(
     return button;
   };
 
-  groupedTools.forEach((group) => {
-    const groupEl = document.createElement('div');
-    groupEl.className = 'toolbar-group';
-    group.forEach((key) => {
-      const button = createPrimaryButton(key);
-      groupEl.appendChild(button);
+  let radioHost: HTMLElement;
+  let radioStationHost: HTMLElement;
+
+  if (layoutMode === 'compact') {
+    // --- Compact shell: a thumb-zone current-tool button that opens a
+    // bottom sheet listing every group, flattened (no anchored popups). ---
+    const shell = document.createElement('div');
+    shell.className = 'toolbar-compact';
+
+    const sheetBackdrop = document.createElement('div');
+    sheetBackdrop.className = 'tool-sheet-backdrop';
+
+    const toolSheet = document.createElement('div');
+    toolSheet.className = 'tool-sheet';
+    toolSheet.setAttribute('role', 'dialog');
+    toolSheet.setAttribute('aria-label', 'Tools');
+
+    groupedTools.forEach((group) => {
+      const groupEl = document.createElement('div');
+      groupEl.className = 'tool-sheet-group';
+      group.forEach((key) => {
+        const expanded = submenuSources[key];
+        if (expanded) {
+          expanded.forEach((subKey) => groupEl.appendChild(createToolButton(subKey, 'tool-sheet-button')));
+        } else {
+          groupEl.appendChild(createToolButton(key, 'tool-sheet-button'));
+        }
+      });
+      toolSheet.appendChild(groupEl);
     });
-    primaryRow.appendChild(groupEl);
-  });
 
-  const spacer = document.createElement('div');
-  spacer.className = 'toolbar-spacer';
-  primaryRow.appendChild(spacer);
+    const dock = document.createElement('div');
+    dock.className = 'toolbar-compact-dock';
 
-  const trailingCluster = document.createElement('div');
-  trailingCluster.className = 'toolbar-cluster';
-  primaryRow.appendChild(trailingCluster);
+    const radioGroup = document.createElement('div');
+    radioGroup.className = 'toolbar-group toolbar-group-radio';
+    radioHost = document.createElement('div');
+    radioHost.className = 'toolbar-radio-slot';
+    radioStationHost = document.createElement('div');
+    radioStationHost.className = 'toolbar-radio-station';
+    radioGroup.append(radioHost, radioStationHost);
 
-  const radioGroup = document.createElement('div');
-  radioGroup.className = 'toolbar-group toolbar-group-radio';
-  const radioHost = document.createElement('div');
-  radioHost.className = 'toolbar-radio-slot';
-  const radioStationHost = document.createElement('div');
-  radioStationHost.className = 'toolbar-radio-station';
-  radioGroup.appendChild(radioHost);
-  radioGroup.appendChild(radioStationHost);
-  trailingCluster.appendChild(radioGroup);
+    const currentToolBtn = document.createElement('button');
+    currentToolBtn.type = 'button';
+    currentToolBtn.className = 'toolbar-current-tool-btn';
+    currentToolBtn.setAttribute('aria-haspopup', 'true');
+    currentToolBtn.setAttribute('aria-expanded', 'false');
 
-  const createSubButton = (row: HTMLElement, key: Tool, labelOverride?: string) => {
-    const button = document.createElement('button');
-    button.className = 'tool-sub-button';
-    button.textContent = labelOverride ?? toolLabels[key];
-    const hotkey = getToolHotkey(key);
-    button.title = hotkey ? `${toolLabels[key]} (${hotkey})` : toolLabels[key];
-    button.dataset.tool = key;
-    button.addEventListener('click', () => {
-      onSelect(key);
-      updateToolbar(toolbar, key);
+    dock.append(radioGroup, currentToolBtn);
+    shell.append(sheetBackdrop, toolSheet, dock);
+    toolbar.appendChild(shell);
+
+    const closeSheet = () => {
+      toolSheet.classList.remove('open');
+      sheetBackdrop.classList.remove('open');
+      currentToolBtn.setAttribute('aria-expanded', 'false');
+    };
+    const openSheet = () => {
+      toolSheet.classList.add('open');
+      sheetBackdrop.classList.add('open');
+      currentToolBtn.setAttribute('aria-expanded', 'true');
+    };
+    currentToolBtn.addEventListener('click', () => {
+      if (toolSheet.classList.contains('open')) closeSheet();
+      else openSheet();
     });
-    row.appendChild(button);
-  };
+    sheetBackdrop.addEventListener('click', closeSheet);
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') closeSheet();
+    });
+  } else {
+    // --- Full desktop shell: unchanged from before the compact shell. ---
+    const primaryRow = document.createElement('div');
+    primaryRow.className = 'toolbar-row';
+    const powerRow = document.createElement('div');
+    powerRow.className = 'toolbar-sub';
+    powerRow.dataset.submenu = 'power';
+    const waterRow = document.createElement('div');
+    waterRow.className = 'toolbar-sub';
+    waterRow.dataset.submenu = 'water';
+    const educationRow = document.createElement('div');
+    educationRow.className = 'toolbar-sub';
+    educationRow.dataset.submenu = 'education';
+    toolbar.appendChild(primaryRow);
+    toolbar.appendChild(powerRow);
+    toolbar.appendChild(waterRow);
+    toolbar.appendChild(educationRow);
 
-  powerOptions.forEach((key) => createSubButton(powerRow, key, key === Tool.PowerLine ? '⚡ Lines' : undefined));
-  waterOptions.forEach((key) => createSubButton(waterRow, key, key === Tool.WaterPump ? '🚰 Pump' : undefined));
-  educationOptions.forEach((key) =>
-    createSubButton(educationRow, key, key === Tool.ElementarySchool ? '🎓 Elementary' : '🏢 High')
-  );
+    groupedTools.forEach((group) => {
+      const groupEl = document.createElement('div');
+      groupEl.className = 'toolbar-group';
+      group.forEach((key) => groupEl.appendChild(createToolButton(key, 'tool-button')));
+      primaryRow.appendChild(groupEl);
+    });
+
+    const spacer = document.createElement('div');
+    spacer.className = 'toolbar-spacer';
+    primaryRow.appendChild(spacer);
+
+    const trailingCluster = document.createElement('div');
+    trailingCluster.className = 'toolbar-cluster';
+    primaryRow.appendChild(trailingCluster);
+
+    const radioGroup = document.createElement('div');
+    radioGroup.className = 'toolbar-group toolbar-group-radio';
+    radioHost = document.createElement('div');
+    radioHost.className = 'toolbar-radio-slot';
+    radioStationHost = document.createElement('div');
+    radioStationHost.className = 'toolbar-radio-station';
+    radioGroup.appendChild(radioHost);
+    radioGroup.appendChild(radioStationHost);
+    trailingCluster.appendChild(radioGroup);
+
+    const createSubButton = (row: HTMLElement, key: Tool, labelOverride?: string) => {
+      const button = document.createElement('button');
+      button.className = 'tool-sub-button';
+      button.textContent = labelOverride ?? toolLabels[key];
+      const hotkey = getToolHotkey(key);
+      button.title = hotkey ? `${toolLabels[key]} (${hotkey})` : toolLabels[key];
+      button.dataset.tool = key;
+      button.addEventListener('click', () => {
+        onSelect(key);
+        updateToolbar(toolbar, key);
+      });
+      row.appendChild(button);
+    };
+
+    powerOptions.forEach((key) => createSubButton(powerRow, key, key === Tool.PowerLine ? '⚡ Lines' : undefined));
+    waterOptions.forEach((key) => createSubButton(waterRow, key, key === Tool.WaterPump ? '🚰 Pump' : undefined));
+    educationOptions.forEach((key) =>
+      createSubButton(educationRow, key, key === Tool.ElementarySchool ? '🎓 Elementary' : '🏢 High')
+    );
+  }
 
   const radio = initRadioWidget(radioHost, { initialVolume: radioVolume });
 
@@ -197,7 +283,7 @@ export function initToolbar(
   const closeStationMenu = () => {
     stationMenu.classList.remove('open');
     stationButton.setAttribute('aria-expanded', 'false');
-    radioGroup.classList.remove('toolbar-group-radio-open');
+    radioStationHost.closest('.toolbar-group-radio')?.classList.remove('toolbar-group-radio-open');
   };
 
   const positionStationMenu = () => {
@@ -219,7 +305,7 @@ export function initToolbar(
     positionStationMenu();
     stationMenu.classList.add('open');
     stationButton.setAttribute('aria-expanded', 'true');
-    radioGroup.classList.add('toolbar-group-radio-open');
+    radioStationHost.closest('.toolbar-group-radio')?.classList.add('toolbar-group-radio-open');
   };
 
   const toggleStationMenu = () => {
@@ -307,11 +393,27 @@ export function initToolbar(
   toolbar.addEventListener('scroll', restyleSubmenus);
   window.addEventListener('resize', restyleSubmenus);
 
-  return { radio, setRadioStation };
+  return { radio, setRadioStation, getActiveStationId: () => activeStationId ?? undefined };
 }
 
 export function updateToolbar(toolbar: HTMLElement, active: Tool) {
   toolbar.dataset.activeTool = active;
+
+  if (toolbar.dataset.layoutMode === 'compact') {
+    const currentToolBtn = toolbar.querySelector<HTMLButtonElement>('.toolbar-current-tool-btn');
+    if (currentToolBtn) {
+      currentToolBtn.textContent = primaryLabelOverrides[active] ?? toolLabels[active];
+    }
+    toolbar.querySelectorAll('.tool-sheet-button').forEach((btn) => {
+      const key = btn.getAttribute('data-tool');
+      btn.classList.toggle('active', key === active);
+    });
+    toolbar.querySelector('.tool-sheet')?.classList.remove('open');
+    toolbar.querySelector('.tool-sheet-backdrop')?.classList.remove('open');
+    currentToolBtn?.setAttribute('aria-expanded', 'false');
+    return;
+  }
+
   toolbar.querySelectorAll('.tool-button').forEach((btn) => {
     const key = btn.getAttribute('data-tool');
     if (!key) return;

--- a/docs/mobile-web-plan.md
+++ b/docs/mobile-web-plan.md
@@ -40,59 +40,59 @@ chrome. No visible UI changes on desktop.*
   `deps:` none.
   **DoD:** a save predating a known settings field deserializes with the default
   applied; camera round-trip and zoom-anchor invariants covered; both suites green.
-- [ ] **M0-1 · Input/layout mode detection module.** `src/ui/deviceMode.ts` (or
+- [x] **M0-1 · Input/layout mode detection module.** `src/ui/deviceMode.ts` (or
   similar): derives `inputMode: 'touch' | 'mouse'` from `(pointer: coarse)` +
   `maxTouchPoints`, and `layoutMode: 'compact' | 'full'` from viewport dimensions
   (media query / `ResizeObserver`); emits change events (rotation, window resize,
   mouse plugged into a tablet). `deps:` none.
   **DoD:** unit tests cover the derivation matrix; modes re-evaluate live on viewport
-  and pointer-capability changes.
-- [ ] **M0-2 · Settings override + dev param.** `ui: 'auto' | 'desktop' | 'mobile'`
+  and pointer-capability changes. (#92)
+- [x] **M0-2 · Settings override + dev param.** `ui: 'auto' | 'desktop' | 'mobile'`
   setting (auto = M0-1 detection) with a `createDefault*` factory in `gameState.ts`,
   back-fill in `persistence.deserialize`, and a control in the settings modal.
   `?ui=mobile|desktop` query param forces a mode for dev testing (same pattern as
   `?bridge=tauri`). `deps:` M0-1.
   **DoD:** old saves load with the field defaulted; the query param wins over the
-  setting; `bun run lint` clean.
-- [ ] **M0-3 · Viewport meta + safe areas.** Add `viewport-fit=cover` to the viewport
+  setting; `bun run lint` clean. (#93)
+- [x] **M0-3 · Viewport meta + safe areas.** Add `viewport-fit=cover` to the viewport
   meta in `index.html`; pad HUD/toolbar with `env(safe-area-inset-*)`; replace any
   `100vh`-style sizing with `dvh`/`svh` or `visualViewport` so the layout survives
   the mobile address bar showing/hiding. `deps:` none.
   **DoD:** in standalone PWA mode on a notched phone, no controls sit under the
-  notch/home bar; toggling browser chrome doesn't leave dead space or clipped UI.
-- [ ] **M0-4 · Suppress competing browser gestures.** `touch-action: none` on the
+  notch/home bar; toggling browser chrome doesn't leave dead space or clipped UI. (#89)
+- [x] **M0-4 · Suppress competing browser gestures.** `touch-action: none` on the
   canvas wrapper, `overscroll-behavior: none` (kills pull-to-refresh mid-pan),
   `user-select: none` + context-menu suppression on HUD chrome, and an edge inset so
   painting near screen edges doesn't fight Android's back-swipe gesture. `deps:` none.
   **DoD:** on-device: pull-to-refresh, double-tap zoom, long-press text selection,
-  and accidental back-navigation no longer trigger during play.
-- [ ] **M0-5 · Resize contract hardening.** Pixi already uses `resizeTo`; make the
+  and accidental back-navigation no longer trigger during play. (#89)
+- [x] **M0-5 · Resize contract hardening.** Pixi already uses `resizeTo`; make the
   toolbar-height CSS variables (`--toolbar-base-height` etc., measured in `main.ts`)
   re-measure on viewport resize and layout-mode changes, including rotation.
   `deps:` M0-1. **DoD:** rotating portrait↔landscape mid-game leaves camera, HUD,
-  and toolbar layout correct in both orientations with no reload.
+  and toolbar layout correct in both orientations with no reload. (#94)
 
 ## Phase M1 — Touch input
 *Goal: the game is fully playable with fingers. Desktop mouse behaviour unchanged;
 desktop touchscreens get these gestures for free (input handling is already
 PointerEvents in `main.ts`).*
 
-- [ ] **M1-1 · Gesture disambiguation: one finger = tool, two fingers = pan/zoom.**
+- [x] **M1-1 · Gesture disambiguation: one finger = tool, two fingers = pan/zoom.**
   In touch input mode, single-pointer tap/drag drives the active tool (as drag-paint
   does today); a second pointer cancels any in-progress paint and switches to
   camera control. `deps:` M0-1.
   **DoD:** starting a two-finger gesture mid-paint never leaves stray tiles (the
-  in-flight paint is undone or never committed); mouse path untouched.
-- [ ] **M1-2 · Pinch-zoom + two-finger pan.** Track two active pointers; scale the
+  in-flight paint is undone or never committed); mouse path untouched. (#67, #96)
+- [x] **M1-2 · Pinch-zoom + two-finger pan.** Track two active pointers; scale the
   camera around the gesture midpoint, pan with the midpoint delta. Respect the
   existing `zoomSensitivity` setting. `deps:` M1-1.
   **DoD:** pinch keeps the point under the fingers stationary (no drift); wheel zoom
-  on desktop unchanged.
-- [ ] **M1-3 · Tap slop + touch-appropriate defaults.** A small movement tolerance so
+  on desktop unchanged. (#68, #97)
+- [x] **M1-3 · Tap slop + touch-appropriate defaults.** A small movement tolerance so
   a slightly-moving finger registers as a tap, not a one-tile drag-paint; deeper
   default camera zoom on compact layouts so tiles are finger-sized. `deps:` M1-1.
   **DoD:** on-device, single-tile placement is reliable at default zoom; slop does
-  not affect mouse input.
+  not affect mouse input. (#69, #98)
 - [ ] **M1-4 · Hover replacement.** Hovered-tile preview, tooltips, and `toolInfo`
   hover details don't exist on touch — surface the equivalent via tap feedback
   (e.g. tile inspect on tap with an inspect tool, tool details shown in the picker,

--- a/docs/mobile-web-plan.md
+++ b/docs/mobile-web-plan.md
@@ -105,12 +105,12 @@ PointerEvents in `main.ts`).*
 shell around the same `toolbar.ts` tool groups and callbacks — not a fork that drifts
 when tools are added.*
 
-- [ ] **M2-1 · Compact toolbar shell.** Bottom-anchored current-tool button (thumb
+- [x] **M2-1 · Compact toolbar shell.** Bottom-anchored current-tool button (thumb
   zone) that opens a bottom sheet/drawer rendering the existing `groupedTools`
   groups; picking a tool closes the sheet. Admin/overlay/radio groups collapse
   behind the sheet or a secondary button. Hit targets ≥ ~44px. `deps:` M0-1, M0-3.
   **DoD:** every tool and admin action reachable in compact mode; adding a tool to
-  `groupedTools` appears in both shells with no extra wiring; full layout unchanged.
+  `groupedTools` appears in both shells with no extra wiring; full layout unchanged. (#103)
 - [ ] **M2-2 · Tool info in the picker.** `toolInfo.ts` content (cost, description)
   shown for the highlighted tool inside the sheet, replacing hover. `deps:` M2-1.
   **DoD:** cost is visible before placing in compact mode.


### PR DESCRIPTION
Part of the mobile web plan (epic #61) — Phase M2's first item.

## Summary

- **M2-1 · Compact toolbar shell**: on compact layouts, the always-visible desktop tool row (with anchored popup submenus for Power/Water/Education) is replaced by a thumb-zone current-tool button that opens a bottom sheet listing every tool group flattened — no anchored popups needed, since the sheet already scrolls. Picking a tool updates the button and closes the sheet. The full radio widget (marquee, cover art) collapses to just its icon buttons + station picker here; hover/focus's existing popover still surfaces track details.
- Both shells render from the same `groupedTools`/submenu data, so adding a tool to either picks it up in both with no extra wiring, and the toolbar can flip shells live on a layoutMode change (e.g. rotation) instead of requiring a reload.
- **Landscape-phone detection fix**: `layoutMode` was width-only (`≤900px`), which misclassifies a phone in landscape — comfortably wider than 900px on most devices, but short enough that a full desktop shell leaves almost no canvas. Confirmed on a real device. Now triggers on `width ≤ 900px OR height ≤ 500px`, with a matching combined media query in `style.css`. A genuine tablet in landscape (e.g. 1024×768) still resolves to `full`, per the plan's existing "tablets get full layout" decision.
- **Topbar polish from on-device testing**: the logo is now vertically centred against the (taller) ribbon chips it shares a line with, instead of looking stranded at the top; and the ribbon/controls now share one line whenever there's room (phone landscape) instead of always splitting to two (previously wasted vertical space there even when width wasn't the constraint).
- Also fixes two bugs the new shell surfaced: `#viewport` was still reserving top padding for a toolbar row that no longer exists in compact mode, and Pixi's `resizeTo` doesn't reliably respond to a layout-only container resize (a known upstream limitation, pixijs/pixijs#11427) — worked around by setting the compact toolbar height before the renderer ever initializes, so it never needs a live resize for the common case.
- Retroactively ticked off M0-1..M0-5 and M1-1..M1-3 in `docs/mobile-web-plan.md` — all merged earlier this session but never marked done.

### User-facing changes

Phones get a bottom-sheet tool picker instead of the desktop tool row; this now correctly applies in landscape too, where it previously showed the desktop layout with almost no room to see the map.

### Known limitations

Two more issues found during on-device testing, intentionally deferred as their own follow-up work (tracked as M2-4 and M2-2 in the plan): the minimap takes up a large portion of a phone-sized viewport by default, and the floating tool-info card can visually collide with it. Both already have dedicated tickets for the real fix (minimap defaults/toggle, moving cost info into the tool sheet) rather than a quick patch here.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run test` — 145/145 non-`jsdom` tests pass locally (pre-existing machine-local jsdom quirk, unrelated — see #92/#93/#96–#102 history; CI is authoritative there), including new `deviceMode.test.ts` coverage for the height-based fallback and a phone-landscape scenario
- [x] Verified with Playwright: compact shell renders/opens/closes/selects correctly; phone-landscape (926×428) now gets the compact shell with everything on one topbar line; phone-portrait (390×844) still wraps to two lines; tablet-landscape (1024×768) and desktop (1280×900) both remain unaffected (`full` layout, single-line topbar)
- [x] **Tested live on your phone**: compact shell works in portrait; logo centring and one-line landscape topbar confirmed after the follow-up fixes
- [ ] Still to try on-device: landscape detection fix itself (was fixed after the initial device test, based on your landscape screenshots)
