### PR TITLE
Share the minimap and tile inspector as one tabbed panel in compact mode

### DIFF
--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -200,6 +200,11 @@ compactInfoTabInspect.type = 'button';
 compactInfoTabInspect.className = 'compact-info-tab';
 compactInfoTabInspect.textContent = '🔍 Inspect';
 compactInfoTabs.append(compactInfoTabMap, compactInfoTabInspect);
+// compactInfoTabs is a DOM child of wrapper (like .minimap-panel and the hud
+// .overlay before it), so without this a tap on it also bubbles up to
+// wrapper's own pointerdown handler below and gets treated as a tile tap —
+// applying the Inspect tool underneath and re-toggling the tab right back.
+compactInfoTabs.addEventListener('pointerdown', (e) => e.stopPropagation());
 wrapper.append(compactInfoTabs);
 
 function setCompactInfoTab(tab: 'map' | 'inspect' | 'none') {

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -184,6 +184,37 @@ const pendingPenaltyBtn = requireElement<HTMLButtonElement>('#pending-penalty-bt
 const simBridgeBtn = requireElement<HTMLButtonElement>('#sim-bridge-btn');
 const newsTickerEl = requireElement<HTMLDivElement>('#news-ticker');
 
+// Compact layout has no room for the minimap and the tile inspector as two
+// separate floating panels (they collide) — they share one corner instead,
+// switched with these tabs. Always created (cheap, two buttons); style.css
+// scopes all of the compact-sharing CSS to the compact breakpoint, so this
+// is inert on desktop regardless of the dataset value below.
+const compactInfoTabs = document.createElement('div');
+compactInfoTabs.className = 'compact-info-tabs';
+const compactInfoTabMap = document.createElement('button');
+compactInfoTabMap.type = 'button';
+compactInfoTabMap.className = 'compact-info-tab';
+compactInfoTabMap.textContent = '🗺️ Map';
+const compactInfoTabInspect = document.createElement('button');
+compactInfoTabInspect.type = 'button';
+compactInfoTabInspect.className = 'compact-info-tab';
+compactInfoTabInspect.textContent = '🔍 Inspect';
+compactInfoTabs.append(compactInfoTabMap, compactInfoTabInspect);
+wrapper.append(compactInfoTabs);
+
+function setCompactInfoTab(tab: 'map' | 'inspect' | 'none') {
+  wrapper.dataset.compactInfoTab = tab;
+  compactInfoTabMap.classList.toggle('active', tab === 'map');
+  compactInfoTabInspect.classList.toggle('active', tab === 'inspect');
+}
+compactInfoTabMap.addEventListener('click', () => {
+  setCompactInfoTab(wrapper.dataset.compactInfoTab === 'map' ? 'none' : 'map');
+});
+compactInfoTabInspect.addEventListener('click', () => {
+  setCompactInfoTab(wrapper.dataset.compactInfoTab === 'inspect' ? 'none' : 'inspect');
+});
+setCompactInfoTab('none');
+
 // Ribbon dropdowns (<details>): only one open at a time, close on outside
 // click or Escape, and close the saves menu after an action is chosen.
 const ribbonMenus = [...document.querySelectorAll<HTMLDetailsElement>('details.ribbon-menu')];
@@ -236,6 +267,12 @@ const syncToolbarHeights = () => {
   if (toolbar.dataset.layoutMode === 'compact') {
     viewport.style.setProperty('--toolbar-base-height', '0px');
     viewport.style.setProperty('--toolbar-visible-height', '0px');
+    // The compact-info-tabs / shared minimap+inspector panel float above
+    // .toolbar-compact-dock (position: fixed, bottom: 0) — measure its real
+    // height (varies with safe-area-inset-bottom) instead of guessing, same
+    // approach as the full shell's own height vars above.
+    const dockHeight = toolbar.querySelector('.toolbar-compact-dock')?.getBoundingClientRect().height ?? 0;
+    viewport.style.setProperty('--compact-dock-height', `${dockHeight}px`);
     return;
   }
   const rect = toolbar.getBoundingClientRect();
@@ -501,6 +538,9 @@ function applyCurrentTool(tilePos: Position) {
   if (!getTile(state, tilePos.x, tilePos.y)) return;
   if (activeTool === Tool.Inspect) {
     selected = tilePos;
+    if (toolbar.dataset.layoutMode === 'compact') {
+      setCompactInfoTab('inspect');
+    }
     return;
   }
   const result = bridge.send(applyToolCmd(activeTool, tilePos.x, tilePos.y));
@@ -809,6 +849,7 @@ function gameLoop(renderer: MapRenderer, hud: ReturnType<typeof createHud>) {
     wildernessChip,
     overlayRoot: wrapper
   });
+  hud.setToolInfoSuppressed(deviceMode.getMode().layoutMode === 'compact');
   newsTicker = initNewsTicker({
     root: newsTickerEl,
     getItems: () => narrativeManager.getTickerQueue(),
@@ -976,6 +1017,18 @@ function gameLoop(renderer: MapRenderer, hud: ReturnType<typeof createHud>) {
     });
   };
 
+  // In compact mode the minimap's own Hide/Show control is replaced by the
+  // shared map/inspect tabs (see setCompactInfoTab above), so the panel's
+  // *content* should always be ready to draw — force `open` in memory only
+  // (syncSettings doesn't call onSettingsChange) rather than persisting it,
+  // so an explicit "hide minimap" choice made on desktop survives a phone
+  // session.
+  const syncMinimapSettings = (settings: GameState['settings']['minimap']) => {
+    minimap?.syncSettings(
+      deviceMode.getMode().layoutMode === 'compact' ? { ...settings, open: true } : settings
+    );
+  };
+
   const applySettings = (
     nextSettings: GameState['settings'],
     options: { skipHotkeyReload?: boolean } = {}
@@ -995,7 +1048,7 @@ function gameLoop(renderer: MapRenderer, hud: ReturnType<typeof createHud>) {
     });
     newsTicker?.update();
     if (minimapChanged) {
-      minimap?.syncSettings(state.settings.minimap);
+      syncMinimapSettings(state.settings.minimap);
       minimap?.markDirty();
     }
     updatePendingPenaltyBtn();
@@ -1018,6 +1071,7 @@ function gameLoop(renderer: MapRenderer, hud: ReturnType<typeof createHud>) {
     getViewportSize: minimapViewport,
     palette
   });
+  syncMinimapSettings(state.settings.minimap);
 
   settingsModal = initSettingsModal({
     getSettings: () => state.settings,
@@ -1055,6 +1109,8 @@ function gameLoop(renderer: MapRenderer, hud: ReturnType<typeof createHud>) {
     if (toolbar.dataset.layoutMode !== deviceMode.getMode().layoutMode) {
       setupToolbar();
     }
+    hud.setToolInfoSuppressed(deviceMode.getMode().layoutMode === 'compact');
+    syncMinimapSettings(state.settings.minimap);
     syncToolbarHeights();
     // See the matching comment below: force Pixi to pick up canvas-wrapper's
     // new size, since `resizeTo`'s own auto-resize doesn't reliably do so

--- a/app/src/style.css
+++ b/app/src/style.css
@@ -487,6 +487,39 @@ select {
   border-color: var(--accent);
 }
 
+/* Compact layout only: the minimap and tile inspector share one floating
+   corner (see .overlay/.minimap-panel in the compact breakpoint below)
+   instead of each getting their own, so these tabs pick which is showing.
+   Always in the DOM (main.ts creates them unconditionally) but only ever
+   visible once the compact breakpoint below turns display back on. */
+.compact-info-tabs {
+  display: none;
+  position: absolute;
+  right: calc(8px + env(safe-area-inset-right, 0px));
+  /* Clears .toolbar-compact-dock (position: fixed, bottom: 0), whose real
+     height (safe-area-inset-bottom varies it) main.ts measures into this
+     var — see syncToolbarHeights(). The 84px fallback matches its typical
+     measured height before that first measurement lands. */
+  bottom: calc(var(--compact-dock-height, 84px) + 8px);
+  gap: 6px;
+  z-index: 7;
+}
+
+.compact-info-tab {
+  background: #132644;
+  border: 2px solid #223557;
+  border-radius: 10px;
+  color: var(--text);
+  padding: 8px 12px;
+  min-height: 40px;
+  font-family: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  box-shadow: 0 4px 0 #0a1020;
+}
+
+.compact-info-tab.active {
+  border-color: var(--accent);
 }
 
 .toolbar-sub {
@@ -2267,10 +2300,37 @@ footer {
     height: 60vh;
     height: 60dvh;
   }
+  /* Purely cosmetic (tagline + GitHub link) and gets visually buried under
+     the fixed-position compact toolbar dock anyway — drop it to reclaim
+     real flow height for the canvas instead of leaving it fought-over. */
+  footer {
+    display: none;
+  }
+  .compact-info-tabs {
+    display: flex;
+  }
+  /* Minimap and the tile inspector now share this one footprint, switched
+     by .compact-info-tabs above instead of each floating independently
+     (where they used to overlap by roughly half their width on a phone). */
+  .overlay,
   .minimap-panel {
-    width: min(100%, 280px);
+    left: auto;
     right: calc(8px + env(safe-area-inset-right, 0px));
-    bottom: calc(8px + env(safe-area-inset-bottom, 0px));
+    /* Sits directly above .compact-info-tabs — dock height + its own gap,
+       plus the tab strip's own ~40px height and gap. */
+    bottom: calc(var(--compact-dock-height, 84px) + 8px + 40px + 8px);
+    width: min(100%, 280px);
+  }
+  /* Title + the panel's own Hide/Show button are redundant here — the tabs
+     above now own showing/hiding it. */
+  .minimap-header {
+    display: none;
+  }
+  .canvas-wrapper[data-compact-info-tab='map'] .overlay,
+  .canvas-wrapper[data-compact-info-tab='inspect'] .minimap-panel,
+  .canvas-wrapper[data-compact-info-tab='none'] .overlay,
+  .canvas-wrapper[data-compact-info-tab='none'] .minimap-panel {
+    display: none !important;
   }
 }
 

--- a/app/src/ui/hud.ts
+++ b/app/src/ui/hud.ts
@@ -48,6 +48,12 @@ export function createHud(elements: HudElements) {
   let overlayContainer: HTMLDivElement | null = null;
   let toolInfoPinned = false;
   let overlayFrozen = false;
+  // In compact layout the tool-info card and the tile inspector share one
+  // small floating panel (tabbed) instead of each getting their own — the
+  // always-on "here's the selected tool's cost" card would otherwise eat
+  // that whole shared footprint by default. Suppressed there until M2-2
+  // gives tool info a proper home in the compact tool sheet instead.
+  let toolInfoSuppressed = false;
 
   const ensureOverlayContainer = () => {
     if (!overlayContainer) {
@@ -118,7 +124,7 @@ export function createHud(elements: HudElements) {
   const renderOverlays = (state: GameState, selected: Position | null, activeTool: Tool) => {
     if (overlayFrozen) return;
     const hasTileSelection = activeTool === Tool.Inspect && selected ? getTile(state, selected.x, selected.y) : null;
-    const showToolInfo = toolInfoPinned || activeTool !== Tool.Inspect;
+    const showToolInfo = !toolInfoSuppressed && (toolInfoPinned || activeTool !== Tool.Inspect);
 
     if (!showToolInfo && !hasTileSelection) {
       overlayContainer?.remove();
@@ -294,5 +300,9 @@ export function createHud(elements: HudElements) {
     cleanupOverlayContainer();
   };
 
-  return { update, renderOverlays };
+  const setToolInfoSuppressed = (suppressed: boolean) => {
+    toolInfoSuppressed = suppressed;
+  };
+
+  return { update, renderOverlays, setToolInfoSuppressed };
 }

--- a/docs/mobile-web-plan.md
+++ b/docs/mobile-web-plan.md
@@ -130,7 +130,7 @@ when tools are added.*
   Also hides the footer (cosmetic tagline + GitHub link, permanently buried under
   the fixed compact toolbar dock anyway) to reclaim its flow height for the canvas.
   `deps:` M2-1. **DoD:** neither element occludes the canvas by default on a
-  phone-sized viewport in either orientation.
+  phone-sized viewport in either orientation. (#104)
 - [ ] **M2-5 · Responsive modals + manual.** Settings/budget/bylaws modals size to
   small viewports in both orientations. `manual.html` is a separate document in an
   iframe — give it its own viewport meta and mobile styles, and document the touch

--- a/docs/mobile-web-plan.md
+++ b/docs/mobile-web-plan.md
@@ -113,15 +113,24 @@ when tools are added.*
   `groupedTools` appears in both shells with no extra wiring; full layout unchanged. (#103)
 - [ ] **M2-2 · Tool info in the picker.** `toolInfo.ts` content (cost, description)
   shown for the highlighted tool inside the sheet, replacing hover. `deps:` M2-1.
-  **DoD:** cost is visible before placing in compact mode.
+  **DoD:** cost is visible before placing in compact mode. More load-bearing than it
+  was: M2-4 suppresses the old always-on tool-info card in compact mode entirely
+  (it was eating the same footprint the minimap/inspector needed), so tool cost has
+  no compact-mode home at all until this ships.
 - [ ] **M2-3 · Prominent undo.** Surface the existing undo (P5-5) as a visible button
   in the compact HUD — mis-taps cost money and undo is the cheap fix. `deps:` M2-1.
   **DoD:** undo reachable in one tap; shows the same "Undone" notification.
-- [ ] **M2-4 · Minimap + news ticker in compact mode.** Ticker collapses to a
-  tap-to-expand strip; minimap becomes toggleable (respecting existing minimap
-  settings). Both work in portrait and landscape. `deps:` M2-1.
-  **DoD:** neither element occludes the canvas by default on a phone-sized viewport
-  in either orientation.
+- [x] **M2-4 · Minimap + inspector in compact mode.** On-device testing found the
+  minimap and the tile inspector — not the news ticker, which turned out fine as-is —
+  were the real offenders: both float over `#canvas-wrapper` in the same bottom
+  corner and visibly collided. Implemented as one shared tabbed panel ("Map" /
+  "Inspect") instead of two independent floats; closed by default, and tapping a
+  tile with the Inspect tool active auto-switches to the Inspect tab. The
+  always-visible desktop tool-info card is suppressed in compact mode (see M2-2).
+  Also hides the footer (cosmetic tagline + GitHub link, permanently buried under
+  the fixed compact toolbar dock anyway) to reclaim its flow height for the canvas.
+  `deps:` M2-1. **DoD:** neither element occludes the canvas by default on a
+  phone-sized viewport in either orientation.
 - [ ] **M2-5 · Responsive modals + manual.** Settings/budget/bylaws modals size to
   small viewports in both orientations. `manual.html` is a separate document in an
   iframe — give it its own viewport meta and mobile styles, and document the touch


### PR DESCRIPTION
Part of the mobile web plan (epic #61) — Phase M2's fourth item, M2-4. Follows up on #103 (M2-1).

## Summary

- On-device testing (phone screenshots) found the minimap and tile inspector — not the news ticker, which turned out fine as-is — were the real space problem on a compact layout: both float over `#canvas-wrapper` in the same bottom corner and visibly collide, each claiming ~280-300px of a ~375px-wide screen.
- **Shared tabbed panel**: replaces the two independent floats with one panel in compact mode, switched by new "Map"/"Inspect" tabs — closed by default, so neither occludes the canvas until asked for. Tapping a tile with the Inspect tool active auto-switches to the Inspect tab, matching existing desktop behaviour.
- **Tool-info suppression**: the always-on desktop tool-cost card is suppressed in compact mode (`hud.ts`'s new `toolInfoSuppressed` flag) since it was eating the same footprint the minimap/inspector needed; genuine tile info (tap a tile with Inspect active) is unaffected. This makes M2-2 ("Tool info in the picker") more load-bearing — tool cost has no compact-mode home until it ships.
- **Footer hidden in compact mode**: it's cosmetic (tagline + GitHub link) and was permanently buried under the fixed compact toolbar dock anyway — hiding it reclaims real canvas height, not just a visual fix.
- `syncToolbarHeights` now also measures `.toolbar-compact-dock`'s real height into a `--compact-dock-height` CSS var, so the new tabs/panel float just above the dock instead of guessing a fixed offset.
- Fixes a stray orphaned `}` left over in `style.css` from an earlier reorder of `.tool-sheet-button.active` (harmless — CSS ignores an unmatched closing brace — but sloppy).

### User-facing changes

On a phone-sized viewport, the minimap and tile inspector now share one small tabbed panel instead of visually overlapping; both default to closed. The footer no longer shows in compact mode.

### Known limitations

Tool cost/description, previously always visible in compact mode via the same panel, is suppressed there until M2-2 gives it a proper home inside the tool sheet instead.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run test` — 145/145 non-`jsdom` tests pass locally (pre-existing machine-local jsdom quirk, unrelated — CI is authoritative there)
- [x] Verified with Playwright: phone portrait (390×844) — footer hidden, tabs float cleanly above the toolbar dock with zero overlap, "Map" tab shows the minimap header-free, "Inspect" tab shows tile info, tapping a tile auto-switches from "Map" to "Inspect"; phone landscape (926×428) — same behaviour, tab state carries over; desktop (1280×900) — completely unaffected, minimap/inspector/footer all shown independently as before; live compact→full→compact flip re-applies correctly with no console errors throughout
- [ ] Not yet tested on a real device
