### PR TITLE
Stop the first finger of a pinch/pan gesture from placing a tool

### DIFF
--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -306,6 +306,19 @@ let lastPinchDistance: number | null = null;
 const TOUCH_TAP_SLOP_PX = 10;
 let touchDownPos: { x: number; y: number } | null = null;
 let touchSlopExceeded = false;
+// A touch pointerdown can't tell in advance whether a second finger is about
+// to land and turn it into a pinch/pan gesture — without this, the first
+// finger down immediately (and expensively) applies the active tool to
+// whatever tile it landed on. Give a fast-following second finger a brief
+// grace window to arrive and cancel it before it commits.
+const TOUCH_MULTI_TOUCH_GRACE_MS = 60;
+let pendingTouchApply: { tile: Position; timeoutId: number } | null = null;
+
+function cancelPendingTouchApply() {
+  if (!pendingTouchApply) return;
+  window.clearTimeout(pendingTouchApply.timeoutId);
+  pendingTouchApply = null;
+}
 let activeTool: Tool = Tool.Inspect;
 let selectedTool: Tool = Tool.Inspect;
 let temporaryTool: Tool | null = null;
@@ -572,6 +585,7 @@ function attachViewportEvents(canvas: HTMLCanvasElement) {
         // paint before it can commit another tile, and start a pinch-pan
         // gesture from the fingers' midpoint/spread. Re-priming on a third
         // finger joining (rather than requiring exactly two) avoids a jump.
+        cancelPendingTouchApply();
         isPainting = false;
         lastPainted = null;
         hovered = null;
@@ -603,9 +617,23 @@ function attachViewportEvents(canvas: HTMLCanvasElement) {
       }
     }
     if (hovered) {
-      isPainting = true;
-      lastPainted = hovered;
-      applyCurrentTool(hovered);
+      if (e.pointerType === 'touch') {
+        cancelPendingTouchApply();
+        const tile = hovered;
+        pendingTouchApply = {
+          tile,
+          timeoutId: window.setTimeout(() => {
+            pendingTouchApply = null;
+            isPainting = true;
+            lastPainted = tile;
+            applyCurrentTool(tile);
+          }, TOUCH_MULTI_TOUCH_GRACE_MS)
+        };
+      } else {
+        isPainting = true;
+        lastPainted = hovered;
+        applyCurrentTool(hovered);
+      }
     }
   });
 
@@ -652,6 +680,10 @@ function attachViewportEvents(canvas: HTMLCanvasElement) {
         return;
       }
       touchSlopExceeded = true;
+      // Dragging means this was never a stationary tap — let the paint-while-
+      // dragging logic below take over from here rather than also committing
+      // the original touchdown tile once the grace window above elapses.
+      cancelPendingTouchApply();
     }
     const primaryDown = (e.buttons & 1) !== 0;
     const secondaryDown = (e.buttons & 2) !== 0;


### PR DESCRIPTION
Found while testing #104 on a real phone: starting a pinch-zoom or two-finger pan gesture placed a tool on a random tile from the first finger touching down, before the second finger arrived to signal "this is a camera gesture, not a tap." With a paid tool active (e.g. Road) that silently spends money on an unwanted tile; with Inspect active it force-selects that tile instead. Independent of #104/the compact toolbar work — this is in the general touch input path from M1, affects every layout mode and every touch device.

## Summary

- **Root cause**: `wrapper`'s `pointerdown` handler in `main.ts` calls `applyCurrentTool` synchronously for any touch pointerdown — there's no way for a single pointerdown to know in advance a second finger is about to land; the two-finger/pinch branch only exists once `activeTouchPointers.size` actually reaches 2, one event later.
- **Fix**: for touch input only, defer the tool application by a short `TOUCH_MULTI_TOUCH_GRACE_MS` (60ms) window (`pendingTouchApply`) instead of committing immediately. A second finger arriving, or the touch moving past the existing tap-slop threshold (a drag, not a stationary tap), both cancel the pending apply via `cancelPendingTouchApply()` before it fires. A genuine single-finger tap still commits once the window elapses. Mouse input path is unchanged.

### User-facing changes

Pinch-zoom and two-finger pan on touch devices no longer place/inspect a stray tile from the first finger touching down.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run test` — 145/145 non-`jsdom` tests pass locally (pre-existing machine-local jsdom quirk, unrelated — CI is authoritative there)
- [x] Verified with Playwright against a paused simulation (avoids ordinary income muddying the money-delta signal), using the game's own MCP debug bridge to read exact state before/after: a simulated two-finger pinch gesture left money and tick unchanged (nothing was placed); a plain single-finger tap immediately afterward still correctly spent money placing a road, confirming the fix suppresses only the multi-touch race and leaves genuine taps working as before
- [ ] Not yet re-tested on a real device (the original report came from one)
