### PR TITLE
Expand design tokens and de-duplicate repeated colours

### DIFF
--- a/app/src/styles/base.css
+++ b/app/src/styles/base.css
@@ -5,9 +5,17 @@
   color-scheme: dark;
   --bg: #0e1525;
   --panel: #162236;
+  --panel-alt: #0f1d34;
   --accent: #7bffb7;
   --text: #e8f1ff;
+  --text-dim: #9fb2d1;
   --warning: #ffcc70;
+  --negative: #f08c42;
+  --alert: #ff8c8c;
+  --border: #223557;
+  --border-subtle: #1f2c4b;
+  --border-hover: #96d9ff;
+  --shadow-color: #0a1020;
   --grid: #0f1b2f;
 }
 
@@ -70,8 +78,8 @@ button.primary {
 }
 
 button.secondary {
-  background: #162236;
-  border: 2px solid #223557;
+  background: var(--panel);
+  border: 2px solid var(--border);
   color: #d9e6ff;
   border-radius: 10px;
   padding: 8px 12px;
@@ -83,13 +91,13 @@ button.secondary.active {
   background: #1f3354;
   border-color: var(--accent);
   color: var(--text);
-  box-shadow: 0 4px 0 #0a1020;
+  box-shadow: 0 4px 0 var(--shadow-color);
 }
 
 button.primary:hover,
 button.secondary:hover {
-  border-color: #96d9ff;
-  box-shadow: 0 4px 0 #0a1020;
+  border-color: var(--border-hover);
+  box-shadow: 0 4px 0 var(--shadow-color);
 }
 
 button.primary:active,
@@ -102,8 +110,8 @@ button.secondary.active {
 }
 
 .chip-button {
-  background: #162236;
-  border: 1px solid #223557;
+  background: var(--panel);
+  border: 1px solid var(--border);
   color: #d9e6ff;
   border-radius: 8px;
   padding: 6px 10px;

--- a/app/src/styles/base.css
+++ b/app/src/styles/base.css
@@ -15,7 +15,7 @@
   --border: #223557;
   --border-subtle: #1f2c4b;
   --border-hover: #96d9ff;
-  --shadow-color: #0a1020;
+  --shadow-colour: #0a1020;
   --grid: #0f1b2f;
 }
 
@@ -91,13 +91,13 @@ button.secondary.active {
   background: #1f3354;
   border-color: var(--accent);
   color: var(--text);
-  box-shadow: 0 4px 0 var(--shadow-color);
+  box-shadow: 0 4px 0 var(--shadow-colour);
 }
 
 button.primary:hover,
 button.secondary:hover {
   border-color: var(--border-hover);
-  box-shadow: 0 4px 0 var(--shadow-color);
+  box-shadow: 0 4px 0 var(--shadow-colour);
 }
 
 button.primary:active,

--- a/app/src/styles/debug.css
+++ b/app/src/styles/debug.css
@@ -23,7 +23,7 @@
 }
 
 .debug-section {
-  border-bottom: 1px solid #1f2c4b;
+  border-bottom: 1px solid var(--border-subtle);
   padding-bottom: 8px;
   margin-bottom: 8px;
 }
@@ -47,7 +47,7 @@
 }
 
 .debug-hint {
-  color: #9fb2d1;
+  color: var(--text-dim);
   font-size: 11px;
   margin-top: 2px;
 }

--- a/app/src/styles/hud.css
+++ b/app/src/styles/hud.css
@@ -21,13 +21,13 @@
 
 .map-stats {
   font-size: 11px;
-  color: #9fb2d1;
+  color: var(--text-dim);
 }
 
 .info-box {
   background: rgba(10, 16, 32, 0.8);
   padding: 10px;
-  border: 1px solid #1f2c4b;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
 }
 
@@ -44,7 +44,7 @@
 
 .info-label {
   font-size: 11px;
-  color: #9fb2d1;
+  color: var(--text-dim);
 }
 
 .info-name {
@@ -54,7 +54,7 @@
 
 .info-meta {
   font-size: 11px;
-  color: #9fb2d1;
+  color: var(--text-dim);
   margin-top: 2px;
 }
 
@@ -76,19 +76,19 @@
 
 .info-subtitle {
   font-size: 11px;
-  color: #9fb2d1;
+  color: var(--text-dim);
   margin-top: 2px;
 }
 
 .tool-hints {
   margin-top: 8px;
-  color: #9fb2d1;
+  color: var(--text-dim);
   font-size: 11px;
   line-height: 1.4;
 }
 
 .tool-hints.warning {
-  color: #f08c42;
+  color: var(--negative);
 }
 
 .tool-hints.subtle {
@@ -116,7 +116,7 @@
 
 .compact-info-tab {
   background: #132644;
-  border: 2px solid #223557;
+  border: 2px solid var(--border);
   border-radius: 10px;
   color: var(--text);
   padding: 8px 12px;
@@ -124,7 +124,7 @@
   font-family: inherit;
   font-size: 12px;
   cursor: pointer;
-  box-shadow: 0 4px 0 #0a1020;
+  box-shadow: 0 4px 0 var(--shadow-color);
 }
 
 .compact-info-tab.active {

--- a/app/src/styles/hud.css
+++ b/app/src/styles/hud.css
@@ -124,7 +124,7 @@
   font-family: inherit;
   font-size: 12px;
   cursor: pointer;
-  box-shadow: 0 4px 0 var(--shadow-color);
+  box-shadow: 0 4px 0 var(--shadow-colour);
 }
 
 .compact-info-tab.active {

--- a/app/src/styles/layout.css
+++ b/app/src/styles/layout.css
@@ -64,7 +64,7 @@
   border: 2px solid var(--border);
   border-radius: 10px;
   padding: 7px 10px;
-  box-shadow: 0 4px 0 var(--shadow-color);
+  box-shadow: 0 4px 0 var(--shadow-colour);
   font-size: 12px;
 }
 
@@ -142,7 +142,7 @@
   font-family: inherit;
   font-size: 13px;
   cursor: pointer;
-  box-shadow: 0 4px 0 var(--shadow-color);
+  box-shadow: 0 4px 0 var(--shadow-colour);
   list-style: none;
 }
 
@@ -152,7 +152,7 @@
 
 .ribbon-btn.active {
   border-color: var(--accent);
-  box-shadow: 0 4px 0 var(--shadow-color), 0 0 10px rgba(123, 255, 183, 0.25);
+  box-shadow: 0 4px 0 var(--shadow-colour), 0 0 10px rgba(123, 255, 183, 0.25);
 }
 
 /* Dropdowns for Saves and Debug. */

--- a/app/src/styles/layout.css
+++ b/app/src/styles/layout.css
@@ -11,7 +11,7 @@
      overflow: hidden to silently clip it with no way back in. */
   overflow-y: auto;
   background: #0d1731;
-  border-bottom: 2px solid #1f2c4b;
+  border-bottom: 2px solid var(--border-subtle);
   padding: 10px 16px;
   /* Keep controls clear of notches and rounded corners in viewport-fit=cover. */
   padding-top: calc(10px + env(safe-area-inset-top, 0px));
@@ -61,10 +61,10 @@
   gap: 5px;
   white-space: nowrap;
   background: var(--panel);
-  border: 2px solid #223557;
+  border: 2px solid var(--border);
   border-radius: 10px;
   padding: 7px 10px;
-  box-shadow: 0 4px 0 #0a1020;
+  box-shadow: 0 4px 0 var(--shadow-color);
   font-size: 12px;
 }
 
@@ -92,7 +92,7 @@
 }
 
 .ribbon-dim {
-  color: #9fb2d1;
+  color: var(--text-dim);
 }
 
 /* Compact horizontal RCI demand meters. */
@@ -111,7 +111,7 @@
   width: 88px;
   height: 8px;
   background: #0c1425;
-  border: 1px solid #1f2c4b;
+  border: 1px solid var(--border-subtle);
   border-radius: 4px;
   overflow: hidden;
 }
@@ -124,7 +124,7 @@
 
 .rci-label {
   font-size: 9px;
-  color: #9fb2d1;
+  color: var(--text-dim);
   width: 8px;
 }
 
@@ -136,13 +136,13 @@
   min-width: 34px;
   padding: 6px 8px;
   background: #132644;
-  border: 2px solid #223557;
+  border: 2px solid var(--border);
   border-radius: 10px;
   color: var(--text);
   font-family: inherit;
   font-size: 13px;
   cursor: pointer;
-  box-shadow: 0 4px 0 #0a1020;
+  box-shadow: 0 4px 0 var(--shadow-color);
   list-style: none;
 }
 
@@ -152,7 +152,7 @@
 
 .ribbon-btn.active {
   border-color: var(--accent);
-  box-shadow: 0 4px 0 #0a1020, 0 0 10px rgba(123, 255, 183, 0.25);
+  box-shadow: 0 4px 0 var(--shadow-color), 0 0 10px rgba(123, 255, 183, 0.25);
 }
 
 /* Dropdowns for Saves and Debug. */
@@ -183,8 +183,8 @@
   display: grid;
   gap: 6px;
   padding: 10px;
-  background: #0f1d34;
-  border: 2px solid #223557;
+  background: var(--panel-alt);
+  border: 2px solid var(--border);
   border-radius: 12px;
   box-shadow: 0 10px 18px rgba(0, 0, 0, 0.55);
   min-width: max-content;
@@ -196,10 +196,10 @@
 }
 
 .budget-net.positive {
-  color: #7bffb7;
+  color: var(--accent);
 }
 .budget-net.negative {
-  color: #ff8c8c;
+  color: var(--alert);
 }
 .budget-net.neutral {
   color: var(--text);
@@ -247,18 +247,18 @@ footer {
   padding-bottom: calc(12px + env(safe-area-inset-bottom, 0px));
   padding-left: calc(16px + env(safe-area-inset-left, 0px));
   padding-right: calc(16px + env(safe-area-inset-right, 0px));
-  border-top: 2px solid #1f2c4b;
-  color: #7bffb7;
+  border-top: 2px solid var(--border-subtle);
+  color: var(--accent);
 }
 
 .footer-link {
-  color: #96d9ff;
+  color: var(--border-hover);
   text-decoration: none;
   font-weight: bold;
 }
 
 .footer-link:hover {
-  color: #7bffb7;
+  color: var(--accent);
   text-decoration: underline;
 }
 

--- a/app/src/styles/loading-screen.css
+++ b/app/src/styles/loading-screen.css
@@ -49,7 +49,7 @@
 .ls-bld {
   position: absolute;
   bottom: 0;
-  background: #162236;
+  background: var(--panel);
   border-top: 2px solid #2a3f5f;
   border-left: 1px solid #1e3050;
   border-right: 1px solid #1e3050;
@@ -66,7 +66,7 @@
   position: absolute;
   width: 3px;
   height: 3px;
-  background: #7bffb7;
+  background: var(--accent);
   opacity: 0.55;
   image-rendering: pixelated;
   animation: ls-blink 2.8s infinite;

--- a/app/src/styles/minimap.css
+++ b/app/src/styles/minimap.css
@@ -8,7 +8,7 @@
   max-height: calc(100% - 24px);
   overflow-y: auto;
   background: rgba(12, 20, 40, 0.9);
-  border: 2px solid #223557;
+  border: 2px solid var(--border);
   border-radius: 12px;
   padding: 10px;
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.4);
@@ -36,7 +36,7 @@
 
 .minimap-subtitle {
   font-size: 11px;
-  color: #9fb2d1;
+  color: var(--text-dim);
 }
 
 .minimap-actions {
@@ -62,7 +62,7 @@
 
 .minimap-legend {
   background: rgba(12, 20, 40, 0.75);
-  border: 1px solid #1f2c4b;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   padding: 6px 8px;
 }
@@ -85,7 +85,7 @@
 .minimap-body {
   margin-top: 8px;
   background: rgba(9, 14, 26, 0.85);
-  border: 1px solid #1f2c4b;
+  border: 1px solid var(--border-subtle);
   border-radius: 10px;
   padding: 8px;
   display: grid;
@@ -106,7 +106,7 @@
   height: 100%;
   image-rendering: pixelated;
   background: #0b1424;
-  border: 1px solid #1f2c4b;
+  border: 1px solid var(--border-subtle);
   border-radius: 10px;
 }
 
@@ -119,7 +119,7 @@
 .minimap-hint {
   margin-top: 6px;
   font-size: 11px;
-  color: #9fb2d1;
+  color: var(--text-dim);
 }
 
 /* Matches deviceMode.ts's DEFAULT_COMPACT_BREAKPOINT_PX/

--- a/app/src/styles/modals/budget-ledger.css
+++ b/app/src/styles/modals/budget-ledger.css
@@ -23,7 +23,7 @@
   justify-content: space-between;
   align-items: baseline;
   font-size: 12px;
-  color: #9fb2d1;
+  color: var(--text-dim);
   margin-bottom: 4px;
 }
 
@@ -35,7 +35,7 @@
   display: flex;
   height: 14px;
   background: #0c1425;
-  border: 1px solid #1f2c4b;
+  border: 1px solid var(--border-subtle);
   border-radius: 7px;
   overflow: hidden;
 }
@@ -66,7 +66,7 @@
 .ledger-list-title {
   font-weight: 700;
   font-size: 13px;
-  color: #e8f1ff;
+  color: var(--text);
   margin-bottom: 6px;
 }
 
@@ -119,7 +119,7 @@
   display: flex;
   justify-content: space-between;
   font-size: 11px;
-  color: #9fb2d1;
+  color: var(--text-dim);
   padding: 1px 0 1px 14px;
 }
 
@@ -135,7 +135,7 @@
 .ledger-policy-heading {
   font-weight: 700;
   font-size: 14px;
-  color: #e8f1ff;
+  color: var(--text);
 }
 
 .ledger-policy-section {
@@ -158,7 +158,7 @@
 
 .ledger-slider-value {
   font-weight: 700;
-  color: #9fb2d1;
+  color: var(--text-dim);
 }
 
 .ledger-slider-value.off-neutral {
@@ -184,7 +184,7 @@
 
 .ledger-strip > div {
   background: #0a1224;
-  border: 1px solid #1f2c4b;
+  border: 1px solid var(--border-subtle);
   border-radius: 10px;
   padding: 10px 12px;
 }
@@ -227,16 +227,16 @@
 }
 
 .ledger-month-bar.positive {
-  background: #7bffb7;
+  background: var(--accent);
 }
 
 .ledger-month-bar.negative {
-  background: #ff8c8c;
+  background: var(--alert);
 }
 
 .ledger-month-label {
   font-size: 9px;
-  color: #9fb2d1;
+  color: var(--text-dim);
 }
 
 .ledger-quarter-net {
@@ -255,7 +255,7 @@
 }
 
 .ledger-insight[data-severity='high'] strong {
-  color: #ff8c8c;
+  color: var(--alert);
 }
 
 .ledger-recommendation {
@@ -263,11 +263,11 @@
 }
 
 .ledger-quarter-net .positive {
-  color: #7bffb7;
+  color: var(--accent);
 }
 
 .ledger-quarter-net .negative {
-  color: #ff8c8c;
+  color: var(--alert);
 }
 
 .budget-header {
@@ -280,11 +280,11 @@
 .budget-title {
   font-size: 18px;
   font-weight: 700;
-  color: #e8f1ff;
+  color: var(--text);
 }
 
 .budget-subtitle {
-  color: #9fb2d1;
+  color: var(--text-dim);
   font-size: 12px;
 }
 
@@ -301,7 +301,7 @@
 
 .summary-card {
   background: #0a1224;
-  border: 1px solid #1f2c4b;
+  border: 1px solid var(--border-subtle);
   border-radius: 10px;
   padding: 10px 12px;
   display: flex;
@@ -310,26 +310,26 @@
 }
 
 .summary-label {
-  color: #9fb2d1;
+  color: var(--text-dim);
   font-size: 12px;
 }
 
 .summary-value {
   font-size: 20px;
   font-weight: 700;
-  color: #e8f1ff;
+  color: var(--text);
 }
 
 .summary-value.positive {
-  color: #7bffb7;
+  color: var(--accent);
 }
 
 .summary-value.negative {
-  color: #f08c42;
+  color: var(--negative);
 }
 
 .summary-hint {
-  color: #9fb2d1;
+  color: var(--text-dim);
   font-size: 11px;
 }
 
@@ -344,7 +344,7 @@
 
 .budget-column {
   background: #0a1224;
-  border: 1px solid #1f2c4b;
+  border: 1px solid var(--border-subtle);
   border-radius: 10px;
   padding: 12px;
   display: flex;
@@ -357,12 +357,12 @@
 .budget-section-title {
   font-weight: 700;
   font-size: 15px;
-  color: #e8f1ff;
+  color: var(--text);
   letter-spacing: 0.01em;
 }
 
 .budget-hint {
-  color: #9fb2d1;
+  color: var(--text-dim);
   font-size: 11px;
   margin: 2px 0 6px;
 }
@@ -393,20 +393,20 @@
 }
 
 .budget-row-label.subtle {
-  color: #9fb2d1;
+  color: var(--text-dim);
 }
 
 .budget-row-value {
-  color: #e8f1ff;
+  color: var(--text);
   font-weight: 600;
 }
 
 .budget-row-value.positive {
-  color: #7bffb7;
+  color: var(--accent);
 }
 
 .budget-row-value.negative {
-  color: #f08c42;
+  color: var(--negative);
 }
 
 .budget-total {
@@ -416,7 +416,7 @@
   padding: 6px 0;
   font-weight: 700;
   font-size: 14px;
-  color: #e8f1ff;
+  color: var(--text);
 }
 
 .budget-total-label {
@@ -424,11 +424,11 @@
 }
 
 .budget-total-value.positive {
-  color: #7bffb7;
+  color: var(--accent);
 }
 
 .budget-total-value.negative {
-  color: #f08c42;
+  color: var(--negative);
 }
 
 .budget-row-bar {
@@ -445,20 +445,20 @@
 }
 
 .budget-bar.bar-positive {
-  background: linear-gradient(90deg, #5bc0eb, #7bffb7);
+  background: linear-gradient(90deg, #5bc0eb, var(--accent));
 }
 
 .budget-bar.bar-negative {
-  background: linear-gradient(90deg, #f08c42, #f45d48);
+  background: linear-gradient(90deg, var(--negative), #f45d48);
 }
 
 .budget-divider {
-  border-bottom: 1px solid #1f2c4b;
+  border-bottom: 1px solid var(--border-subtle);
   margin: 8px 0;
 }
 
 .budget-footer {
-  color: #9fb2d1;
+  color: var(--text-dim);
   font-size: 11px;
   padding: 4px 6px 2px;
 }
@@ -487,7 +487,7 @@
 }
 
 .budget-detail-hint {
-  color: #9fb2d1;
+  color: var(--text-dim);
   font-size: 11px;
   margin-top: -2px;
 }
@@ -510,7 +510,7 @@
 .budget-insights-item,
 .budget-insights-risk {
   background: #0f1a30;
-  border: 1px solid #1f2c4b;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   padding: 8px 10px;
   display: flex;
@@ -533,7 +533,7 @@
 }
 
 .budget-insights-label {
-  color: #e8f1ff;
+  color: var(--text);
   font-size: 12px;
   font-weight: 600;
 }

--- a/app/src/styles/modals/bylaws.css
+++ b/app/src/styles/modals/bylaws.css
@@ -21,18 +21,18 @@
 .bylaws-title {
   font-size: 18px;
   font-weight: 700;
-  color: #e8f1ff;
+  color: var(--text);
 }
 
 .bylaws-subtitle {
-  color: #9fb2d1;
+  color: var(--text-dim);
   font-size: 12px;
   max-width: 520px;
 }
 
 .bylaws-lede {
   background: #0a1224;
-  border: 1px solid #1f2c4b;
+  border: 1px solid var(--border-subtle);
   border-radius: 10px;
   padding: 10px 12px;
   color: #d8e6ff;
@@ -59,7 +59,7 @@
   gap: 8px;
   align-items: flex-start;
   padding: 10px;
-  border: 1px solid #1f2c4b;
+  border: 1px solid var(--border-subtle);
   border-radius: 10px;
   background: #0d1830;
   box-shadow: inset 0 1px 0 #132441;
@@ -82,7 +82,7 @@
 
 .bylaws-option-title {
   font-weight: 600;
-  color: #e8f1ff;
+  color: var(--text);
 }
 
 .bylaws-option-lede {
@@ -112,17 +112,17 @@
 
 .bylaws-delta.positive {
   border-color: #c28a43;
-  color: #ffcc70;
+  color: var(--warning);
 }
 
 .bylaws-delta.negative {
   border-color: #2e7b60;
-  color: #7bffb7;
+  color: var(--accent);
 }
 
 .bylaws-delta-label {
   font-size: 11px;
-  color: #9fb2d1;
+  color: var(--text-dim);
 }
 
 .bylaws-delta-value {
@@ -130,13 +130,13 @@
 }
 
 .bylaws-delta-hint {
-  color: #9fb2d1;
+  color: var(--text-dim);
   font-size: 12px;
 }
 
 .bylaws-section {
   background: #0a1224;
-  border: 1px solid #1f2c4b;
+  border: 1px solid var(--border-subtle);
   border-radius: 10px;
   padding: 10px 12px;
   display: flex;
@@ -145,13 +145,13 @@
 }
 
 .bylaws-section-title {
-  color: #e8f1ff;
+  color: var(--text);
   font-weight: 600;
   font-size: 14px;
 }
 
 .bylaws-section-hint {
-  color: #9fb2d1;
+  color: var(--text-dim);
   font-size: 12px;
 }
 
@@ -166,7 +166,7 @@
 }
 
 .bylaws-list strong {
-  color: #e8f1ff;
+  color: var(--text);
 }
 
 .bylaws-callout {
@@ -179,7 +179,7 @@
 }
 
 .bylaws-footer {
-  color: #9fb2d1;
+  color: var(--text-dim);
   font-size: 12px;
   padding: 0 2px 2px;
 }

--- a/app/src/styles/modals/modal-base.css
+++ b/app/src/styles/modals/modal-base.css
@@ -11,7 +11,7 @@
 
 .modal {
   background: #0f1b2f;
-  border: 2px solid #223557;
+  border: 2px solid var(--border);
   border-radius: 12px;
   box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
   width: min(90vw, 960px);

--- a/app/src/styles/modals/settings.css
+++ b/app/src/styles/modals/settings.css
@@ -24,11 +24,11 @@
 .settings-title {
   font-size: 18px;
   font-weight: 700;
-  color: #e8f1ff;
+  color: var(--text);
 }
 
 .settings-subtitle {
-  color: #9fb2d1;
+  color: var(--text-dim);
   font-size: 12px;
 }
 
@@ -41,7 +41,7 @@
 
 .settings-section {
   background: #0a1224;
-  border: 1px solid #1f2c4b;
+  border: 1px solid var(--border-subtle);
   border-radius: 10px;
   padding: 10px;
   display: grid;
@@ -56,11 +56,11 @@
 
 .settings-section-title {
   font-weight: 700;
-  color: #e8f1ff;
+  color: var(--text);
 }
 
 .settings-section-hint {
-  color: #9fb2d1;
+  color: var(--text-dim);
   font-size: 12px;
 }
 
@@ -79,11 +79,11 @@
 
 .settings-label {
   font-weight: 600;
-  color: #e8f1ff;
+  color: var(--text);
 }
 
 .settings-description {
-  color: #9fb2d1;
+  color: var(--text-dim);
   font-size: 12px;
 }
 
@@ -96,9 +96,9 @@
 .settings-row select,
 .settings-row input[type="range"],
 .settings-row input[type="text"] {
-  background: #0f1d34;
-  border: 1px solid #223557;
-  color: #e8f1ff;
+  background: var(--panel-alt);
+  border: 1px solid var(--border);
+  color: var(--text);
   border-radius: 8px;
   padding: 6px 8px;
 }
@@ -112,12 +112,12 @@
 }
 
 .settings-warning {
-  color: #9fb2d1;
+  color: var(--text-dim);
   font-size: 12px;
 }
 
 .settings-warning.error {
-  color: #f08c42;
+  color: var(--negative);
 }
 
 .hotkey-table {
@@ -133,6 +133,6 @@
 }
 
 .hotkey-row-header {
-  color: #9fb2d1;
+  color: var(--text-dim);
   font-size: 12px;
 }

--- a/app/src/styles/news-ticker.css
+++ b/app/src/styles/news-ticker.css
@@ -4,7 +4,7 @@
   gap: 12px;
   padding: 6px 16px;
   background: linear-gradient(90deg, #101b33 0%, #12284a 55%, #101b33 100%);
-  border-bottom: 2px solid #223557;
+  border-bottom: 2px solid var(--border);
   box-shadow: inset 0 -3px 0 #0a0f1b;
   font-size: 11px;
   letter-spacing: 0.3px;
@@ -18,7 +18,7 @@
 
 .news-ticker-label {
   text-transform: uppercase;
-  color: #7bffb7;
+  color: var(--accent);
   font-weight: bold;
 }
 
@@ -48,11 +48,11 @@
 }
 
 .news-ticker-alert .news-ticker-text {
-  color: #ff8c8c;
+  color: var(--alert);
 }
 
 .news-ticker-warn .news-ticker-text {
-  color: #ffcc70;
+  color: var(--warning);
 }
 
 .news-ticker-info .news-ticker-text {

--- a/app/src/styles/radio.css
+++ b/app/src/styles/radio.css
@@ -10,7 +10,7 @@
   cursor: pointer;
   font-size: 16px;
   line-height: 1;
-  box-shadow: 0 2px 0 var(--shadow-color);
+  box-shadow: 0 2px 0 var(--shadow-colour);
   transition: border-color 0.1s ease, transform 0.1s ease;
   display: flex;
   align-items: center;
@@ -145,7 +145,7 @@
   cursor: pointer;
   font-size: 15px;
   line-height: 1;
-  box-shadow: 0 2px 0 var(--shadow-color);
+  box-shadow: 0 2px 0 var(--shadow-colour);
   transition: border-color 0.1s ease, transform 0.1s ease;
 }
 

--- a/app/src/styles/radio.css
+++ b/app/src/styles/radio.css
@@ -10,7 +10,7 @@
   cursor: pointer;
   font-size: 16px;
   line-height: 1;
-  box-shadow: 0 2px 0 #0a1020;
+  box-shadow: 0 2px 0 var(--shadow-color);
   transition: border-color 0.1s ease, transform 0.1s ease;
   display: flex;
   align-items: center;
@@ -18,7 +18,7 @@
 }
 
 .radio-station-button:hover {
-  border-color: #96d9ff;
+  border-color: var(--border-hover);
 }
 
 .radio-station-button:active {
@@ -36,8 +36,8 @@
   left: 0;
   top: 0;
   min-width: 220px;
-  background: #0f1d34;
-  border: 2px solid #223557;
+  background: var(--panel-alt);
+  border: 2px solid var(--border);
   border-radius: 12px;
   box-shadow: 0 10px 20px rgba(0, 0, 0, 0.35);
   padding: 8px;
@@ -63,7 +63,7 @@
   background: #1a2d4f;
   border: 1px solid #2a3f63;
   border-radius: 8px;
-  color: #e8f1ff;
+  color: var(--text);
   padding: 6px 8px;
   text-align: left;
   cursor: pointer;
@@ -71,12 +71,12 @@
 }
 
 .radio-station-menu-item:hover {
-  border-color: #96d9ff;
+  border-color: var(--border-hover);
   background: #223d65;
 }
 
 .radio-station-menu-item-active {
-  border-color: #7bffb7;
+  border-color: var(--accent);
   background: #1f3a5f;
 }
 
@@ -115,7 +115,7 @@
   height: 32px;
   border-radius: 8px;
   object-fit: cover;
-  border: 1px solid #223557;
+  border: 1px solid var(--border);
   display: block;
   flex-shrink: 0;
   background: #0b1424;
@@ -145,12 +145,12 @@
   cursor: pointer;
   font-size: 15px;
   line-height: 1;
-  box-shadow: 0 2px 0 #0a1020;
+  box-shadow: 0 2px 0 var(--shadow-color);
   transition: border-color 0.1s ease, transform 0.1s ease;
 }
 
 .radio-icon-button:hover {
-  border-color: #96d9ff;
+  border-color: var(--border-hover);
 }
 
 .radio-icon-button:active {
@@ -173,7 +173,7 @@
 .radio-marquee-text {
   white-space: nowrap;
   font-size: 11px;
-  color: #e8f1ff;
+  color: var(--text);
 }
 
 .radio-marquee-text.scrolling {
@@ -200,7 +200,7 @@
   display: flex;
   gap: 10px;
   background: #101c34;
-  border: 2px solid #223557;
+  border: 2px solid var(--border);
   border-radius: 10px;
   padding: 8px;
   box-shadow: 0 10px 20px rgba(0, 0, 0, 0.35);
@@ -217,7 +217,7 @@
   height: 64px;
   border-radius: 10px;
   object-fit: cover;
-  border: 1px solid #223557;
+  border: 1px solid var(--border);
   display: none;
   background: #0b1424;
 }
@@ -235,7 +235,7 @@
 
 .radio-popover-title {
   font-weight: bold;
-  color: #7bffb7;
+  color: var(--accent);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -251,7 +251,7 @@
 
 .radio-popover-status {
   font-size: 11px;
-  color: #96d9ff;
+  color: var(--border-hover);
 }
 
 .radio-popover-open .radio-popover {

--- a/app/src/styles/toolbar.css
+++ b/app/src/styles/toolbar.css
@@ -67,7 +67,7 @@
   font-size: 14px;
   font-weight: bold;
   cursor: pointer;
-  box-shadow: 0 4px 0 var(--shadow-color), 0 0 12px rgba(123, 255, 183, 0.25);
+  box-shadow: 0 4px 0 var(--shadow-colour), 0 0 12px rgba(123, 255, 183, 0.25);
 }
 
 .tool-sheet-backdrop {
@@ -134,7 +134,7 @@
   font-family: inherit;
   font-size: 12px;
   cursor: pointer;
-  box-shadow: 0 4px 0 var(--shadow-color);
+  box-shadow: 0 4px 0 var(--shadow-colour);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -201,7 +201,7 @@
 
 .toolbar-group-sub-open {
   border-color: var(--accent);
-  box-shadow: 0 4px 0 var(--shadow-color), 0 0 10px rgba(123, 255, 183, 0.22);
+  box-shadow: 0 4px 0 var(--shadow-colour), 0 0 10px rgba(123, 255, 183, 0.22);
   z-index: 2004;
 }
 
@@ -232,7 +232,7 @@
   font-size: 11px;
   cursor: pointer;
   transition: transform 0.1s ease, border-color 0.1s ease;
-  box-shadow: 0 4px 0 var(--shadow-color);
+  box-shadow: 0 4px 0 var(--shadow-colour);
   height: 44px;
   display: inline-flex;
   align-items: center;
@@ -269,7 +269,7 @@
   border: 2px solid var(--border);
   border-radius: 14px;
   padding: 8px 8px;
-  box-shadow: 0 4px 0 var(--shadow-color);
+  box-shadow: 0 4px 0 var(--shadow-colour);
   position: relative;
   overflow: visible;
   z-index: 2002;

--- a/app/src/styles/toolbar.css
+++ b/app/src/styles/toolbar.css
@@ -9,8 +9,8 @@
   padding-left: calc(16px + env(safe-area-inset-left, 0px));
   padding-right: calc(16px + env(safe-area-inset-right, 0px));
   background: #0d1a2f;
-  border-top: 2px solid #1f2c4b;
-  border-bottom: 2px solid #1f2c4b;
+  border-top: 2px solid var(--border-subtle);
+  border-bottom: 2px solid var(--border-subtle);
   position: absolute;
   left: 0;
   right: 0;
@@ -67,7 +67,7 @@
   font-size: 14px;
   font-weight: bold;
   cursor: pointer;
-  box-shadow: 0 4px 0 #0a1020, 0 0 12px rgba(123, 255, 183, 0.25);
+  box-shadow: 0 4px 0 var(--shadow-color), 0 0 12px rgba(123, 255, 183, 0.25);
 }
 
 .tool-sheet-backdrop {
@@ -94,7 +94,7 @@
   max-height: 60dvh;
   overflow-y: auto;
   background: #0d1a2f;
-  border-top: 2px solid #1f2c4b;
+  border-top: 2px solid var(--border-subtle);
   border-radius: 16px 16px 0 0;
   padding: 16px;
   padding-bottom: calc(16px + env(safe-area-inset-bottom, 0px));
@@ -115,7 +115,7 @@
   flex-wrap: wrap;
   gap: 8px;
   padding-bottom: 10px;
-  border-bottom: 1px solid #1f2c4b;
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .tool-sheet-group:last-child {
@@ -125,7 +125,7 @@
 
 .tool-sheet-button {
   background: #132644;
-  border: 2px solid #223557;
+  border: 2px solid var(--border);
   border-radius: 12px;
   color: var(--text);
   padding: 10px 14px;
@@ -134,7 +134,7 @@
   font-family: inherit;
   font-size: 12px;
   cursor: pointer;
-  box-shadow: 0 4px 0 #0a1020;
+  box-shadow: 0 4px 0 var(--shadow-color);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -166,8 +166,8 @@
   padding: 8px 10px;
   margin: 0;
   align-self: flex-start;
-  background: #0f1d34;
-  border: 2px solid #223557;
+  background: var(--panel-alt);
+  border: 2px solid var(--border);
   border-radius: 14px;
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.5);
   width: fit-content;
@@ -183,25 +183,25 @@
   left: 10px;
   right: 10px;
   height: 6px;
-  background: #0f1d34;
-  border-left: 2px solid #223557;
-  border-right: 2px solid #223557;
-  border-top: 2px solid #223557;
+  background: var(--panel-alt);
+  border-left: 2px solid var(--border);
+  border-right: 2px solid var(--border);
+  border-top: 2px solid var(--border);
   border-radius: 12px 12px 0 0;
 }
 
 .toolbar-sub.toolbar-sub-open {
-  border-color: #223557;
+  border-color: var(--border);
   box-shadow: 0 10px 18px rgba(0, 0, 0, 0.55);
 }
 
 .toolbar-sub.toolbar-sub-open::before {
-  border-color: #223557;
+  border-color: var(--border);
 }
 
 .toolbar-group-sub-open {
   border-color: var(--accent);
-  box-shadow: 0 4px 0 #0a1020, 0 0 10px rgba(123, 255, 183, 0.22);
+  box-shadow: 0 4px 0 var(--shadow-color), 0 0 10px rgba(123, 255, 183, 0.22);
   z-index: 2004;
 }
 
@@ -212,10 +212,10 @@
   right: 10px;
   bottom: -6px;
   height: 8px;
-  background: #0f1d34;
-  border-left: 2px solid #223557;
-  border-right: 2px solid #223557;
-  border-bottom: 2px solid #223557;
+  background: var(--panel-alt);
+  border-left: 2px solid var(--border);
+  border-right: 2px solid var(--border);
+  border-bottom: 2px solid var(--border);
   border-top: none;
   border-radius: 0 0 12px 12px;
   z-index: -1;
@@ -224,7 +224,7 @@
 .tool-button,
 .tool-sub-button {
   background: #132644;
-  border: 2px solid #223557;
+  border: 2px solid var(--border);
   border-radius: 12px;
   color: var(--text);
   padding: 10px 12px;
@@ -232,7 +232,7 @@
   font-size: 11px;
   cursor: pointer;
   transition: transform 0.1s ease, border-color 0.1s ease;
-  box-shadow: 0 4px 0 #0a1020;
+  box-shadow: 0 4px 0 var(--shadow-color);
   height: 44px;
   display: inline-flex;
   align-items: center;
@@ -249,7 +249,7 @@
 
 .tool-button:hover,
 .tool-sub-button:hover {
-  border-color: #96d9ff;
+  border-color: var(--border-hover);
 }
 
 .tool-button:disabled,
@@ -257,7 +257,7 @@
   opacity: 0.45;
   cursor: not-allowed;
   transform: none;
-  border-color: #223557;
+  border-color: var(--border);
   box-shadow: none;
 }
 
@@ -265,11 +265,11 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  background: #0f1d34;
-  border: 2px solid #223557;
+  background: var(--panel-alt);
+  border: 2px solid var(--border);
   border-radius: 14px;
   padding: 8px 8px;
-  box-shadow: 0 4px 0 #0a1020;
+  box-shadow: 0 4px 0 var(--shadow-color);
   position: relative;
   overflow: visible;
   z-index: 2002;


### PR DESCRIPTION
Follow-up to #106 (the style.css split). Auditing the newly-split files for shareable commonalities, per your ask.

## Summary

- `base.css` already defined `--accent`, `--text`, `--warning`, `--panel`, `--bg`, `--grid`, but they weren't consistently referenced — `#7bffb7` (== `--accent`) and `#e8f1ff` (== `--text`) each appeared as bare hex literals 15-19 times across other files.
- Several more values recur dozens of times with no token at all: `#9fb2d1` dim/secondary text (31x), `#223557` border (27x), `#1f2c4b` subtle border/divider (22x), `#0a1020` the button drop-shadow colour (13x), `#96d9ff` hover border (7x), `#0f1d34` secondary panel surface (7x).
- Adds `--text-dim`, `--border`, `--border-subtle`, `--border-hover`, `--shadow-colour`, `--negative`, `--alert`, and `--panel-alt` to `base.css`, then replaces every non-definition occurrence of these values (existing and new) with the matching `var(--token)` — 155 replacements across 13 files.
- Kept `--negative` (`#f08c42`, orange — budget/financial negatives) and `--alert` (`#ff8c8c`, red — ticker/ribbon alerts) as two separate tokens rather than merging them; they're visually close but used for genuinely different things.

### Maintainer-facing changes

Retheming any of these eight values (e.g. adjusting the border colour) now touches one `:root` line instead of hunting down scattered literals across a dozen files.

### Naming

`--shadow-colour` uses Canadian spelling, per this repo's convention — it's our own custom-property identifier, not a CSS/DOM spec property name (unlike `box-shadow` or `color-scheme`, which must keep standard spelling).

### Known limitations

Deliberately lightweight — spacing/radius/font-size weren't tokenized, and there's no broader documented design-system scale. This closes the gap between "there are already tokens" and "they're actually used" rather than building something more ambitious a single-app stylesheet doesn't need yet.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run test` — 145/145 non-`jsdom` tests pass locally (pre-existing machine-local jsdom quirk, unrelated — CI is authoritative there)
- [x] `bun run build` succeeds
- [x] Verified with a resolve-and-diff script (parses old and new stylesheets with `tinycss2`, substitutes every `var()` reference back to its resolved literal value via the `:root` definitions, diffs the two rule sets): identical resolved values — every substitution is a visual no-op
- [x] Spot-checked with Playwright screenshots (desktop HUD + minimap, the City Ledger/budget modal — the file with the most replacements): pixel-identical, zero console errors

