### PR TITLE
Show tool cost in the compact picker and dock

### DIFF
--- a/app/src/styles/toolbar.css
+++ b/app/src/styles/toolbar.css
@@ -136,9 +136,17 @@
   cursor: pointer;
   box-shadow: 0 4px 0 var(--shadow-colour);
   display: inline-flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: 2px;
+}
+
+/* No hover on touch, so cost lives on the button itself (see toolbar.ts's
+   createToolButton) rather than behind a highlight/focus state. */
+.tool-sheet-button-cost {
+  font-size: 10px;
+  color: var(--text-dim);
 }
 
 /* The full radio widget (flex-basis 360px, marquee + cover art) is sized for

--- a/app/src/ui/toolbar.ts
+++ b/app/src/ui/toolbar.ts
@@ -4,10 +4,19 @@
 // SPDX-License-Identifier: MIT
 
 import { Tool } from '../game/toolTypes';
-import { getToolHotkey, primaryLabelOverrides, toolLabels } from './toolInfo';
+import { getToolDetails, getToolHotkey, primaryLabelOverrides, toolLabels } from './toolInfo';
 import { initRadioWidget, type RadioWidget } from './radio';
 import { fetchRadioStations, type RadioStation } from './radioStations';
 import type { LayoutMode } from './deviceMode';
+
+// There's no hover on touch, so unlike the desktop shell's hover-driven
+// .overlay card, the compact sheet can't rely on a highlight/focus state to
+// reveal cost — every button just shows its own, and the current-tool dock
+// button (which stays visible after the sheet closes) carries it forward
+// right up to the moment of tapping the canvas.
+function getToolCostLabel(tool: Tool): string | undefined {
+  return getToolDetails(tool).rows.find((row) => row.label === 'Cost')?.value;
+}
 
 const powerOptions: Tool[] = [
   Tool.PowerLine,
@@ -75,10 +84,24 @@ export function initToolbar(
   const createToolButton = (key: Tool, className: string) => {
     const button = document.createElement('button');
     button.className = className;
-    button.textContent = primaryLabelOverrides[key] ?? toolLabels[key];
     const hotkey = getToolHotkey(key);
     button.title = hotkey ? `${toolLabels[key]} (${hotkey})` : toolLabels[key];
     button.dataset.tool = key;
+    if (className === 'tool-sheet-button') {
+      const label = document.createElement('span');
+      label.className = 'tool-sheet-button-label';
+      label.textContent = primaryLabelOverrides[key] ?? toolLabels[key];
+      button.append(label);
+      const costLabel = getToolCostLabel(key);
+      if (costLabel) {
+        const cost = document.createElement('span');
+        cost.className = 'tool-sheet-button-cost';
+        cost.textContent = costLabel;
+        button.append(cost);
+      }
+    } else {
+      button.textContent = primaryLabelOverrides[key] ?? toolLabels[key];
+    }
     button.addEventListener('click', () => {
       onSelect(key);
       updateToolbar(toolbar, key);
@@ -420,7 +443,9 @@ export function updateToolbar(toolbar: HTMLElement, active: Tool) {
   if (toolbar.dataset.layoutMode === 'compact') {
     const currentToolBtn = toolbar.querySelector<HTMLButtonElement>('.toolbar-current-tool-btn');
     if (currentToolBtn) {
-      currentToolBtn.textContent = primaryLabelOverrides[active] ?? toolLabels[active];
+      const label = primaryLabelOverrides[active] ?? toolLabels[active];
+      const costLabel = getToolCostLabel(active);
+      currentToolBtn.textContent = costLabel ? `${label} · ${costLabel}` : label;
     }
     toolbar.querySelectorAll('.tool-sheet-button').forEach((btn) => {
       const key = btn.getAttribute('data-tool');

--- a/docs/mobile-web-plan.md
+++ b/docs/mobile-web-plan.md
@@ -111,12 +111,16 @@ when tools are added.*
   behind the sheet or a secondary button. Hit targets ≥ ~44px. `deps:` M0-1, M0-3.
   **DoD:** every tool and admin action reachable in compact mode; adding a tool to
   `groupedTools` appears in both shells with no extra wiring; full layout unchanged. (#103)
-- [ ] **M2-2 · Tool info in the picker.** `toolInfo.ts` content (cost, description)
-  shown for the highlighted tool inside the sheet, replacing hover. `deps:` M2-1.
-  **DoD:** cost is visible before placing in compact mode. More load-bearing than it
-  was: M2-4 suppresses the old always-on tool-info card in compact mode entirely
-  (it was eating the same footprint the minimap/inspector needed), so tool cost has
-  no compact-mode home at all until this ships.
+- [x] **M2-2 · Tool info in the picker.** No hover on touch, so instead of a
+  highlight-driven reveal, every button in the compact sheet shows its own cost
+  directly (`toolbar.ts`'s `createToolButton`, sourced from the same
+  `toolInfo.ts` `getToolDetails` the desktop hover card uses) — free tools like
+  Inspect just show no badge. The current-tool dock button carries the cost
+  forward too (e.g. "Road · $5.00"), so it stays visible after the sheet closes,
+  right up to tapping the canvas. Full description/hints text intentionally left
+  out of the tiny grid buttons; cost was the DoD and what M2-4 actually left with
+  no compact-mode home. `deps:` M2-1.
+  **DoD:** cost is visible before placing in compact mode. (#108)
 - [ ] **M2-3 · Prominent undo.** Surface the existing undo (P5-5) as a visible button
   in the compact HUD — mis-taps cost money and undo is the cheap fix. `deps:` M2-1.
   **DoD:** undo reachable in one tap; shows the same "Undone" notification.


### PR DESCRIPTION
Part of the mobile web plan (epic #61) — Phase M2's second item, M2-2. Follows up on #104, which left a real gap: the desktop shell's tool-info card (cost, description) is hover-driven, and M2-4 suppressed that card entirely in compact mode since it was fighting the minimap/inspector for the same footprint. Since then, compact mode has had no way to see a tool's cost before placing it.

## Summary

- There's no hover on touch, so instead of trying to recreate a highlight/focus-driven reveal, every button in the compact tool sheet now shows its own cost directly — sourced from the same `toolInfo.ts` `getToolDetails` the desktop hover card already uses. Free tools (Inspect) just show no badge.
- The current-tool dock button carries the cost forward too (e.g. "Road · $5.00"), so it's still visible after the sheet closes — arguably the more useful of the two spots, since it's the one still on screen right up to the moment of tapping the canvas.
- `.tool-sheet-button` becomes a column flex (label over cost) instead of a single row. Desktop's `.tool-button` class is untouched.

### User-facing changes

Compact layout: every tool in the picker sheet shows its cost, and the current-tool button keeps showing it after you've picked one.

### Known limitations

Full description/hints text is intentionally left out of the small grid buttons — cost was the actual DoD here and the gap M2-4 left open. Longer tool descriptions on touch remain part of M1-4 ("hover replacement"), not addressed by this PR.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run test` — 145/145 non-`jsdom` tests pass locally (pre-existing machine-local jsdom quirk, unrelated — CI is authoritative there)
- [x] Verified with Playwright: compact portrait (390×844) and landscape (926×428) both show cost on every priced sheet button and on the dock button after selecting one; desktop (1280×900) unchanged — still label-only, relies on its existing hover card; zero console errors throughout
- [ ] Not yet tested on a real device
