### PR TITLE
Persist the command log so undo stops wiping tiles across a reload

### DIFF
--- a/app/src/game/persistence.ts
+++ b/app/src/game/persistence.ts
@@ -242,17 +242,27 @@ export function copyState(state: GameState): GameState {
   return deserialize(serialize(state));
 }
 
-export function saveToBrowser(state: GameState) {
-  localStorage.setItem(LOCAL_STORAGE_KEY, serialize(state));
+export type CmdLogEntry = { tool: string; x: number; y: number };
+
+// Carries the command log alongside the state, same as downloadState/
+// uploadState below — without it, a bridge rebuilt from this save (every
+// page load, or an explicit Load) has no history to undo *from*, so its
+// first undo rolls all the way back to the engine's compiled-in starting
+// scenario instead of one step back from the loaded save.
+export function saveToBrowser(state: GameState, cmdLog?: CmdLogEntry[]) {
+  const data: Record<string, unknown> = JSON.parse(serialize(state));
+  if (cmdLog?.length) data.cmdLog = cmdLog;
+  localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(data));
 }
 
-export function loadFromBrowser(): GameState | null {
+export function loadFromBrowser(): { state: GameState; cmdLog?: CmdLogEntry[] } | null {
   const data = localStorage.getItem(LOCAL_STORAGE_KEY);
   if (!data) return null;
-  return deserialize(data);
+  const raw = JSON.parse(data) as Record<string, unknown>;
+  const { cmdLog, ...stateData } = raw;
+  const state = deserialize(JSON.stringify(stateData));
+  return { state, cmdLog: Array.isArray(cmdLog) ? (cmdLog as CmdLogEntry[]) : undefined };
 }
-
-export type CmdLogEntry = { tool: string; x: number; y: number };
 
 export function downloadState(
   state: GameState,

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -364,7 +364,12 @@ function cancelPendingTouchApply() {
 let activeTool: Tool = Tool.Inspect;
 let selectedTool: Tool = Tool.Inspect;
 let temporaryTool: Tool | null = null;
-let state: GameState = loadFromBrowser() ?? createInitialState();
+const browserSave = loadFromBrowser();
+let state: GameState = browserSave?.state ?? createInitialState();
+// Without this, a bridge built from a loaded save has no command history to
+// undo *from* — its first undo would roll the sim all the way back to its
+// compiled-in starting scenario instead of one step back from the save.
+const initialCmdLog = browserSave?.cmdLog;
 state.settings = ensureSettingsShape(state.settings);
 // Dev override, same pattern as `?bridge=`: forces `desktop`/`mobile` for
 // this load. Unlike the bridge param, this mutates `state.settings` (the
@@ -385,11 +390,15 @@ const inTauri = '__TAURI_INTERNALS__' in window;
 const isTauri = bridgeParam === 'tauri' || (inTauri && bridgeParam !== 'wasm' && bridgeParam !== 'ts');
 const isTs    = bridgeParam === 'ts';
 let activeBridgeKind: 'wasm' | 'local' | 'tauri' = isTauri ? 'tauri' : isTs ? 'local' : 'wasm';
+// Same cast the file-upload path already uses (see bindPersistenceControls'
+// onStateLoaded below) — persisted command logs are loosely typed (`tool` is
+// a plain string on disk) versus the bridges' stricter runtime Tool type.
+const typedInitialCmdLog = initialCmdLog as { tool: Tool; x: number; y: number }[] | undefined;
 let bridge: SimBridge = isTauri
   ? new TauriSimBridge(state)
   : isTs
-    ? new LocalSimBridge(state, { ticksPerSecond: 20 })
-    : new WasmSimBridge(state);
+    ? new LocalSimBridge(state, { ticksPerSecond: 20, initialCmdLog: typedInitialCmdLog })
+    : new WasmSimBridge(state, {}, typedInitialCmdLog?.length ? typedInitialCmdLog : undefined);
 
 const loadingScreen = initLoadingScreen(document.body);
 

--- a/app/src/ui/dialogs.ts
+++ b/app/src/ui/dialogs.ts
@@ -113,7 +113,7 @@ export function bindPersistenceControls(options: PersistenceOptions) {
   const { saveBtn, loadBtn, downloadBtn, uploadBtn, fileInput, getState, getCmdLog, onStateLoaded } = options;
 
   saveBtn.addEventListener('click', () => {
-    saveToBrowser(getState());
+    saveToBrowser(getState(), getCmdLog?.());
     showToast('Saved to browser');
   });
 
@@ -123,7 +123,7 @@ export function bindPersistenceControls(options: PersistenceOptions) {
       showToast('No save found');
       return;
     }
-    onStateLoaded(loaded);
+    onStateLoaded(loaded.state, loaded.cmdLog);
     showToast('Loaded from browser');
   });
 


### PR DESCRIPTION
Found while building M2-3 (a prominent, one-tap undo button — see `docs/mobile-web-plan.md`), which surfaces the existing `Ctrl`/`Cmd`+`Z` undo path far more prominently and made this much easier to hit.

## Summary

Reproduced with the game's own MCP debug bridge, using the pre-existing, completely unmodified `Ctrl`/`Cmd`+`Z` path (no code of mine involved in the repro): on a fresh page load, placing one tile and undoing it correctly reverted that tile — but the whole simulation also silently reset to the engine's hardcoded starting scenario (tick 0, $100,000, population 12), discarding the rest of the loaded save.

- **Root cause**: `saveToBrowser`/`loadFromBrowser` only ever persisted the `GameState` snapshot, never the command log — unlike `downloadState`/`uploadState` (the file save/load path), which already carry it correctly. Without a command log, a bridge rebuilt from a loaded save (every page load, or an explicit Load) has no history for undo to replay from, so its first undo rolls the Rust engine all the way back to `Simulation::new()`'s defaults instead of one step back from the save.
- `persistence.ts`: `saveToBrowser`/`loadFromBrowser` now carry `cmdLog` alongside state, mirroring the `downloadState`/`uploadState` shape.
- `dialogs.ts`: the Save/Load buttons now actually pass it through (`getCmdLog` was already threaded in for the download button but unused by Save; Load never had anywhere to get one from).
- `main.ts`: the initial bridge construction (page load) now seeds `preloadCommands` from the loaded save's command log, the same way `swapSimBridge` already does when switching bridges mid-session.

### Known limitations

This is a real improvement — tiles placed before a reload/Load no longer get wiped by a later undo — but it does **not** fully fix undo. Filed #109 for the remaining gap: the simulation's stats (tick/day/population/money) still snap back to defaults once an undo reaches back into a loaded save's replayed history, because the Rust engine's bulk-replay path (`wasmSim.worker.ts`'s `'init'`/`'load'` handlers) applies all preloaded commands before fast-forwarding ticks, so they're all internally recorded at tick 0 — a deeper, Rust-side fix (see the issue for two suggested directions).

M2-3 (the prominent undo button UI) is built and tested, parked on `mobile-web/prominent-undo`, and will resume once this and/or #109 land.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run test` — 145/145 non-`jsdom` tests pass locally (pre-existing machine-local jsdom quirk, unrelated — CI is authoritative there)
- [x] Verified with the MCP debug bridge across an actual save/reload cycle: placed a road, saved (confirmed `cmdLog` now present in `localStorage`), reloaded fresh, placed a second road, undid it — the second road correctly reverted **and the first road (placed before the reload) survived**, where before this fix the whole map would have been wiped back to empty
- [ ] Stats (tick/day/population) after that same undo are still wrong — tracked separately as #109, not fixed by this PR
