### PR TITLE
Browser autosave with newest-wins restore on boot

### DIFF
--- a/app/public/manual.html
+++ b/app/public/manual.html
@@ -131,6 +131,7 @@
       <li><strong>Download</strong> exports a <code>.citysim</code> file so you can back your city up or move it between devices.</li>
       <li><strong>Upload</strong> restores any exported city — including JSON saves downloaded before the <code>.citysim</code> format existed; old browser saves are upgraded automatically the first time you play.</li>
       <li>Loading a save starts a fresh undo history — the loaded city is the floor that undo can never damage.</li>
+      <li><strong>Autosave</strong>: the game quietly saves to its own slot every minute while you play, and whenever the tab is hidden or closed. If a crash or accidental refresh strikes, the game restores whichever save is newest and tells you (e.g. "Restored autosave from 2 min ago"). Your manual Save slot is never overwritten by autosave.</li>
     </ul>
 
     <h2>The status ribbon</h2>

--- a/app/src/game/autosave.test.ts
+++ b/app/src/game/autosave.test.ts
@@ -1,0 +1,145 @@
+// autosave.test.ts — timing/trigger logic for the browser autosave.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  initAutosave,
+  type AutosaveController,
+  type AutosaveDocument,
+  type AutosaveWindow
+} from './autosave';
+import { pickNewestSave, type SaveRecord } from './saveStore';
+
+/** Minimal event-target fakes so the timing logic tests run in plain node. */
+class FakeDoc implements AutosaveDocument {
+  visibilityState: DocumentVisibilityState = 'visible';
+  private listeners = new Map<string, Set<() => void>>();
+  addEventListener(type: string, listener: () => void) {
+    const set = this.listeners.get(type) ?? new Set();
+    set.add(listener);
+    this.listeners.set(type, set);
+  }
+  removeEventListener(type: string, listener: () => void) {
+    this.listeners.get(type)?.delete(listener);
+  }
+  emit(type: string) {
+    this.listeners.get(type)?.forEach((l) => l());
+  }
+}
+class FakeWin extends FakeDoc implements AutosaveWindow {}
+
+describe('initAutosave', () => {
+  let controller: AutosaveController | null = null;
+  let doc: FakeDoc;
+  let win: FakeWin;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    doc = new FakeDoc();
+    win = new FakeWin();
+  });
+
+  afterEach(() => {
+    controller?.dispose();
+    controller = null;
+    vi.useRealTimers();
+  });
+
+  it('saves on the interval while the tick advances', async () => {
+    let tick = 0;
+    const save = vi.fn(() => Promise.resolve());
+    controller = initAutosave({ intervalMs: 1000, getTick: () => tick, save, doc, win });
+    tick = 10;
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(save).toHaveBeenCalledTimes(1);
+    tick = 20;
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(save).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips when the tick has not advanced since the last save', async () => {
+    const save = vi.fn(() => Promise.resolve());
+    controller = initAutosave({ intervalMs: 1000, getTick: () => 42, save, doc, win });
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(save).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not stack a second save while one is in flight', async () => {
+    let tick = 0;
+    let resolveSave!: () => void;
+    const save = vi.fn(() => new Promise<void>((resolve) => { resolveSave = resolve; }));
+    controller = initAutosave({ intervalMs: 1000, getTick: () => (tick += 1), save, doc, win });
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(save).toHaveBeenCalledTimes(1);
+    resolveSave();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(save).toHaveBeenCalledTimes(2);
+  });
+
+  it('flushes when the document becomes hidden and on pagehide', async () => {
+    let tick = 0;
+    const save = vi.fn(() => Promise.resolve());
+    controller = initAutosave({ intervalMs: 60_000, getTick: () => (tick += 1), save, doc, win });
+    doc.visibilityState = 'hidden';
+    doc.emit('visibilitychange');
+    expect(save).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(0);
+    win.emit('pagehide');
+    expect(save).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports errors and keeps running', async () => {
+    let tick = 0;
+    const onError = vi.fn();
+    const save = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error('quota'))
+      .mockResolvedValue(undefined);
+    controller = initAutosave({ intervalMs: 1000, getTick: () => (tick += 1), save, onError, doc, win });
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(onError).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(save).toHaveBeenCalledTimes(2);
+  });
+
+  it('dispose stops the timer and listeners', async () => {
+    let tick = 0;
+    const save = vi.fn(() => Promise.resolve());
+    controller = initAutosave({ intervalMs: 1000, getTick: () => (tick += 1), save, doc, win });
+    controller.dispose();
+    controller = null;
+    await vi.advanceTimersByTimeAsync(5000);
+    win.emit('pagehide');
+    expect(save).not.toHaveBeenCalled();
+  });
+});
+
+describe('pickNewestSave', () => {
+  const record = (id: 'manual' | 'autosave', savedAt: string): SaveRecord => ({
+    id,
+    meta: {
+      savedAt, kind: id, width: 8, height: 8, seed: 1,
+      tick: 0, day: 1, population: 0, money: 0
+    },
+    container: new ArrayBuffer(0)
+  });
+
+  it('prefers the newer record', () => {
+    const manual = record('manual', '2026-07-22T10:00:00.000Z');
+    const autosave = record('autosave', '2026-07-22T11:00:00.000Z');
+    expect(pickNewestSave(manual, autosave)?.id).toBe('autosave');
+    expect(pickNewestSave(record('manual', '2026-07-22T12:00:00.000Z'), autosave)?.id).toBe('manual');
+  });
+
+  it('handles missing slots and favours manual on ties or bad timestamps', () => {
+    const manual = record('manual', '2026-07-22T10:00:00.000Z');
+    expect(pickNewestSave(null, null)).toBeNull();
+    expect(pickNewestSave(manual, null)?.id).toBe('manual');
+    expect(pickNewestSave(null, record('autosave', '2026-07-22T10:00:00.000Z'))?.id).toBe('autosave');
+    expect(pickNewestSave(manual, record('autosave', manual.meta.savedAt))?.id).toBe('manual');
+    expect(pickNewestSave(manual, record('autosave', 'not-a-date'))?.id).toBe('manual');
+  });
+});

--- a/app/src/game/autosave.ts
+++ b/app/src/game/autosave.ts
@@ -1,0 +1,85 @@
+// autosave.ts — periodic browser autosave plus save-on-hide.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+// Timing and trigger logic only — the caller supplies the actual save (an
+// async write of a CSAV container into the dedicated `'autosave'` IndexedDB
+// slot). Saving is a pure read of the engine, so an autosave can never touch
+// the undo history; the manual save slot is never written by this module.
+
+/** The slice of `document` the autosave listens to — injectable for tests. */
+export interface AutosaveDocument {
+  addEventListener: (type: string, listener: () => void) => void;
+  removeEventListener: (type: string, listener: () => void) => void;
+  readonly visibilityState: DocumentVisibilityState;
+}
+
+/** The slice of `window` the autosave listens to — injectable for tests. */
+export interface AutosaveWindow {
+  addEventListener: (type: string, listener: () => void) => void;
+  removeEventListener: (type: string, listener: () => void) => void;
+}
+
+export interface AutosaveOptions {
+  /** Milliseconds between periodic attempts. Default 60 000. */
+  intervalMs?: number;
+  /** Current sim tick — attempts are skipped while it hasn't advanced. */
+  getTick: () => number;
+  /** Perform the save (encode + write to the `'autosave'` slot). */
+  save: () => Promise<void>;
+  /** Called on save failure (the interval keeps running). */
+  onError?: (err: unknown) => void;
+  /** Injectable for tests; defaults to the real `document`/`window`. */
+  doc?: AutosaveDocument;
+  win?: AutosaveWindow;
+}
+
+export interface AutosaveController {
+  /** Fire an attempt now (also used by the hide/pagehide listeners). */
+  flush: () => void;
+  dispose: () => void;
+}
+
+export function initAutosave(options: AutosaveOptions): AutosaveController {
+  const intervalMs = options.intervalMs ?? 60_000;
+  const doc = options.doc ?? document;
+  const win = options.win ?? window;
+  let lastSavedTick = -1;
+  let inFlight = false;
+
+  const attempt = () => {
+    if (inFlight) return;
+    const tick = options.getTick();
+    // Paused or idle since the last write — nothing new to preserve.
+    if (tick === lastSavedTick) return;
+    inFlight = true;
+    options
+      .save()
+      .then(() => {
+        lastSavedTick = tick;
+      })
+      .catch((err) => options.onError?.(err))
+      .finally(() => {
+        inFlight = false;
+      });
+  };
+
+  const timer = setInterval(attempt, intervalMs);
+  // Tab hidden or being unloaded — the moments a refresh/crash would
+  // otherwise lose everything since the last periodic write.
+  const onVisibility = () => {
+    if (doc.visibilityState === 'hidden') attempt();
+  };
+  doc.addEventListener('visibilitychange', onVisibility);
+  win.addEventListener('pagehide', attempt);
+
+  return {
+    flush: attempt,
+    dispose() {
+      clearInterval(timer);
+      doc.removeEventListener('visibilitychange', onVisibility);
+      win.removeEventListener('pagehide', attempt);
+    }
+  };
+}

--- a/app/src/game/saveStore.ts
+++ b/app/src/game/saveStore.ts
@@ -90,3 +90,19 @@ export async function listSaveMetas(): Promise<{ id: SaveSlotId; meta: SaveMeta 
 export async function deleteSave(id: SaveSlotId): Promise<void> {
   await withStore('readwrite', store => store.delete(id));
 }
+
+/**
+ * The record to restore on boot: whichever of the two slots has the later
+ * `savedAt`. Ties (or an invalid timestamp on one side) favour the manual
+ * save — the deliberate one.
+ */
+export function pickNewestSave(
+  manual: SaveRecord | null,
+  autosave: SaveRecord | null
+): SaveRecord | null {
+  if (!manual) return autosave;
+  if (!autosave) return manual;
+  const manualAt = Date.parse(manual.meta.savedAt);
+  const autoAt = Date.parse(autosave.meta.savedAt);
+  return Number.isFinite(autoAt) && autoAt > manualAt ? autosave : manual;
+}

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -33,7 +33,8 @@ import {
   type SaveContainer
 } from './game/persistence';
 import { applyClientState, ensureSettingsShape, extractClientState } from './game/clientState';
-import { getSave, putSave } from './game/saveStore';
+import { getSave, pickNewestSave, putSave } from './game/saveStore';
+import { initAutosave } from './game/autosave';
 import { initMcpBridge } from './game/mcpBridge';
 import { createCamera, centerCamera, screenToTile, zoomAt } from './rendering/camera';
 import { MapRenderer, Position } from './rendering/renderer';
@@ -468,12 +469,31 @@ function afterCityLoaded(): void {
   minimap?.markDirty();
 }
 
-/** Boot-time restore: CSAV from IndexedDB, else the legacy localStorage save. */
+/** "just now" / "5 min ago" / "3 h ago" — for the autosave-restore toast. */
+function formatAgo(iso: string): string {
+  const ms = Date.now() - Date.parse(iso);
+  if (!Number.isFinite(ms) || ms < 0) return 'just now';
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours} h ago`;
+}
+
+/**
+ * Boot-time restore: the newest of the manual and autosave slots (a crash or
+ * refresh should cost at most one autosave interval), else the legacy
+ * localStorage save.
+ */
 async function bootLoadSave(): Promise<void> {
   try {
-    const record = await getSave('manual');
+    const [manual, autosave] = await Promise.all([getSave('manual'), getSave('autosave')]);
+    const record = pickNewestSave(manual, autosave);
     if (record) {
       await loadCityContainer(decodeSave(new Uint8Array(record.container)));
+      if (record.id === 'autosave') {
+        showToast(`Restored autosave from ${formatAgo(record.meta.savedAt)}`);
+      }
       return;
     }
     const legacy = loadLegacyBrowserSave();
@@ -486,9 +506,33 @@ async function bootLoadSave(): Promise<void> {
   }
 }
 
+/**
+ * Start the periodic autosave — only after the boot restore has resolved, so
+ * a freshly booted default city can never overwrite a real autosave.
+ */
+function startAutosave(): void {
+  let warnedOnce = false;
+  initAutosave({
+    getTick: () => state.tick,
+    save: async () => {
+      const engineSnapshot = await bridge.getSnapshot();
+      const meta = buildSaveMeta(state, 'autosave', new Date().toISOString());
+      const bytes = encodeSave({ meta, engineSnapshot, client: extractClientState(state) });
+      await putSave('autosave', meta, bytes);
+    },
+    onError: (err) => {
+      console.error('[autosave] failed', err);
+      if (!warnedOnce) {
+        warnedOnce = true;
+        showToast('Autosave failed — use Download to back up your city', { severity: 'warning' });
+      }
+    }
+  });
+}
+
 wireBridge(bridge);
 initMcpBridge(bridge, state);
-void bootLoadSave();
+void bootLoadSave().finally(startAutosave);
 
 let debugOverlay: ReturnType<typeof initDebugOverlay> | null = null;
 let hotkeys: HotkeyController | null = null;

--- a/docs/mobile-web-plan.md
+++ b/docs/mobile-web-plan.md
@@ -146,12 +146,13 @@ when tools are added.*
 *Goal: nobody loses a city — on any platform. Mobile browsers discard background tabs
 aggressively, and desktop browser sessions currently don't autosave either.*
 
-- [ ] **M3-1 · Autosave (all platforms).** Periodic autosave to localStorage (existing
+- [x] **M3-1 · Autosave (all platforms).** Periodic autosave to localStorage (existing
   serialize path) plus save-on-`visibilitychange`/`pagehide`. Applies to desktop and
   mobile alike. Pause the sim (and radio, if playing) while hidden. `deps:` none.
   **DoD:** backgrounding the tab mid-game and having it discarded loses at most the
   last few seconds; desktop refresh mid-game restores the city; no save spam while
   the tab stays visible.
+  *Shipped (#117):* IndexedDB `'autosave'` slot (CSAV container, not localStorage — better than planned), 60 s cadence skipping idle ticks, `visibilitychange`/`pagehide` flushes, newest-wins boot restore with a toast. "Pause sim while hidden" was superseded by #116 — the sim now genuinely runs in background tabs via the worker clock.
 - [ ] **M3-2 · Durable storage request.** Call `navigator.storage.persist()` (once,
   post-first-save) to reduce eviction risk; surface quota problems as a notification
   rather than a silent failure. `deps:` M3-1.


### PR DESCRIPTION
## Summary

- **Autosave, finally** (#117): every 60 s while you play — skipping paused/idle ticks and in-flight writes — plus a flush whenever the tab is hidden (`visibilitychange`) or unloaded (`pagehide`). Writes go to the dedicated `'autosave'` IndexedDB slot; the manual Save slot is never overwritten, and because saving is a pure engine read, autosave can never clear the undo history.
- **Newest-wins boot**: page load restores whichever of manual/autosave is newer (`pickNewestSave`, ties favour the manual save) and says so — "Restored autosave from 2 min ago". The autosave loop starts only after the boot restore resolves, so a freshly booted default city can never clobber a real autosave.
- Failures (private-mode/quota) toast once with a pointer to Download, and the loop keeps trying.
- `docs/mobile-web-plan.md` M3-1 checked off: shipped on IndexedDB CSAV containers rather than the planned localStorage JSON; "pause sim while hidden" is superseded by #116's background clock. `navigator.storage.persist()` remains M3-2.

**Stacked on** #118 (`feat/worker-sim-clock`) — merge #118 first, then retarget/merge this (the two compose: hidden tabs keep simulating *and* keep getting autosaved).

## Test plan

- [x] `bun run lint`; `bun run test` — 165 tests (8 new timing/trigger tests with injectable `document`/`window` fakes, no jsdom dependency; `pickNewestSave` units)
- [x] Playwright end-to-end: wipe slots → place a road → dispatch `pagehide` → the `'autosave'` record exists with the right meta; reload → city restored exactly (road intact, tick continuous from the autosaved value) and the "Restored autosave from just now" toast appears
- [x] Manual slot untouched throughout (only the `'autosave'` record exists in the store in the E2E run)

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnxdyzXk3wbY1cJ12oaHVT

