### PR TITLE
Durable storage request after first save

### DIFF
--- a/app/src/game/durableStorage.test.ts
+++ b/app/src/game/durableStorage.test.ts
@@ -1,0 +1,86 @@
+// durableStorage.test.ts — the once-only persist() request.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  requestDurableStorage,
+  resetDurableStorageRequestForTests,
+  type StorageManagerLike
+} from './durableStorage';
+
+describe('requestDurableStorage', () => {
+  beforeEach(() => {
+    resetDurableStorageRequestForTests();
+  });
+
+  afterEach(() => {
+    resetDurableStorageRequestForTests();
+  });
+
+  it('skips persist() when already persisted, and logs it', async () => {
+    const manager: StorageManagerLike = {
+      persisted: vi.fn().mockResolvedValue(true),
+      persist: vi.fn().mockResolvedValue(true)
+    };
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+    requestDurableStorage(manager);
+    await vi.waitFor(() => expect(manager.persisted).toHaveBeenCalledTimes(1));
+    expect(manager.persist).not.toHaveBeenCalled();
+    expect(info).toHaveBeenCalledWith(expect.stringContaining('already granted'));
+    info.mockRestore();
+  });
+
+  it('requests persist() and logs the granted result', async () => {
+    const manager: StorageManagerLike = {
+      persisted: vi.fn().mockResolvedValue(false),
+      persist: vi.fn().mockResolvedValue(true)
+    };
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+    requestDurableStorage(manager);
+    await vi.waitFor(() => expect(manager.persist).toHaveBeenCalledTimes(1));
+    expect(info).toHaveBeenCalledWith(expect.stringContaining('granted'));
+    info.mockRestore();
+  });
+
+  it('logs the declined result', async () => {
+    const manager: StorageManagerLike = {
+      persisted: vi.fn().mockResolvedValue(false),
+      persist: vi.fn().mockResolvedValue(false)
+    };
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+    requestDurableStorage(manager);
+    await vi.waitFor(() => expect(manager.persist).toHaveBeenCalledTimes(1));
+    expect(info).toHaveBeenCalledWith(expect.stringContaining('declined'));
+    info.mockRestore();
+  });
+
+  it('is a no-op when navigator.storage is absent', () => {
+    expect(() => requestDurableStorage(undefined)).not.toThrow();
+  });
+
+  it('only fires once, subsequent calls are no-ops', async () => {
+    const manager: StorageManagerLike = {
+      persisted: vi.fn().mockResolvedValue(false),
+      persist: vi.fn().mockResolvedValue(true)
+    };
+    requestDurableStorage(manager);
+    requestDurableStorage(manager);
+    requestDurableStorage(manager);
+    await vi.waitFor(() => expect(manager.persist).toHaveBeenCalledTimes(1));
+    expect(manager.persisted).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports errors without throwing', async () => {
+    const manager: StorageManagerLike = {
+      persisted: vi.fn().mockRejectedValue(new Error('denied')),
+      persist: vi.fn()
+    };
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => requestDurableStorage(manager)).not.toThrow();
+    await vi.waitFor(() => expect(error).toHaveBeenCalledTimes(1));
+    expect(manager.persist).not.toHaveBeenCalled();
+    error.mockRestore();
+  });
+});

--- a/app/src/game/durableStorage.ts
+++ b/app/src/game/durableStorage.ts
@@ -1,0 +1,44 @@
+// durableStorage.ts — best-effort request for durable (eviction-resistant) browser storage.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+// Fired once, after the first successful save write (see `saveStore.putSave`).
+// `navigator.storage.persist()` only reduces — never eliminates — the chance
+// the browser evicts IndexedDB under storage pressure, but it's cheap to ask
+// and cheap to skip where unsupported.
+
+export interface StorageManagerLike {
+  persisted: () => Promise<boolean>;
+  persist: () => Promise<boolean>;
+}
+
+let requested = false;
+
+/** Test-only: clears the once-guard between cases. */
+export function resetDurableStorageRequestForTests(): void {
+  requested = false;
+}
+
+/**
+ * Fire-and-forget: no-op after the first call (module-level guard), and a
+ * no-op wherever `navigator.storage` (or an injected equivalent) is absent.
+ */
+export function requestDurableStorage(manager?: StorageManagerLike | null): void {
+  if (requested) return;
+  requested = true;
+  const mgr = manager ?? (typeof navigator === 'undefined' ? undefined : navigator.storage);
+  if (!mgr) return;
+  void (async () => {
+    try {
+      if (await mgr.persisted()) {
+        console.info('[storage] durable storage already granted');
+        return;
+      }
+      const granted = await mgr.persist();
+      console.info(`[storage] durable storage ${granted ? 'granted' : 'declined'}`);
+    } catch (err) {
+      console.error('[storage] durable storage request failed', err);
+    }
+  })();
+}

--- a/app/src/game/saveStore.ts
+++ b/app/src/game/saveStore.ts
@@ -4,14 +4,15 @@
 // SPDX-License-Identifier: MIT
 
 // Binary-native storage for browser saves: no base64 bloat, no 5 MB
-// localStorage ceiling, async writes off the frame budget — and ready for the
-// planned periodic autosave (M3) plus `navigator.storage.persist()`.
+// localStorage ceiling, async writes off the frame budget.
 //
-// One record per slot (`'manual'` now; `'autosave'` later). The whole CSAV
-// blob is stored verbatim alongside its decoded meta, so save pickers can
-// list cities without decoding postcard.
+// One record per slot (`'manual'`, `'autosave'`). The whole CSAV blob is
+// stored verbatim alongside its decoded meta, so save pickers can list
+// cities without decoding postcard. Every successful write also fires a
+// (once-only, fire-and-forget) `navigator.storage.persist()` request.
 
 import type { SaveMeta } from './persistence';
+import { requestDurableStorage } from './durableStorage';
 
 const DB_NAME = 'city-sim-1000';
 const DB_VERSION = 1;
@@ -73,6 +74,7 @@ async function withStore<T>(
 export async function putSave(id: SaveSlotId, meta: SaveMeta, container: Uint8Array): Promise<void> {
   const copy = container.slice().buffer as ArrayBuffer;
   await withStore('readwrite', store => store.put({ id, meta, container: copy } satisfies SaveRecord));
+  requestDurableStorage();
 }
 
 /** Fetch a slot's record, or null when the slot is empty. */

--- a/docs/mobile-web-plan.md
+++ b/docs/mobile-web-plan.md
@@ -153,11 +153,17 @@ aggressively, and desktop browser sessions currently don't autosave either.*
   last few seconds; desktop refresh mid-game restores the city; no save spam while
   the tab stays visible.
   *Shipped (#117):* IndexedDB `'autosave'` slot (CSAV container, not localStorage — better than planned), 60 s cadence skipping idle ticks, `visibilitychange`/`pagehide` flushes, newest-wins boot restore with a toast. "Pause sim while hidden" was superseded by #116 — the sim now genuinely runs in background tabs via the worker clock.
-- [ ] **M3-2 · Durable storage request.** Call `navigator.storage.persist()` (once,
+- [x] **M3-2 · Durable storage request.** Call `navigator.storage.persist()` (once,
   post-first-save) to reduce eviction risk; surface quota problems as a notification
   rather than a silent failure. `deps:` M3-1.
   **DoD:** persistence request made and result logged; a failed save (quota) tells
   the player to export.
+  *Shipped (#120):* `durableStorage.ts` fires a once-only, fire-and-forget
+  `navigator.storage.persist()` request from `saveStore.putSave` after every
+  successful write (checks `persisted()` first, `console.info`s the outcome).
+  The "failed save tells the player to export" half of the DoD already
+  existed (the `dialogs.ts` save-button toast and `main.ts`'s `startAutosave`
+  `onError` toast both point at Download) — verified, not duplicated.
 - [ ] **M3-3 · Share-based save export on touch.** The download/upload save flow is
   awkward on phones — offer Web Share API export where available, falling back to
   the existing download path. `deps:` M0-1.


### PR DESCRIPTION
## Summary

- **Requests durable storage once a save has landed:** `durableStorage.ts` calls `navigator.storage.persist()` after the first successful `saveStore.putSave` write, fire-and-forget, guarded by a module-level once-only flag so repeat saves don't re-request.
- **Checks before asking:** calls `persisted()` first and skips the `persist()` request entirely if already granted; logs the granted/declined/already-granted outcome via `console.info` (errors via `console.error`).
- **Safe everywhere:** no-ops when `navigator`/`navigator.storage` is unavailable (older browsers, non-browser test environments).
- **Verified (not duplicated) the "tell the player to export" half of the DoD:** the existing save-button toast in `dialogs.ts` ("Save failed — try Download instead") and the `startAutosave` `onError` toast in `main.ts` ("Autosave failed — use Download to back up your city") already cover this.

Closes #120

### User-facing changes
None visible in normal play — this only affects browser storage eviction odds under storage pressure.

### Documentation
Checked off M3-2 in `docs/mobile-web-plan.md` with a "shipped" note.

## Test plan
- [x] `bun run lint` — clean.
- [x] `bun run test` — all 171 tests pass, including 6 new `durableStorage.test.ts` cases (already-persisted skip, granted, declined, absent-manager no-op, once-only guard, error handling). One pre-existing unrelated `html-encoding-sniffer` unhandled-error warning from this machine's local jsdom environment (documented gotcha, not introduced by this change) — does not fail any test.
- [ ] CI green on the PR (pending).