### PR TITLE
Playwright mobile emulation e2e suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,58 @@ jobs:
             echo "- Run URL: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           } >> "${GITHUB_STEP_SUMMARY}"
 
+  mobile-e2e:
+    name: Mobile e2e (Playwright)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@wasm-pack
+
+      - name: Build WASM target
+        run: bun run build:wasm
+
+      - name: Install Playwright browsers
+        run: cd app && bunx playwright install --with-deps chromium
+
+      - name: Run mobile e2e suite
+        id: mobile_e2e
+        run: bun run test:e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: app/playwright-report/
+          if-no-files-found: warn
+
+      - name: Write summary
+        if: always()
+        run: |
+          {
+            echo "## Mobile e2e (Playwright)"
+            echo
+            echo "- Runner: \`ubuntu-24.04\`"
+            echo "- Result: \`${{ steps.mobile_e2e.outcome }}\`"
+            echo "- Command: \`bun run test:e2e\` (mobile-portrait + mobile-landscape projects)"
+            echo "- Report artefact: \`app/playwright-report/\`"
+            echo "- Run URL: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
   tauri-plugin-build:
     name: Tauri plugin build
     runs-on: ubuntu-24.04
@@ -343,6 +395,7 @@ jobs:
       - ts-typecheck
       - ts-test
       - wasm-build
+      - mobile-e2e
       - tauri-plugin-build
     runs-on: ubuntu-latest
     steps:
@@ -362,6 +415,7 @@ jobs:
             const tsCheck    = '${{ needs.ts-typecheck.result }}';
             const tsTests    = '${{ needs.ts-test.result }}';
             const wasmBuild  = '${{ needs.wasm-build.result }}';
+            const mobileE2e  = '${{ needs.mobile-e2e.result }}';
             const tauriBuild = '${{ needs.tauri-plugin-build.result }}';
 
             const body = [
@@ -375,6 +429,7 @@ jobs:
               `- ${label(tsCheck)} TypeScript typecheck: \`${tsCheck}\``,
               `- ${label(tsTests)} TypeScript tests: \`${tsTests}\``,
               `- ${label(wasmBuild)} WASM build: \`${wasmBuild}\``,
+              `- ${label(mobileE2e)} Mobile e2e (Playwright): \`${mobileE2e}\``,
               `- ${label(tauriBuild)} Tauri plugin build: \`${tauriBuild}\``,
             ].join('\n');
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,6 +275,9 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
+      - name: Restore Rust cache
+        uses: swatinem/rust-cache@v2
+
       - name: Install wasm-pack
         uses: taiki-e/install-action@wasm-pack
 
@@ -312,6 +315,9 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
+      - name: Restore Rust cache
+        uses: swatinem/rust-cache@v2
+
       - name: Install wasm-pack
         uses: taiki-e/install-action@wasm-pack
 
@@ -320,6 +326,12 @@ jobs:
 
       - name: Build Tauri plugin JS
         run: bun run build:plugin-js
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
 
       - name: Install Playwright browsers
         run: cd app && bunx playwright install --with-deps chromium

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,6 +318,9 @@ jobs:
       - name: Build WASM target
         run: bun run build:wasm
 
+      - name: Build Tauri plugin JS
+        run: bun run build:plugin-js
+
       - name: Install Playwright browsers
         run: cd app && bunx playwright install --with-deps chromium
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ app/src/wasm/
 
 # Playwright MCP session artifacts (screenshots, console logs, page snapshots)
 .playwright-mcp/
+
+# Playwright/vitest test output (app/test-results/junit.xml is a CI artefact, not a commit)
+app/test-results/
+app/playwright-report/
+app/blob-report/

--- a/app/e2e/mobile.spec.ts
+++ b/app/e2e/mobile.spec.ts
@@ -1,0 +1,145 @@
+// mobile.spec.ts — mobile emulation coverage (M5-2), run in both the
+// mobile-portrait and mobile-landscape Playwright projects.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { test, expect, type Page } from '@playwright/test';
+
+declare global {
+  interface Window {
+    __mcpTest: (method: string, params?: Record<string, unknown>) => Promise<unknown>;
+  }
+}
+
+/** Boots the app with the MCP debug bridge active and waits past the loading screen. */
+async function boot(page: Page): Promise<void> {
+  await page.goto('/?mcp');
+  await page.waitForSelector('#loading-screen', { state: 'detached', timeout: 30_000 });
+}
+
+function mcp(page: Page, method: string, params?: Record<string, unknown>): Promise<unknown> {
+  return page.evaluate(
+    ({ method, params }) => window.__mcpTest(method, params),
+    { method, params }
+  );
+}
+
+test.describe('mobile emulation', () => {
+  test('compact layout renders with current-tool button and undo', async ({ page }) => {
+    await boot(page);
+    await expect(page.locator('.toolbar[data-layout-mode="compact"]')).toBeVisible();
+    await expect(page.locator('.toolbar-current-tool-btn')).toBeVisible();
+    const undoBtn = page.locator('.toolbar-undo-btn');
+    await expect(undoBtn).toBeVisible();
+    await expect(undoBtn).toBeDisabled();
+  });
+
+  test('tool sheet opens, picks Road, and closes', async ({ page }) => {
+    await boot(page);
+    const sheet = page.locator('.tool-sheet');
+    await expect(sheet).not.toHaveClass(/open/);
+
+    await page.locator('.toolbar-current-tool-btn').tap();
+    await expect(sheet).toHaveClass(/open/);
+
+    await page.locator('.tool-sheet-button[data-tool="road"]').tap();
+    await expect(sheet).not.toHaveClass(/open/);
+    await expect(page.locator('.toolbar')).toHaveAttribute('data-active-tool', 'road');
+  });
+
+  test('two-finger gesture pans the camera without painting a tile', async ({ page }) => {
+    await boot(page);
+    await mcp(page, 'set_speed', { multiplier: 0 });
+
+    // Road is the active tool so a stray one-finger touch would leave visible
+    // evidence — the gesture below must be read as camera control, not paint.
+    await page.locator('.toolbar-current-tool-btn').tap();
+    await page.locator('.tool-sheet-button[data-tool="road"]').tap();
+
+    const box = await page.locator('#canvas-wrapper').boundingBox();
+    if (!box) throw new Error('#canvas-wrapper has no layout box');
+    const cx = box.x + box.width / 2;
+    const cy = box.y + box.height / 2;
+
+    // Playwright's own (CDP-based) element screenshot, not the MCP `screenshot`
+    // op — that reads the WebGL canvas via `toDataURL()`, which races the
+    // browser's implicit buffer clear (no `preserveDrawingBuffer`) and can
+    // return a stale/blank capture unrelated to what's actually on screen.
+    const before = await page.locator('#canvas-wrapper').screenshot();
+
+    await page.evaluate(({ cx, cy }) => {
+      const wrapper = document.querySelector('#canvas-wrapper');
+      if (!wrapper) throw new Error('#canvas-wrapper missing');
+      const fire = (type: string, id: number, x: number, y: number) => {
+        wrapper.dispatchEvent(
+          new PointerEvent(type, {
+            pointerId: id,
+            pointerType: 'touch',
+            clientX: x,
+            clientY: y,
+            bubbles: true,
+            cancelable: true,
+            isPrimary: id === 1,
+            buttons: 1
+          })
+        );
+      };
+      // Both fingers land in the same tick — well inside the 60 ms grace
+      // window `main.ts` gives a first touch before committing a paint — then
+      // move apart while shifting sideways, which both pans and pinch-zooms.
+      fire('pointerdown', 1, cx - 30, cy);
+      fire('pointerdown', 2, cx + 30, cy);
+      fire('pointermove', 1, cx - 70, cy - 25);
+      fire('pointermove', 2, cx + 70, cy + 25);
+      fire('pointerup', 1, cx - 70, cy - 25);
+      fire('pointerup', 2, cx + 70, cy + 25);
+    }, { cx, cy });
+
+    // Let the render loop pick up the new camera position.
+    await page.waitForTimeout(200);
+
+    const after = await page.locator('#canvas-wrapper').screenshot();
+    expect(before.equals(after)).toBe(false);
+
+    const roadTiles = await mcp(page, 'get_tiles_where', { kind: 'road' });
+    expect(roadTiles).toEqual([]);
+  });
+
+  test('autosave fires on visibilitychange', async ({ page }) => {
+    await boot(page);
+    await mcp(page, 'apply_tool', { tool: 'road', x: 2, y: 2 });
+    // Give the sim clock a moment to advance the tick past the autosave
+    // module's initial sentinel, so the hidden-tab flush isn't skipped as "no
+    // new tick since the last write".
+    await page.waitForTimeout(500);
+
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        get: () => 'hidden'
+      });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            () =>
+              new Promise<boolean>((resolve, reject) => {
+                const openReq = indexedDB.open('city-sim-1000');
+                openReq.onerror = () => reject(openReq.error);
+                openReq.onsuccess = () => {
+                  const db = openReq.result;
+                  const getReq = db.transaction('saves', 'readonly').objectStore('saves').get('autosave');
+                  getReq.onerror = () => reject(getReq.error);
+                  getReq.onsuccess = () => resolve(getReq.result != null);
+                };
+              })
+          ),
+        { timeout: 10_000 }
+      )
+      .toBe(true);
+  });
+});

--- a/app/package.json
+++ b/app/package.json
@@ -10,6 +10,7 @@
     "lint": "tsc --noEmit",
     "test": "vitest run --pool=threads --poolOptions.threads.singleThread=true",
     "test:ci": "vitest run --pool=threads --poolOptions.threads.singleThread=true --reporter=verbose --reporter=junit --outputFile.junit=test-results/junit.xml",
+    "test:e2e": "playwright test",
     "build:favicon": "node scripts/generate-favicon.mjs",
     "build:radio-playlist": "tsx scripts/build-radio-playlist.ts --extract-embedded-covers"
   },
@@ -20,6 +21,7 @@
   },
   "devDependencies": {
     "@napi-rs/canvas": "^0.1.83",
+    "@playwright/test": "^1.61.1",
     "@types/node": "^24.10.1",
     "fake-indexeddb": "^6.2.5",
     "jsdom": "^27.2.0",

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -1,0 +1,37 @@
+// playwright.config.ts — mobile emulation e2e coverage (M5-2).
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+// Two projects share one spec (`e2e/mobile.spec.ts`): portrait and landscape
+// on the same device profile, dimensions swapped. Both land in the compact
+// layout — `deviceMode.ts`'s breakpoint triggers on width OR height, and a
+// landscape phone is short even though it's not narrow.
+import { defineConfig, devices } from '@playwright/test';
+
+const PORTRAIT = devices['Pixel 5'];
+const LANDSCAPE = {
+  ...PORTRAIT,
+  viewport: { width: PORTRAIT.viewport.height, height: PORTRAIT.viewport.width }
+};
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['html', { open: 'never' }], ['list']] : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'retain-on-failure'
+  },
+  projects: [
+    { name: 'mobile-portrait', use: { ...PORTRAIT } },
+    { name: 'mobile-landscape', use: { ...LANDSCAPE } }
+  ],
+  webServer: {
+    command: 'bun run build && bun run preview -- --port 4173',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000
+  }
+});

--- a/app/src/game/mcpBridge.ts
+++ b/app/src/game/mcpBridge.ts
@@ -278,19 +278,20 @@ export function initMcpBridge(bridge: SimBridge, state: GameState): void {
 
   connect();
 
-  // Dev-only helper: lets Playwright smoke-test the bridge without a real MCP client.
-  if (import.meta.env.DEV) {
-    (window as unknown as Record<string, unknown>).__mcpTest = (
-      method: string,
-      params?: Record<string, unknown>,
-    ) =>
-      new Promise((resolve, reject) => {
-        const id = crypto.randomUUID();
-        replyOverrides.set(id, (result, error) => {
-          if (error) reject(new Error(error));
-          else resolve(result);
-        });
-        void handleCommand({ id, method, params: params ?? {} });
+  // Lets Playwright (or any script) drive the bridge directly without a real
+  // MCP server — gated the same way the rest of this module is, by the
+  // explicit `?mcp` opt-in above, so it ships in production builds too (the
+  // mobile e2e suite runs against a built `vite preview`, not the dev server).
+  (window as unknown as Record<string, unknown>).__mcpTest = (
+    method: string,
+    params?: Record<string, unknown>,
+  ) =>
+    new Promise((resolve, reject) => {
+      const id = crypto.randomUUID();
+      replyOverrides.set(id, (result, error) => {
+        if (error) reject(new Error(error));
+        else resolve(result);
       });
-  }
+      void handleCommand({ id, method, params: params ?? {} });
+    });
 }

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -11,6 +11,6 @@
     "forceConsistentCasingInFileNames": true,
     "types": ["vite/client", "vitest"]
   },
-  "include": ["src", "src/**/*.test.ts"],
+  "include": ["src", "src/**/*.test.ts", "e2e", "playwright.config.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -4,6 +4,9 @@ export default defineConfig({
   test: {
     environment: 'node',
     environmentMatchGlobs: [['src/ui/**', 'jsdom']],
+    // Playwright owns e2e/ (see playwright.config.ts) — its specs import
+    // @playwright/test, not vitest.
+    exclude: ['**/node_modules/**', '**/dist/**', 'e2e/**'],
     api: false,
     pool: 'threads',
     poolOptions: {

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@napi-rs/canvas": "^0.1.83",
+        "@playwright/test": "^1.61.1",
         "@types/node": "^24.10.1",
         "fake-indexeddb": "^6.2.5",
         "jsdom": "^27.2.0",
@@ -152,6 +153,8 @@
     "@napi-rs/canvas-win32-x64-msvc": ["@napi-rs/canvas-win32-x64-msvc@0.1.100", "", { "os": "win32", "cpu": "x64" }, "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA=="],
 
     "@pixi/colord": ["@pixi/colord@2.9.6", "", {}, "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA=="],
+
+    "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
 
     "@rollup/plugin-typescript": ["@rollup/plugin-typescript@12.3.0", "", { "dependencies": { "@rollup/pluginutils": "^5.1.0", "resolve": "^1.22.1" }, "peerDependencies": { "rollup": "^2.14.0||^3.0.0||^4.0.0", "tslib": "*", "typescript": ">=3.7.0" }, "optionalPeers": ["rollup", "tslib"] }, "sha512-7DP0/p7y3t67+NabT9f8oTBFE6gGkto4SA6Np2oudYmZE/m1dt8RB0SjL1msMxFpLo631qjRCcBlAbq1ml/Big=="],
 
@@ -449,6 +452,10 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
+
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
+
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
@@ -578,6 +585,8 @@
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "data-urls/whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 

--- a/docs/mobile-web-plan.md
+++ b/docs/mobile-web-plan.md
@@ -202,11 +202,23 @@ hardware.*
   existing `debug-pointer` localStorage flag). `deps:` none.
   **DoD:** a fresh contributor can iterate on a phone against the dev server from
   the docs alone.
-- [ ] **M5-2 · Playwright mobile emulation tests.** CI coverage with a touch +
+- [x] **M5-2 · Playwright mobile emulation tests.** CI coverage with a touch +
   phone-viewport context, both orientations: compact layout renders, tool sheet
   opens/picks, pinch-zoom and two-finger pan work, autosave fires on
   `visibilitychange`. `deps:` M1-2, M2-1, M3-1.
   **DoD:** suite green in CI; a deliberate compact-layout break fails it.
+  *Shipped (#121):* `app/playwright.config.ts` runs `app/e2e/mobile.spec.ts`
+  across `mobile-portrait`/`mobile-landscape` projects (Pixel 5 dimensions,
+  swapped) against a built `vite preview` server. `mcpBridge.ts`'s `?mcp`
+  debug bridge now exposes `window.__mcpTest` unconditionally (previously
+  dev-only) so it works against the production preview build the suite runs
+  under. Camera-change assertions use Playwright's own (CDP) element
+  screenshot rather than the MCP `screenshot` op — that op's
+  `canvas.toDataURL()` races the WebGL implicit buffer clear (no
+  `preserveDrawingBuffer`) and can return a stale/blank capture. New
+  `mobile-e2e` CI job builds WASM, installs Playwright's Chromium, and runs
+  the suite; wired into `report-pr-results`. Verified locally that renaming
+  `.toolbar-undo-btn` fails the compact-layout test, then reverted.
 - [ ] **M5-3 · Docs sync.** README, `manual.html`, and SPEC updated to describe the
   mobile mode, detection/override behaviour, and autosave. `deps:` M2-5, M3-1.
   **DoD:** shipped alongside the final feature PR, per repo convention.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:favicon":        "cd app && bun run build:favicon",
     "build:radio-playlist": "cd app && bun run build:radio-playlist",
     "build:wasm":           "wasm-pack build crates/city-sim-wasm --target web --out-dir ../../app/src/wasm/sim_wasm",
-    "build:plugin-js":      "bun --cwd crates/tauri-plugin-city-sim install && bun --cwd crates/tauri-plugin-city-sim run build"
+    "build:plugin-js":      "cd crates/tauri-plugin-city-sim && bun install && bun run build"
   },
   "engines": {
     "node": ">=20",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint":                 "cd app && bun run lint",
     "test":                 "cd app && bun run test",
     "test:ci":              "cd app && bun run test:ci",
+    "test:e2e":             "cd app && bun run test:e2e",
     "build:favicon":        "cd app && bun run build:favicon",
     "build:radio-playlist": "cd app && bun run build:radio-playlist",
     "build:wasm":           "wasm-pack build crates/city-sim-wasm --target web --out-dir ../../app/src/wasm/sim_wasm",


### PR DESCRIPTION
## Summary

- **`app/playwright.config.ts`:** two projects, `mobile-portrait` and `mobile-landscape` (Pixel 5 dimensions, swapped for landscape — both land in the compact layout since `deviceMode.ts`'s breakpoint triggers on width OR height), sharing one spec. `webServer` builds and serves a production preview (`vite build && vite preview`), matching how the app actually ships.
- **`app/e2e/mobile.spec.ts`** covers the M5-2 DoD:
  1. Compact layout renders (`.toolbar[data-layout-mode="compact"]`, current-tool button, `.toolbar-undo-btn` disabled on a fresh city).
  2. Tool sheet opens, picks Road, closes, and the toolbar's active tool updates.
  3. A two-finger gesture pans/zooms the camera (asserted via a before/after screenshot diff) without painting a stray tile (asserted via `get_tiles_where({kind:'road'})` returning empty) — synthetic touch `PointerEvent`s dispatched on `#canvas-wrapper`.
  4. Autosave fires on `visibilitychange`: places a road, forces `document.visibilityState` to `'hidden'`, dispatches the event, and polls IndexedDB for the `'autosave'` record.
- **`mcpBridge.ts`:** `window.__mcpTest` (the Playwright/MCP debug hook) is now exposed unconditionally instead of gated behind `import.meta.env.DEV` — it's already gated by the explicit `?mcp` query opt-in (same pattern as `?bridge=`/`?ui=`), and the suite runs against a *production* preview build, where `import.meta.env.DEV` is `false` and the old gate stripped the hook entirely.
- **Camera-change assertion uses Playwright's own element screenshot**, not the MCP `screenshot` op. That op reads the PixiJS WebGL canvas via `canvas.toDataURL()`, which races the browser's implicit buffer clear (the renderer doesn't set `preserveDrawingBuffer`) — it intermittently returns a stale/blank capture unrelated to the actual rendered frame. Playwright's CDP-based screenshot captures the composited page instead and isn't affected.
- **New `mobile-e2e` CI job** (`.github/workflows/ci.yml`): builds WASM, installs Playwright's Chromium, runs `bun run test:e2e`, uploads the HTML report. Wired into `report-pr-results`'s `needs` list and summary comment.
- **`vitest.config.ts`** now excludes `e2e/**` (Playwright's `.spec.ts` files would otherwise match vitest's default glob and fail to import since they use `@playwright/test`, not `vitest`); **`tsconfig.json`** adds `e2e`/`playwright.config.ts` so `bun run lint` actually typechecks them.

Closes #121

### Documentation
Checked off M5-2 in `docs/mobile-web-plan.md` with a "shipped" note covering the two non-obvious fixes above (the `__mcpTest` gate and the screenshot method).

## Test plan
- [x] `bun run lint` — clean (now covers `e2e/` too).
- [x] `bun run test` — all 165 tests pass. One pre-existing unrelated `html-encoding-sniffer` unhandled-error warning from this machine's local jsdom environment (documented gotcha, not introduced by this change) — does not fail any test.
- [x] `bun run test:e2e` locally (headless) — 8/8 pass (4 spec tests × 2 projects).
- [x] Verified the DoD's "a deliberate compact-layout break fails it" claim: temporarily renamed `.toolbar-undo-btn`'s class in `toolbar.ts`, confirmed the compact-layout test fails with a clear "element(s) not found" error, then reverted (clean diff afterward).
- [ ] CI green on the PR (pending) — the `mobile-e2e` job builds WASM and installs Playwright fresh, so first-run timing may need a look.