### PR TITLE
Bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install system dependencies
         run: |
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install system dependencies
         run: |
@@ -117,7 +117,7 @@ jobs:
 
       - name: Upload Rust test artefacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rust-test-results
           path: target/nextest/ci/junit.xml
@@ -152,7 +152,7 @@ jobs:
         os: [ubuntu-24.04, ubuntu-24.04-arm]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -171,7 +171,7 @@ jobs:
 
       - name: Upload determinism test artefacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rust-determinism-results-${{ matrix.os }}
           path: target/nextest/ci/junit.xml
@@ -194,7 +194,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -223,7 +223,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -237,7 +237,7 @@ jobs:
 
       - name: Upload TypeScript test artefacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ts-test-results
           path: app/test-results/junit.xml
@@ -268,7 +268,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -299,7 +299,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install system dependencies
         run: |
@@ -347,7 +347,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Post CI summary comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const marker = '<!-- ci-check-summary -->';

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -53,7 +53,7 @@ jobs:
           VITE_BASE: /city-sim-1000/
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: app/dist
 
@@ -66,4 +66,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

- **Bumps six actions to their current latest major**, all several majors behind: `actions/checkout` (v4/v6 → v7), `actions/upload-artifact` (v4 → v7), `actions/upload-pages-artifact` (v3 → v5), `actions/deploy-pages` (v4 → v5), `actions/github-script` (v7 → v9). Some of these still declared the deprecated Node 20 runtime — visible as "Node.js 20 is being deprecated... forced to run on Node.js 24" warnings in recent CI logs (e.g. PR #123's `mobile-e2e` job).
- **Verified `actions/github-script@v9`'s breaking changes don't apply here**: it drops support for `require('@actions/github')` and makes `getOctokit` an injected parameter — `report-pr-results`'s script only uses the standard injected `github`/`context` objects, neither pattern.
- **Left three actions unchanged on purpose**: `EnricoMi/publish-unit-test-result-action@v2`, `oven-sh/setup-bun@v2`, `swatinem/rust-cache@v2`. Checked each repo's git refs directly — unlike the six above (which cut a new major *tag* on each breaking release), these three maintain a genuinely floating `v2` tag that already points at their latest v2.x release (2.24.0 / 2.2.0 / 2.9.1 respectively), so the pin already tracks latest.
- **Left `dtolnay/rust-toolchain@stable`** (intentional non-version ref) **and `taiki-e/install-action@nextest`/`@wasm-pack`** (the tool's documented shorthand for "always install latest", confirmed against its own README) untouched — neither is a stale pin.

### Scope note
This is a standalone audit unrelated to the mobile-web plan (#122/#123 currently open) — it touches `gh-pages.yml` and every existing job in `ci.yml`, none of which those PRs modify, so it's kept separate on purpose.

Closes #124

## Test plan
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`) on both workflow files.
- [x] Confirmed via each action's GitHub releases/tags which are genuinely floating vs. which cut new major tags.
- [x] Read release notes for every major version between old and new pin, checking for breaking changes relevant to our usage (none apply, beyond the Node 24 runtime requirement already satisfied by `ubuntu-24.04`/`ubuntu-latest` runners).
- [ ] CI green on the PR (pending).