### PR TITLE
Bump mobile-e2e's remaining stale action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -328,7 +328,7 @@ jobs:
         run: bun run build:plugin-js
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
@@ -342,7 +342,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: app/playwright-report/


### PR DESCRIPTION
## Summary

- Closes the gap #125 couldn't cover: `actions/checkout@v6` → `v7`, `actions/cache@v4` → `v6`, `actions/upload-artifact@v4` → `v7`, all three only used inside the `mobile-e2e` job (added by #123, which merged after #125 was branched).

Closes #126

## Test plan
- [x] YAML validated.
- [x] Confirmed no `@v6`/`@v4` action pins remain anywhere in `ci.yml`.
- [ ] CI green on the PR (pending).