### PR TITLE
Responsive modals and manual for small viewports

### DIFF
--- a/app/public/manual.html
+++ b/app/public/manual.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>City Sim 1000 Manual</title>
     <style>
       body {
@@ -13,9 +13,31 @@
         padding: 24px;
       }
       h1, h2 { color: #7bffb7; }
-      code { background: #1c2438; padding: 2px 6px; border-radius: 4px; }
+      code {
+        background: #1c2438;
+        padding: 2px 6px;
+        border-radius: 4px;
+        /* Long hotkey lists are comma-separated <code> tags — let them wrap
+           rather than force horizontal scroll in the narrow modal iframe
+           (M2-5: usable down to a 360px-wide compact viewport). */
+        overflow-wrap: break-word;
+      }
       a { color: #89c2ff; }
       ul { margin-top: 8px; }
+
+      /* Matches deviceMode.ts's DEFAULT_COMPACT_BREAKPOINT_PX/
+         DEFAULT_COMPACT_HEIGHT_BREAKPOINT_PX — this document only ever
+         renders inside the manual's iframe (dialogs.ts's showManualModal),
+         not the top-level app, but reusing the same threshold keeps "compact"
+         meaning one thing across the whole game. */
+      @media (max-width: 900px), (max-height: 500px) {
+        body {
+          padding: 16px;
+          font-size: 15px;
+        }
+        h1 { font-size: 1.4em; }
+        h2 { font-size: 1.15em; }
+      }
     </style>
   </head>
   <body>

--- a/app/src/styles/modals/budget-ledger.css
+++ b/app/src/styles/modals/budget-ledger.css
@@ -10,8 +10,19 @@
    City Ledger (budget modal redesign)
    ========================================================================= */
 
-.ledger-body {
-  grid-template-columns: minmax(0, 1.8fr) minmax(220px, 1fr);
+/* Everything below the header (summary cards, ledger, quarterly strip,
+   footer) lives in one scrolling region — see budgetModal.ts's `scrollArea`.
+   Without a single shared scroll container, each of those was a
+   non-shrinking flex sibling of `.budget-body` inside `.modal`'s flex
+   column, and on a small viewport they'd starve `.budget-body` down to
+   ~0px rather than yield space, silently clipping the whole ledger. */
+.budget-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .ledger-main {
@@ -337,9 +348,6 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 12px;
-  flex: 1;
-  min-height: 0;
-  height: 100%;
 }
 
 .budget-column {
@@ -350,8 +358,6 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
-  overflow-y: auto;
-  max-height: 100%;
 }
 
 .budget-section-title {
@@ -552,4 +558,22 @@
   border: 1px solid #253a5a;
   border-radius: 8px;
   padding: 8px 10px;
+}
+
+/* Matches deviceMode.ts's DEFAULT_COMPACT_BREAKPOINT_PX/
+   DEFAULT_COMPACT_HEIGHT_BREAKPOINT_PX — a 360×640 (or 640×360) modal falls
+   well inside this already (M2-5), so reuse it rather than pick a third,
+   modal-specific breakpoint. */
+@media (max-width: 900px), (max-height: 500px) {
+  .budget-summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .ledger-columns {
+    grid-template-columns: 1fr;
+  }
+
+  .ledger-strip {
+    grid-template-columns: 1fr;
+  }
 }

--- a/app/src/styles/modals/settings.css
+++ b/app/src/styles/modals/settings.css
@@ -66,7 +66,11 @@
 
 .settings-row {
   display: grid;
-  grid-template-columns: 1fr 2fr auto;
+  /* minmax(0, …) lets these tracks shrink below their content's natural
+     min-content width — without it the row (and its ancestors, up to the
+     modal's overflow-y-only .settings-body) overflows horizontally on a
+     narrow phone rather than wrapping/shrinking (M2-5). */
+  grid-template-columns: minmax(0, 1fr) minmax(0, 2fr) auto;
   align-items: center;
   gap: 8px;
   padding: 6px 0;
@@ -104,7 +108,11 @@
 }
 
 .settings-row input[type="range"] {
-  width: 180px;
+  /* Caps at 180px on a roomy desktop row but shrinks with its grid track
+     rather than forcing horizontal overflow at narrow modal widths. */
+  width: 100%;
+  max-width: 180px;
+  min-width: 0;
 }
 
 .settings-row input[type="text"] {
@@ -127,7 +135,7 @@
 
 .hotkey-row {
   display: grid;
-  grid-template-columns: 1fr 2fr;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
   gap: 8px;
   align-items: center;
 }

--- a/app/src/ui/budgetModal.ts
+++ b/app/src/ui/budgetModal.ts
@@ -490,11 +490,17 @@ export function initBudgetModal(options: BudgetModalOptions) {
     footer.textContent =
       'Tip: taxes above 9% raise cash but cool demand; funding below 100% saves upkeep but has consequences.';
 
+    // Everything except the header scrolls as one region — on a small
+    // viewport (M2-5) the summary cards + ledger + quarterly strip + footer
+    // together are taller than the modal, and without a single shared scroll
+    // container each of those non-shrinking flex siblings just squeezed
+    // `body`'s `flex: 1` down to nothing rather than yielding space.
+    const scrollArea = document.createElement('div');
+    scrollArea.className = 'budget-scroll';
+    scrollArea.append(summary, body, strip, footer);
+
     modal.appendChild(header);
-    modal.appendChild(summary);
-    modal.appendChild(body);
-    modal.appendChild(strip);
-    modal.appendChild(footer);
+    modal.appendChild(scrollArea);
     backdrop.appendChild(modal);
     document.body.appendChild(backdrop);
 

--- a/docs/mobile-web-plan.md
+++ b/docs/mobile-web-plan.md
@@ -135,12 +135,36 @@ when tools are added.*
   the fixed compact toolbar dock anyway) to reclaim its flow height for the canvas.
   `deps:` M2-1. **DoD:** neither element occludes the canvas by default on a
   phone-sized viewport in either orientation. (#104)
-- [ ] **M2-5 · Responsive modals + manual.** Settings/budget/bylaws modals size to
+- [x] **M2-5 · Responsive modals + manual.** Settings/budget/bylaws modals size to
   small viewports in both orientations. `manual.html` is a separate document in an
   iframe — give it its own viewport meta and mobile styles, and document the touch
   controls (M1) in it. `deps:` M1-2, M2-1.
   **DoD:** all modals usable on a 360×640 viewport, portrait and landscape; manual
   readable without horizontal scrolling and covers touch controls.
+  *Shipped (#130):* the outer `.modal` shell (`min(90vw, 960px)` / `min(80dvh, 720px)`)
+  was already responsive — the real bugs were all in what's built inside it, found
+  by empirically measuring computed styles/bounding rects at 360×640 and 640×360,
+  not just reading the CSS. **Budget modal (critical):** `header`/`summary`/`strip`/
+  `footer` were four non-shrinking flex siblings of the one `min-height: 0` `body` —
+  at small heights they starved it to ~0px, silently clipping the entire ledger and
+  the footer behind the outer `.modal`'s `overflow: hidden`. Fixed by wrapping
+  everything but the header in one `.budget-scroll` region (`budgetModal.ts`) so the
+  whole thing scrolls as a unit instead of relying on `.budget-body`/`.budget-column`
+  fighting for space with siblings that couldn't shrink; `.budget-summary` and
+  `.ledger-strip`/`.ledger-columns` collapse to fewer/stacked columns at the
+  existing compact breakpoint. Also found and removed a dead `.ledger-body`
+  grid-column rule shadowed by `.budget-body`'s (same element, two classes) —
+  it never took effect. **Settings modal:** `.settings-row`'s `1fr 2fr auto` and
+  `.hotkey-row`'s `1fr 2fr` had no `minmax(0, …)`, and a hard-coded `180px` range
+  input width — combined, these overflowed the ~292px available content width at
+  360px. Bylaws modal needed no changes — its `.bylaws-options` `auto-fit`/
+  `minmax(240px, 1fr)` grid was already a good responsive pattern (self-collapses
+  to one column by container width, not a viewport breakpoint). `manual.html`
+  gains its own `viewport-fit=cover`, a compact-breakpoint media query (smaller
+  padding/font-size), and `overflow-wrap: break-word` on `<code>` so the long
+  comma-separated hotkey lists wrap instead of forcing horizontal scroll; its
+  touch-controls coverage was already added by M1-4's "Touch & compact layout"
+  section, verified readable at 360px width here.
 
 ## Phase M3 — Autosave + storage durability
 *Goal: nobody loses a city — on any platform. Mobile browsers discard background tabs


### PR DESCRIPTION
## Summary

- **Budget modal (critical fix):** at 360×640/640×360 the entire revenue/expense ledger and tax/funding sliders were invisible, and the footer clipped — `header`/`summary`/`strip`/`footer` were four non-shrinking flex siblings starving the one `min-height: 0` body down to ~0px, with nothing to catch the overflow since the outer `.modal` clips (`overflow: hidden`). Fixed by wrapping everything but the header in one scrolling `.budget-scroll` region (`budgetModal.ts`) instead of relying on several non-shrinking siblings to yield space to one lone flexible child. `.budget-summary` (4→2 cols) and `.ledger-strip`/`.ledger-columns` (2→1 col) also collapse at the existing compact breakpoint. Removed a dead `.ledger-body` grid-column rule shadowed by `.budget-body`'s (same element, two classes — never took effect).
- **Settings modal:** fixed a real horizontal-overflow bug — `.settings-row`/`.hotkey-row`'s grid columns had no `minmax(0, …)`, plus a hard-coded `180px` range input width, together overflowing the ~292px of content width available at 360px.
- **Bylaws modal:** verified already fine — its `.bylaws-options` grid (`auto-fit`/`minmax(240px, 1fr)`) is a good responsive pattern worth reusing (self-collapses by container width, not a viewport breakpoint).
- **`manual.html`:** own `viewport-fit=cover`, a compact-breakpoint media query, and `overflow-wrap: break-word` on `<code>` so long hotkey lists wrap instead of overflowing. Touch-controls coverage already landed in M1-4 (#128); verified it stays readable at 360px width.

Closes #130

### Documentation
Checked off M2-5 in `docs/mobile-web-plan.md` with a "shipped" note.

## Test plan
- [x] `bun run lint` — clean.
- [x] `bun run test` — all 171 tests pass (same pre-existing, unrelated local jsdom environment issue documented elsewhere).
- [x] `bun run test:e2e` — all 8 runs pass (4 specs × 2 projects), no regressions.
- [x] Empirically verified all three modals + the manual at both 360×640 and 640×360 via Playwright: measured `scrollWidth`/`clientWidth` (no horizontal overflow anywhere) and captured screenshots confirming the budget modal's summary cards/ledger/sliders are all visible and scrollable (not clipped), settings modal's rows fit without overflow, and bylaws/manual were unaffected/already fine.
- [ ] CI green on the PR (pending).