### PR TITLE
Restore independent per-column scroll on desktop budget modal

### DIFF
--- a/app/src/styles/modals/budget-ledger.css
+++ b/app/src/styles/modals/budget-ledger.css
@@ -10,16 +10,19 @@
    City Ledger (budget modal redesign)
    ========================================================================= */
 
-/* Everything below the header (summary cards, ledger, quarterly strip,
-   footer) lives in one scrolling region — see budgetModal.ts's `scrollArea`.
-   Without a single shared scroll container, each of those was a
-   non-shrinking flex sibling of `.budget-body` inside `.modal`'s flex
-   column, and on a small viewport they'd starve `.budget-body` down to
-   ~0px rather than yield space, silently clipping the whole ledger. */
+/* `.budget-scroll` (summary cards, ledger, quarterly strip, footer — see
+   budgetModal.ts's `scrollArea`) replaces those elements' old position as
+   direct flex children of `.modal`, but scrolls as one region only at
+   compact sizes (media query below). At desktop sizes it stays a transparent
+   flex passthrough — `.budget-body`'s two columns keep scrolling
+   *independently* there (a long ledger doesn't push the City Hall sliders
+   out of view), matching pre-#132 behaviour. Compact sizes need the single
+   shared scroll region because `header`/`summary`/`strip`/`footer` are
+   non-shrinking flex siblings of the one `min-height: 0` `body` — at small
+   heights they starved it to ~0px, silently clipping the whole ledger. */
 .budget-scroll {
   flex: 1;
   min-height: 0;
-  overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -348,6 +351,12 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 12px;
+  /* Desktop only (undone at compact sizes below): stretches to fill
+     `.budget-scroll`'s remaining height so `.budget-column`'s own
+     `max-height: 100%` has something to measure against. */
+  flex: 1;
+  min-height: 0;
+  height: 100%;
 }
 
 .budget-column {
@@ -358,6 +367,11 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+  /* Desktop only (undone at compact sizes below): each column scrolls on
+     its own, so a long ledger list doesn't push the City Hall sliders (or
+     vice versa) out of view. */
+  overflow-y: auto;
+  max-height: 100%;
 }
 
 .budget-section-title {
@@ -575,5 +589,25 @@
 
   .ledger-strip {
     grid-template-columns: 1fr;
+  }
+
+  /* At this size `header`/`summary`/`strip`/`footer` alone can already
+     exceed the modal's height, so `.budget-body`'s desktop-only stretch
+     (flex: 1/height: 100%) would starve it back down to ~0px the same way
+     it did before #132 — undo it and let `.budget-scroll` scroll the whole
+     region as one unit instead of `.budget-column` scrolling internally. */
+  .budget-scroll {
+    overflow-y: auto;
+  }
+
+  .budget-body {
+    flex: none;
+    min-height: auto;
+    height: auto;
+  }
+
+  .budget-column {
+    overflow-y: visible;
+    max-height: none;
   }
 }

--- a/docs/mobile-web-plan.md
+++ b/docs/mobile-web-plan.md
@@ -190,6 +190,12 @@ when tools are added.*
   comma-separated hotkey lists wrap instead of forcing horizontal scroll; its
   touch-controls coverage was already added by M1-4's "Touch & compact layout"
   section, verified readable at 360px width here.
+  *Follow-up:* the initial `.budget-scroll` restructure applied unconditionally,
+  losing desktop's independent per-column scrolling in the ledger (a long ledger
+  list could push the City Hall sliders out of view along with it, whereas before
+  each column scrolled on its own) — gated the single-scroll-region behaviour
+  behind the same compact media query so desktop keeps its original per-column
+  scroll and only compact sizes get the starvation fix.
 
 ## Phase M3 — Autosave + storage durability
 *Goal: nobody loses a city — on any platform. Mobile browsers discard background tabs


### PR DESCRIPTION
## Summary

Follow-up to #132, addressing a code-review finding raised before that PR merged: the `.budget-scroll` restructure (fixing a critical clipping bug at 360×640/640×360) applied **unconditionally**, which lost desktop's independent per-column scrolling in the ledger — a long revenue/expense list could push the City Hall sliders out of view along with it, whereas each `.budget-column` used to scroll on its own.

- Gates the single-scroll-region behavior behind the same compact media query used elsewhere in this file. At desktop sizes, `.budget-scroll` is a transparent flex passthrough and `.budget-body`/`.budget-column` keep their original flex-stretch/independent-`overflow-y` behavior (restored). At compact sizes, those are undone so `.budget-scroll` scrolls the whole region as one unit — exactly what #132 shipped, unchanged.

No new issue filed — this is a direct, small follow-up to the code-review finding on the just-merged #132.

## Test plan
- [x] `bun run lint` — clean.
- [x] `bun run test` — all 171 tests pass (pre-existing, unrelated local jsdom environment issue).
- [x] Verified via Playwright at 1280×800: scrolling one `.budget-column` to `scrollTop: 100` leaves the other column's `scrollTop` at `0` — independent scroll restored. `.budget-scroll`'s computed `overflow-y` is `visible` at this size (no double-scroll-region).
- [x] Re-verified at 360×640 and 640×360: no horizontal overflow, `.budget-scroll`'s computed `overflow-y` is `auto`, and the footer (the element that was invisible before #132) is reachable by scrolling to the bottom — the compact fix is intact.
- [ ] CI green on the PR (pending). Note: local e2e re-runs hit heavy flakiness this session from an unrelated stuck process on this machine (a `playwright-mcp`-owned Chromium renderer pegged at ~83% CPU for 3+ hours, driving system load to ~16) — not touching that process since I don't know what else depends on it. Deferring to CI's clean runner as the real signal here.