### PR TITLE
Docs sync: mobile mode, detection/override, and autosave

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ Pointer/touch debugging: in a dev build, run `localStorage.setItem('debug-pointe
 - Undo/redo: `Ctrl/Cmd+Z` undoes the last action (a drag counts as one action); `Ctrl/Cmd+Shift+Z` or `Ctrl/Cmd+Y` redoes it. Undo rewinds the whole city — including the clock — to just before the action; history is per-session and stops at the last load.
 - Inspector: select Inspect, click a tile to see utilities, status, and capacity; pin the tool info card to keep build stats visible.
 
+## Mobile & touch
+- A phone-sized viewport (or any narrow/short window) switches to a compact touch layout automatically — two independent axes, each re-evaluated live with no reload: input mode (`touch`/`mouse`, from `(pointer: coarse)`) and layout mode (`compact`/`full`, from viewport width/height). A tablet gets full layout with touch-sized targets; a touchscreen desktop gets full layout with touch gestures.
+- Force a mode for testing with `?ui=mobile` or `?ui=desktop` in the URL (same pattern as `?bridge=tauri`), or the `ui` setting in Settings for a persistent override.
+- One finger drives the active tool like a mouse click/drag; a second finger always means camera control (two-finger pan + pinch-zoom), cancelling any in-progress paint so a stray second finger never leaves a half-finished drag behind.
+- The compact shell moves tool selection to a bottom-sheet current-tool button, and shares the minimap/tile-inspector/tool-info card in one small tabbed panel instead of floating them separately — see `public/manual.html`'s "Touch & compact layout" section for the full player-facing rundown.
+- Autosave is cross-platform (not mobile-only): the game writes to a dedicated IndexedDB slot every 60 seconds plus on tab-hide/close, and restores whichever of the manual/autosave slots is newest on boot. `navigator.storage.persist()` is requested once after the first save to reduce (not eliminate) the browser's chance of evicting saved data under storage pressure.
+
 ## Offline & PWA
 - `vite-plugin-pwa` (Workbox `generateSW` mode, configured in `vite.config.ts`) generates the service worker at build time from the real Vite build manifest, precaching JS/CSS/HTML/WASM/icons — radio audio (`public/audio/`) and the marketing images (`readme-banner.png`, `social-preview.png`) are excluded via `globIgnores`.
 - `public/manifest.webmanifest` and icons let you install the game as a standalone experience.

--- a/SPEC.md
+++ b/SPEC.md
@@ -244,10 +244,12 @@ export interface Tile {
 
 ## 6.3 Camera
 
-* Pan with right-click drag
-* Zoom in discrete steps: 1.0 → 1.5 → 2.0
-* Pixel-snap at all zoom levels
-* Optional easing for panning
+* Pan by dragging with the mouse, or with `WASD`/arrow keys; right-click drag is reserved for quick bulldoze instead
+* Continuous zoom (not discrete steps) via scroll wheel or pinch, clamped to `MIN_SCALE`–`MAX_SCALE` (0.5×–3×)
+* Zoom keeps the point under the cursor/pinch midpoint stationary
+* Touch input: one finger drives the active tool exactly like a mouse click/drag; a second finger touching down always means camera control — it cancels any in-progress paint and switches to two-finger pan + pinch-zoom, so a stray second finger never leaves a half-finished drag behind
+* Tap slop: a small movement tolerance on touch so a slightly-moving finger still registers as a tap rather than a one-tile drag-paint
+* Compact layout uses a deeper default zoom than desktop so tiles stay finger-sized
 
 ---
 
@@ -357,14 +359,37 @@ Expenses:
 
 ### IndexedDB
 
-* Database `city-sim-1000`, store `saves`, one record per slot (`manual`; `autosave` planned)
+* Database `city-sim-1000`, store `saves`, one record per slot: `manual` (explicit Save) and `autosave` (periodic, see below)
 * Records hold a binary **CSAV** container: magic + version + meta JSON + engine snapshot (CSIM postcard) + client JSON (settings/bylaws)
 * Legacy LocalStorage key `city-sim-1000-save` (plain JSON) is imported once and cleared after a successful CSAV write
+
+### Autosave
+
+* Cross-platform (not mobile-only): desktop browser tabs lose unsaved progress just as easily as a phone browser reclaiming a background tab
+* Writes to the dedicated `autosave` slot every 60 seconds while the sim tick has advanced (skipped on an idle/paused city), plus an immediate flush on `visibilitychange` (tab hidden) and `pagehide`
+* Never touches the `manual` slot or the undo history — autosave is a pure read of the engine
+* On boot, whichever of `manual`/`autosave` is newest wins, with a toast naming which one and how long ago it was written (e.g. "Restored autosave from 2 min ago")
+* `navigator.storage.persist()` is requested once after the first successful save, best-effort — reduces (never eliminates) the browser's chance of evicting IndexedDB data under storage pressure
 
 ### Import/Export
 
 * Export: download a `.citysim` binary container; on touch devices this instead opens the OS share sheet via the Web Share API, falling back to a plain download when sharing isn't supported or the user cancels
 * Import: upload `.citysim` (or a legacy JSON export) → validation → load
+
+---
+
+## 6.7 Mobile & Touch Input
+
+* **Detection, not UA sniffing** — two independent axes, each re-evaluated live as the environment changes (no reload needed):
+  * *Input mode* (`touch` | `mouse`): `(pointer: coarse)` media query, falling back to `navigator.maxTouchPoints` if `matchMedia` is unavailable
+  * *Layout mode* (`compact` | `full`): viewport width ≤ 900px **or** height ≤ 500px — matching on either dimension (not just width) catches a phone in landscape, which is comfortably wider than 900px but too short for a full desktop shell to leave any canvas
+* A tablet gets full layout with touch-sized targets; a desktop with a touchscreen gets full layout with touch gestures — the two axes are independent
+* **Override**: a `ui: 'auto' | 'desktop' | 'mobile'` setting (Settings modal) forces a mode regardless of detection; `?ui=mobile` / `?ui=desktop` in the URL forces it for a single dev/test load and persists into the setting if the player then explicitly Saves
+* **Compact UI shell**: the desktop toolbar row is replaced by a thumb-zone "current tool" button (bottom-right, shows the active tool + cost) that opens a bottom sheet listing every tool; the tile-inspector and tool-info card share one small tabbed panel (Map / Inspect) above the sheet instead of each floating independently, auto-switching content and label to match whichever the active tool makes relevant — the same logic desktop's always-on tool-info card already used
+* **Gesture model**: one finger drives the active tool exactly like a mouse click/drag; a second finger touching down always means camera control (cancels any in-progress paint, switches to two-finger pan + pinch-zoom); a small tap-slop tolerance keeps a slightly-moving finger from registering as an accidental drag-paint
+* **Safe areas**: `viewport-fit=cover` plus `env(safe-area-inset-*)` padding on HUD/toolbar chrome so notches/home indicators never cover controls; `dvh`/`svh` (not bare `vh`) so the layout survives the mobile browser chrome showing/hiding
+* **Save export**: touch devices try the Web Share API first (native share sheet), falling back to the desktop download path when unsupported or cancelled
+* **Radio**: gesture-gated like any autoplay-restricted audio — enabling it is itself the qualifying tap; an out-of-band interruption (OS audio focus loss, a phone call) resyncs the play/pause UI rather than leaving it claiming to still be playing
 
 ---
 
@@ -398,6 +423,9 @@ Create `public/manual.html` with:
 ## 9. Performance Targets
 
 * 60 FPS on modern desktop browsers
+* 30 FPS minimum on a mid-tier Android phone (not a flagship) — verified ~60fps sustained on a Google Pixel 8 Pro with only slight thermal warmth over a play session
+* Pixi canvas `resolution` capped at `min(devicePixelRatio, 2)` — retina-sharp without paying the full uncapped cost on DPR-3 phones
+* The per-frame redraw is skipped when the sim is paused and nothing that feeds it (camera, hover/selection, tool, engine mirror) has changed since the last frame
 * Limit re-drawing:
 
   * Only redraw changed tiles

--- a/docs/mobile-web-plan.md
+++ b/docs/mobile-web-plan.md
@@ -371,9 +371,21 @@ hardware.*
   `mobile-e2e` CI job builds WASM, installs Playwright's Chromium, and runs
   the suite; wired into `report-pr-results`. Verified locally that renaming
   `.toolbar-undo-btn` fails the compact-layout test, then reverted.
-- [ ] **M5-3 · Docs sync.** README, `manual.html`, and SPEC updated to describe the
+- [x] **M5-3 · Docs sync.** README, `manual.html`, and SPEC updated to describe the
   mobile mode, detection/override behaviour, and autosave. `deps:` M2-5, M3-1.
   **DoD:** shipped alongside the final feature PR, per repo convention.
+  *Shipped (#85):* `manual.html`'s player-facing "Touch & compact layout" and
+  "Saving & backups" sections were already in good shape from incremental
+  updates across the session — no changes needed there. `README.md` gained a
+  "Mobile & touch" section (detection axes, `?ui=`/Settings override, gesture
+  model, autosave). `SPEC.md` got the most work: §6.3 Camera had gone stale
+  (still described discrete zoom steps and right-click-drag panning from
+  before those changed) — corrected, plus a new §6.7 "Mobile & Touch Input"
+  consolidating detection/override/gesture/safe-area/share/radio-gesture
+  behaviour; §6.6 Persistence's "autosave planned" note was outdated (M3-1
+  shipped it) — replaced with the actual cadence/flush/newest-wins/durable-
+  storage behaviour; §9 Performance Targets gained the verified mobile figures
+  from M4-3's device pass.
 
 ---
 


### PR DESCRIPTION
## Summary

M5-3's final docs pass — `manual.html`'s player-facing coverage was already solid from incremental updates made alongside each feature PR this session, so this is mostly README.md and SPEC.md.

- **README.md**: new "Mobile & touch" section covering the two detection axes (input mode / layout mode), the `?ui=`/Settings override, the gesture model, and autosave.
- **SPEC.md**:
  - §6.3 Camera had gone stale — still described discrete zoom steps (1.0→1.5→2.0) and right-click-drag panning, both long superseded by continuous scroll/pinch zoom and left-drag/WASD pan (right-click is quick-bulldoze now). Corrected, plus a touch-gesture summary.
  - New §6.7 "Mobile & Touch Input" consolidating detection, override, the compact UI shell, the gesture model, safe-area handling, share-based export, and the radio's gesture-gating — pulling together behaviour that shipped across many separate PRs this session into one reference spot.
  - §6.6 Persistence's "`autosave` planned" note was stale — M3-1 shipped it long ago. Replaced with the actual cadence (60s + visibilitychange/pagehide flush), newest-wins boot restore, and the durable-storage request (M3-2).
  - §9 Performance Targets gained the verified mobile figures from M4-3's device pass (Pixel 8 Pro, ~60fps sustained) alongside the existing desktop target.

### Known limitations
None — this is a docs-only PR.

## Test plan
- [x] `bun run lint` — clean
- [x] `bun run test` — 171/171 passing (pre-existing jsdom `html-encoding-sniffer` error unrelated, documented)
- [x] Grepped for other stale mobile-related mentions across the three docs — none found beyond what's fixed here

Closes #85