### PR TITLE
Fix stray tile placed when lifting one finger of a pinch/pan gesture

### DIFF
--- a/app/e2e/mobile.spec.ts
+++ b/app/e2e/mobile.spec.ts
@@ -106,6 +106,69 @@ test.describe('mobile emulation', () => {
     expect(roadTiles).toEqual([]);
   });
 
+  test('lifting one finger of a two-finger gesture before the other does not leave a stray tile', async ({ page }) => {
+    await boot(page);
+    await mcp(page, 'set_speed', { multiplier: 0 });
+
+    // Found during the M4-3 device pass (#138): a real human two-finger lift
+    // is rarely simultaneous — one finger comes up first while the other is
+    // still down and often shifts slightly as it settles. stopPainting() used
+    // to run unconditionally on every single finger's pointerup, resetting
+    // isPinching regardless of whether another finger was still touching —
+    // the survivor's very next pointermove then fell through to plain
+    // single-finger paint-drag handling, occasionally placing a tile right
+    // where that finger happened to be.
+    await page.locator('.toolbar-current-tool-btn').tap();
+    await page.locator('.tool-sheet-button[data-tool="road"]').tap();
+
+    const box = await page.locator('#canvas-wrapper').boundingBox();
+    if (!box) throw new Error('#canvas-wrapper has no layout box');
+    const cx = box.x + box.width / 2;
+    const cy = box.y + box.height / 2;
+
+    await page.evaluate(
+      async ({ cx, cy }) => {
+        const wrapper = document.querySelector('#canvas-wrapper');
+        if (!wrapper) throw new Error('#canvas-wrapper missing');
+        const fire = (type: string, id: number, x: number, y: number) => {
+          wrapper.dispatchEvent(
+            new PointerEvent(type, {
+              pointerId: id,
+              pointerType: 'touch',
+              clientX: x,
+              clientY: y,
+              bubbles: true,
+              cancelable: true,
+              isPrimary: id === 1,
+              buttons: 1
+            })
+          );
+        };
+        const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+        fire('pointerdown', 1, cx - 30, cy);
+        fire('pointerdown', 2, cx + 30, cy);
+        fire('pointermove', 1, cx - 50, cy - 10);
+        fire('pointermove', 2, cx + 50, cy + 10);
+        await wait(50);
+
+        // Finger 1 lifts alone; finger 2 stays down and settles slightly —
+        // exactly the asymmetric-lift pattern a real pinch produces.
+        fire('pointerup', 1, cx - 50, cy - 10);
+        await wait(30);
+        fire('pointermove', 2, cx + 55, cy + 15);
+        await wait(100);
+
+        fire('pointerup', 2, cx + 55, cy + 15);
+      },
+      { cx, cy }
+    );
+
+    await page.waitForTimeout(100);
+    const roadTiles = await mcp(page, 'get_tiles_where', { kind: 'road' });
+    expect(roadTiles).toEqual([]);
+  });
+
   test('compact combined tab surfaces tool details, labelled by the active tool (M1-4 hover replacement)', async ({ page }) => {
     await boot(page);
     // Desktop's always-on tool-info card only ever gets suppressed in

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -351,6 +351,14 @@ const activeTouchPointers = new Map<number, { x: number; y: number }>();
 let isPinching = false;
 let lastPinchMidpoint: { x: number; y: number } | null = null;
 let lastPinchDistance: number | null = null;
+// Set when one finger of a multi-touch gesture lifts while another is still
+// down. Without this, the surviving finger's very next pointermove falls
+// through to plain single-finger paint-drag handling — using wherever that
+// finger currently happens to be as if it were a fresh tap — occasionally
+// leaving an unwanted tile behind right as a pinch/pan gesture ends. Stays
+// true until every finger is up; a genuinely new gesture starts fresh in
+// pointerdown.
+let ignoreTouchUntilAllLifted = false;
 // A single touch's down position and whether it's moved past tap slop yet —
 // keeps a slightly-trembling tap from registering as a one-tile drag-paint.
 const TOUCH_TAP_SLOP_PX = 10;
@@ -763,6 +771,7 @@ function attachViewportEvents(canvas: HTMLCanvasElement) {
         lastPainted = null;
         hovered = null;
         isPinching = true;
+        ignoreTouchUntilAllLifted = false;
         lastPinchMidpoint = touchMidpoint();
         lastPinchDistance = touchSpread(lastPinchMidpoint);
         return;
@@ -813,6 +822,9 @@ function attachViewportEvents(canvas: HTMLCanvasElement) {
   wrapper.addEventListener('pointermove', (e) => {
     if (e.pointerType === 'touch' && activeTouchPointers.has(e.pointerId)) {
       activeTouchPointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    }
+    if (e.pointerType === 'touch' && ignoreTouchUntilAllLifted) {
+      return;
     }
     pointerActive = e.buttons !== 0;
     if (isPinching && lastPinchMidpoint && lastPinchDistance !== null) {
@@ -880,6 +892,25 @@ function attachViewportEvents(canvas: HTMLCanvasElement) {
   const stopPainting = (e?: PointerEvent) => {
     if (e?.pointerType === 'touch') {
       activeTouchPointers.delete(e.pointerId);
+      if (activeTouchPointers.size > 0) {
+        // One finger of a multi-touch gesture lifted, but at least one other
+        // is still down — stay fully inert (no accidental solo-paint using
+        // the survivor's current position) until every finger is up. See
+        // ignoreTouchUntilAllLifted's own comment for the failure mode this
+        // avoids.
+        isPanning = false;
+        isPinching = false;
+        lastPinchMidpoint = null;
+        lastPinchDistance = null;
+        touchDownPos = null;
+        touchSlopExceeded = false;
+        isPainting = false;
+        lastPainted = null;
+        pointerActive = false;
+        ignoreTouchUntilAllLifted = true;
+        return;
+      }
+      ignoreTouchUntilAllLifted = false;
     }
     isPanning = false;
     isPinching = false;

--- a/docs/mobile-web-plan.md
+++ b/docs/mobile-web-plan.md
@@ -326,8 +326,18 @@ hardware.*
     cluster (undo above radio), aligned with neither — changed to `flex-end`.
 
   Filed, not fixed here: a pinch-zoom/two-finger gesture bug found while
-  playtesting (#138) — needs hands-on iterative debugging on a live device
-  rather than a blind fix.
+  playtesting (#138) — needed hands-on iterative debugging on a live device
+  rather than a blind fix. *Fixed separately:* a real two-finger lift is
+  rarely simultaneous — one finger lifts first while the other, still down,
+  often shifts slightly as it settles. `stopPainting()` reset `isPinching`
+  unconditionally on any single finger's `pointerup`, so the survivor's next
+  `pointermove` fell through to plain single-finger paint-drag handling and
+  occasionally placed a stray tile right where it happened to be. Added
+  `ignoreTouchUntilAllLifted`: once any finger of a multi-touch gesture
+  lifts, stay inert until every finger is up. Verified with a negative
+  control (reverted the fix, confirmed the exact repro reliably placed a
+  tile; restored it, confirmed zero) plus a new e2e regression test covering
+  the asymmetric-lift sequence the existing two-finger test never exercised.
 - [x] **M4-4 · Gesture-gated audio start.** Mobile browsers require a user gesture
   before audio plays. Radio is off by default, so this only bites when the player
   enables it — make sure enabling radio (a tap) is itself the gesture, handle the


### PR DESCRIPTION
## Summary

Root cause for #138 (found during M4-3's device pass): a real two-finger lift is rarely simultaneous — one finger comes up first while the other, still down, often shifts slightly as it settles. `stopPainting()` ran unconditionally on every single finger's `pointerup`, resetting `isPinching` regardless of whether another finger was still touching the screen. The survivor's very next `pointermove` then fell through to plain single-finger paint-drag handling — using wherever that finger currently happened to be as if it were a fresh tap — occasionally placing an unwanted tile right as the gesture ended.

Fixed by adding `ignoreTouchUntilAllLifted`: once any finger of a multi-touch gesture lifts, the input handler stays fully inert (no pinch/pan, no paint) until every finger is up. A genuinely new gesture starts fresh in `pointerdown` as before; a fresh second finger joining still re-arms pinching immediately.

### User-facing changes
- Lifting fingers after a pinch/pan gesture no longer occasionally leaves a stray road/tool tile on the map.

## Test plan
- [x] `bun run lint` — clean
- [x] `bun run test` — 171/171 passing (pre-existing jsdom `html-encoding-sniffer` error unrelated, documented)
- [x] **Negative control**: reverted to the pre-fix code, confirmed the exact repro (pinch, lift one finger, let the other settle) reliably placed a road tile; restored the fix, confirmed zero — same repro, opposite result
- [x] New e2e regression test (`app/e2e/mobile.spec.ts`) covering the asymmetric-lift sequence, passing in both `mobile-portrait` and `mobile-landscape` against a real production preview build — the existing two-finger test only ever lifted both fingers simultaneously, so it never exercised this path
- [x] Existing two-finger gesture test (simultaneous lift) still passes — no regression to normal pinch/pan

Closes #138