### PR TITLE
Bump app version to 0.1.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "city-sim-1000",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
     },
     "app": {
       "name": "city-sim-1000",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "pixi.js": "^8.1.5",


### PR DESCRIPTION
## Summary

- Bumps `app/package.json`'s version from `0.0.1` to `0.1.0`, matching the Rust workspace's `Cargo.toml` (which already declared `0.1.0` — `app/package.json` had drifted).
- Regenerated `bun.lock`'s cached copy of the same field.

Prep step before tagging this point in history as `v0.1.0`, the first tagged release — see the follow-up PR adding a `release.yml` for the ongoing process.

## Test plan
- [x] `bun run lint` — clean
- [x] `bun run test` — 171/171 passing (pre-existing jsdom `html-encoding-sniffer` error unrelated, documented)