### PR TITLE
Radio popover: clamp position so it can't render off the bottom of the screen

### DIFF
--- a/app/src/ui/radio.test.ts
+++ b/app/src/ui/radio.test.ts
@@ -107,6 +107,59 @@ describe('radio widget', () => {
       widget.dispose();
     });
 
+    it('flips the popover above the widget when it would overflow the bottom of the viewport (#145)', async () => {
+      const host = document.createElement('div');
+      document.body.appendChild(host);
+      const widget = initRadioWidget(host, {
+        fetchImpl: vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ version: '1.0', tracks: [] }) }) as unknown as typeof fetch,
+        audioFactory: () => new AudioStub() as unknown as HTMLAudioElement
+      });
+      await widget.refresh();
+
+      const widgetEl = host.querySelector<HTMLElement>('.radio-widget');
+      const popoverEl = host.querySelector<HTMLElement>('.radio-popover');
+      const cover = host.querySelector<HTMLElement>('.radio-cover');
+
+      // Simulate the compact bottom dock: the widget sits near the bottom of
+      // a short viewport, so a naive `rect.bottom + 8` placement would push
+      // most of the popover off-screen with no way to scroll to it.
+      vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(640);
+      vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(360);
+      vi.spyOn(widgetEl!, 'getBoundingClientRect').mockReturnValue({
+        top: 580,
+        bottom: 620,
+        left: 10,
+        right: 190,
+        width: 180,
+        height: 40,
+        x: 10,
+        y: 580,
+        toJSON: () => ({})
+      } as DOMRect);
+      vi.spyOn(popoverEl!, 'getBoundingClientRect').mockReturnValue({
+        top: 0,
+        bottom: 100,
+        left: 0,
+        right: 200,
+        width: 200,
+        height: 100,
+        x: 0,
+        y: 0,
+        toJSON: () => ({})
+      } as DOMRect);
+
+      cover?.dispatchEvent(new Event('click', { bubbles: true }));
+
+      expect(widgetEl?.classList.contains('radio-popover-open')).toBe(true);
+      const top = parseFloat(popoverEl!.style.top);
+      // Naive placement (620 + 8 = 628) would overflow the 640px viewport
+      // with a 100px-tall popover; it should flip above the widget instead.
+      expect(top).toBe(580 - 100 - 8);
+
+      vi.restoreAllMocks();
+      widget.dispose();
+    });
+
     it('a pointerdown outside the widget closes a pinned popover', async () => {
       const host = document.createElement('div');
       document.body.appendChild(host);

--- a/app/src/ui/radio.ts
+++ b/app/src/ui/radio.ts
@@ -123,8 +123,18 @@ export function initRadioWidget(host: HTMLElement, options: RadioWidgetOptions =
       hidePopoverTimeout = null;
     }
     const rect = widget.getBoundingClientRect();
-    popover.style.left = `${Math.round(rect.left)}px`;
-    popover.style.top = `${Math.round(rect.bottom + 8)}px`;
+    const viewportWidth = window.visualViewport?.width ?? window.innerWidth;
+    const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
+    const popoverRect = popover.getBoundingClientRect();
+    // On compact layout the widget sits inside the bottom-anchored dock, so
+    // rect.bottom is already near the screen edge — flip above it rather
+    // than let a position:fixed popover render (unreachably) off-screen.
+    const fitsBelow = rect.bottom + 8 + popoverRect.height <= viewportHeight;
+    const top = fitsBelow ? rect.bottom + 8 : Math.max(8, rect.top - popoverRect.height - 8);
+    const maxLeft = Math.max(8, viewportWidth - popoverRect.width - 8);
+    const left = Math.min(Math.max(8, rect.left), maxLeft);
+    popover.style.left = `${Math.round(left)}px`;
+    popover.style.top = `${Math.round(top)}px`;
     widget.classList.add('radio-popover-open');
   };
 


### PR DESCRIPTION
## Summary
- **Fixes #145** (the bottom toolbar dock "cut off, can't scroll" report) — but the actual bug wasn't the dock itself. `.toolbar-compact-dock` is `position: fixed`, so `#app`'s grid `overflow: hidden` never touched it (my original diagnosis on #145 was wrong; corrected in a follow-up comment there).
- The real culprit is the radio widget's tap-to-pin popover in `app/src/ui/radio.ts`. `showPopover()` positioned it at a raw `rect.bottom + 8`, with no check for whether that overflows the viewport. On compact/mobile layout the widget lives inside the bottom-anchored toolbar dock, so its `rect.bottom` is already near the screen edge — adding the popover's own height reliably pushed it off-screen, with no way to scroll to it since it's `position: fixed`.
- `showPopover()` now flips the popover above the widget when it wouldn't fit below, and clamps horizontally so it can't run off either side.

### Files
- `app/src/ui/radio.ts` — `showPopover()` viewport clamping
- `app/src/ui/radio.test.ts` — regression test simulating a short viewport with the widget near the bottom edge

Closes #145

## Test plan
- [x] `bun run lint` (tsc --noEmit) passes
- [x] New regression test in `radio.test.ts` asserts the popover flips above the widget instead of overflowing a mocked 640px viewport
- [x] Full local suite: 25/25 test files, 211/211 tests pass, including this PR's new test — a separate local-only jsdom/Node issue that was masking `src/ui/**` tests entirely (silently, 0 tests collected rather than a visible failure) has been fixed at the environment level, so this is now locally verified too, not just CI-only as originally noted here.