### PR TITLE
Procedural sound effects + in-game SFX editor

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -307,6 +307,13 @@ Bulldoze
 * Water Pipe: Connects water network underground. Requires Underground View.
 * Power lines: graph-based connectivity
 
+#### Sound Effects
+
+* Procedural one-shot audio via `@liminal-hq/undertone` (zero-dependency Web Audio synth, published separately at [liminal-hq/undertone](https://github.com/liminal-hq/undertone)) — no sample files, every sound is synthesised from oscillator/noise voices with envelope and filter parameters.
+* Four built-in effects: **Place Building** (any successful non-bulldoze tool placement — the priority-1 sound, never throttled, even during a fast drag-paint stroke), **Bulldoze**, **Error** (any failed placement), **Undo**. Bulldoze/Error/Undo get a short per-effect cooldown so rapid repeats don't stack into mush.
+* Settings → Audio has a live volume slider plus a "🎚️ Edit Sound Effects" button opening an in-game editor: every voice layer of every effect is fully tunable (attack/decay/sustain/release, filter cutoff + envelope, pitch slide, sound type/note), with a live Preview button and a generated-parameter save. Edits save either **to this city** (rides the normal save file, `settings.sfxOverrides`) or **globally** (all cities, `localStorage` — the one deliberate exception to this app's IndexedDB-only persistence, since it's small, cross-save, and non-critical if lost). Resolution order: city override → global override → built-in default. Reset (per effect) and Reset All revert to the built-in default.
+* A quick mute toggle lives in the top ribbon next to Pause, independent of the volume slider's saved level.
+
 ---
 
 ## 6.5 Simulation
@@ -362,6 +369,7 @@ Expenses:
 * Database `city-sim-1000`, store `saves`, one record per slot: `manual` (explicit Save) and `autosave` (periodic, see below)
 * Records hold a binary **CSAV** container: magic + version + meta JSON + engine snapshot (CSIM postcard) + client JSON (settings/bylaws)
 * Legacy LocalStorage key `city-sim-1000-save` (plain JSON) is imported once and cleared after a successful CSAV write
+* One deliberate exception: globally-scoped sound effect customizations (§6.4) live in `localStorage`, not IndexedDB — small, cross-save, non-critical if lost
 
 ### Autosave
 
@@ -442,7 +450,6 @@ Create `public/manual.html` with:
 * More tile types
 * Modding support
 * Chunked tile rendering for huge maps
-* Sound effects & music
 
 ---
 

--- a/app/package.json
+++ b/app/package.json
@@ -15,6 +15,7 @@
     "build:radio-playlist": "tsx scripts/build-radio-playlist.ts --extract-embedded-covers"
   },
   "dependencies": {
+    "@liminal-hq/undertone": "^0.1.1",
     "@tauri-apps/api": "^2.0.0",
     "pixi.js": "^8.1.5",
     "tauri-plugin-city-sim": "workspace:*"

--- a/app/public/manual.html
+++ b/app/public/manual.html
@@ -82,6 +82,13 @@
       <li>If no playlist ships with the build yet, the radio reads “Radio offline” and controls are disabled until audio is added.</li>
     </ul>
 
+    <h2>Sound Effects</h2>
+    <ul>
+      <li>Placing a building, road, or zone plays a short procedural "plop" — synthesised on the fly, no sample files. Bulldoze, a failed placement, and undo each get their own sound too. Rapid repeats of bulldoze/error/undo get a brief cooldown so a fast drag-stroke doesn't turn into overlapping noise, but the placement sound always plays for every single placement.</li>
+      <li>A quick mute button (🔊/🔇) sits in the status ribbon next to Pause — one tap silences sound effects without touching your saved volume level.</li>
+      <li>The volume slider under <strong>Settings → Audio</strong> is separate from mute, and a <strong>🎚️ Edit Sound Effects</strong> button there opens a full editor: pick any effect, tweak every layer's tone, envelope, and filter, hit Preview to hear it live, then save either to just this city or globally across every city you play. Reset (per sound) and Reset All revert to the built-in versions.</li>
+    </ul>
+
     <h2>Minimap</h2>
     <ul>
       <li>The minimap lives in the bottom-right of the HUD with a base view showing terrain, zones, roads/rail, power lines, and buildings.</li>
@@ -169,7 +176,7 @@
     <ul>
       <li>The bar across the top shows treasury and monthly net, power and water balances, R/C/I demand columns, the calendar, population/jobs, and the 🌲 Wilderness score.</li>
       <li>Hover any chip for details (the treasury and Wilderness chips are also tap targets, on touch — treasury opens the City Ledger, Wilderness shows its breakdown); the R/C/I columns rise with zone demand, SimCity-style.</li>
-      <li>Right side: a speed menu (icon shows the active tier — 🐢 Slow, 🐇 Fast, ⚡ Ludicrous — hotkeys <code>1</code>/<code>2</code>/<code>3</code>), a ⏸ pause toggle (hotkey <code>Space</code>; picking a speed while paused resumes at that speed), 📊 budget, 📜 bylaws, the 💾 saves menu, 📖 this manual, ⚙️ settings, and 🛠️ debug tools.</li>
+      <li>Right side: a speed menu (icon shows the active tier — 🐢 Slow, 🐇 Fast, ⚡ Ludicrous — hotkeys <code>1</code>/<code>2</code>/<code>3</code>), a ⏸ pause toggle (hotkey <code>Space</code>; picking a speed while paused resumes at that speed), a 🔊/🔇 sound effects mute toggle, 📊 budget, 📜 bylaws, the 💾 saves menu, 📖 this manual, ⚙️ settings, and 🛠️ debug tools.</li>
     </ul>
   </body>
 </html>

--- a/app/src/game/clientState.ts
+++ b/app/src/game/clientState.ts
@@ -21,6 +21,7 @@ import {
 } from './gameState';
 import { DEFAULT_BYLAWS, type BylawState } from './bylaws';
 import { defaultHotkeys } from '../ui/hotkeys';
+import { createDefaultSfxOverrides } from './sfxOverrides';
 
 /** The TS-owned surface of a save — serialised as the CSAV client JSON. */
 export interface ClientState {
@@ -47,6 +48,7 @@ export function ensureSettingsShape(settings?: Partial<GameSettings>): GameSetti
   const cosmeticDefaults = createDefaultCosmeticSettings();
   const narrativeDefaults = createDefaultNarrativeSettings();
   const uiDefaults = createDefaultUiSettings();
+  const sfxOverridesDefaults = createDefaultSfxOverrides();
   const uiSettings = { ...uiDefaults, ...(settings?.ui ?? {}) };
   if (!['auto', 'desktop', 'mobile'].includes(uiSettings.mode)) {
     uiSettings.mode = 'auto';
@@ -60,7 +62,8 @@ export function ensureSettingsShape(settings?: Partial<GameSettings>): GameSetti
     hotkeys: { ...defaultHotkeys, ...(settings?.hotkeys ?? {}) },
     cosmetics: { ...cosmeticDefaults, ...(settings?.cosmetics ?? {}) },
     narrative: { ...narrativeDefaults, ...(settings?.narrative ?? {}) },
-    ui: uiSettings
+    ui: uiSettings,
+    sfxOverrides: { ...sfxOverridesDefaults, ...(settings?.sfxOverrides ?? {}) }
   };
 }
 

--- a/app/src/game/gameState.ts
+++ b/app/src/game/gameState.ts
@@ -7,6 +7,7 @@ import { PowerPlantType } from './constants';
 import { BylawState, DEFAULT_BYLAWS } from './bylaws';
 import { createDefaultPolicies, type Policies } from './protocol/commands';
 import { defaultHotkeys, type HotkeyBindings } from '../ui/hotkeys';
+import { createDefaultSfxOverrides, type SfxOverrides } from './sfxOverrides';
 import type { BudgetHistory } from './economy';
 import type { EducationStats } from './education';
 import type { BuildingInstance } from './buildings/state';
@@ -86,6 +87,7 @@ export interface AccessibilitySettings {
 export interface AudioSettings {
   radioVolume: number;
   sfxVolume: number;
+  sfxMuted: boolean;
 }
 
 export interface CosmeticSettings {
@@ -113,6 +115,8 @@ export interface GameSettings {
   cosmetics: CosmeticSettings;
   narrative: NarrativeSettings;
   ui: UiSettings;
+  /** City-scoped custom sound effect voice stacks; see also globalSfxStore.ts for the cross-city scope. */
+  sfxOverrides: SfxOverrides;
 }
 
 export interface UtilityStats {
@@ -250,7 +254,8 @@ export function createDefaultAccessibilitySettings(): AccessibilitySettings {
 export function createDefaultAudioSettings(): AudioSettings {
   return {
     radioVolume: 1,
-    sfxVolume: 1
+    sfxVolume: 1,
+    sfxMuted: false
   };
 }
 
@@ -303,7 +308,8 @@ export function createDefaultSettings(): GameSettings {
     hotkeys: { ...defaultHotkeys },
     cosmetics: createDefaultCosmeticSettings(),
     narrative: createDefaultNarrativeSettings(),
-    ui: createDefaultUiSettings()
+    ui: createDefaultUiSettings(),
+    sfxOverrides: createDefaultSfxOverrides()
   };
 }
 

--- a/app/src/game/globalSfxStore.test.ts
+++ b/app/src/game/globalSfxStore.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+// Unit tests for the localStorage-backed global SFX override store
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { VoiceParams } from '@liminal-hq/undertone';
+import { loadGlobalSfxOverrides, saveGlobalSfxOverrides } from './globalSfxStore';
+import type { SfxOverrides } from './sfxOverrides';
+
+function makeParams(): VoiceParams {
+  return {
+    soundType: 'sine',
+    gainLevel: 0.8,
+    attack: 0.01,
+    decay: 0.1,
+    sustain: 0,
+    release: 0.05,
+    filterEnvAmount: 0,
+    filterAttack: 0,
+    filterDecay: 0,
+    filterSustain: 1,
+    filterRelease: 0,
+    slideTime: 0,
+    nudgeTime: 0
+  };
+}
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe('loadGlobalSfxOverrides', () => {
+  it('returns an empty object when nothing has been saved', () => {
+    expect(loadGlobalSfxOverrides()).toEqual({});
+  });
+
+  it('round-trips whatever saveGlobalSfxOverrides wrote', () => {
+    const overrides: SfxOverrides = { bulldoze: [makeParams()] };
+    saveGlobalSfxOverrides(overrides);
+    expect(loadGlobalSfxOverrides()).toEqual(overrides);
+  });
+
+  it('falls back to empty rather than throwing on corrupt stored JSON', () => {
+    localStorage.setItem('city-sim-1000:global-sfx-overrides', '{not json');
+    expect(loadGlobalSfxOverrides()).toEqual({});
+  });
+});
+
+describe('saveGlobalSfxOverrides', () => {
+  it('does not throw when localStorage.setItem fails (storage disabled/full)', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+    expect(() => saveGlobalSfxOverrides({ error: [makeParams()] })).not.toThrow();
+  });
+});

--- a/app/src/game/globalSfxStore.ts
+++ b/app/src/game/globalSfxStore.ts
@@ -1,0 +1,31 @@
+// Cross-city sound-effect overrides, persisted globally in localStorage
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+// Every other real persistence in this app goes through saveStore.ts's IndexedDB —
+// localStorage is otherwise only used for the legacy pre-IndexedDB save format and
+// a debug flag. This is a deliberate first: SFX overrides a player wants applied to
+// every city are small, genuinely global (not per-save), and non-critical if lost,
+// which is exactly the case localStorage fits and IndexedDB's save-slot model doesn't.
+
+import { createDefaultSfxOverrides, type SfxOverrides } from './sfxOverrides';
+
+const STORAGE_KEY = 'city-sim-1000:global-sfx-overrides';
+
+export function loadGlobalSfxOverrides(): SfxOverrides {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : createDefaultSfxOverrides();
+  } catch {
+    return createDefaultSfxOverrides();
+  }
+}
+
+export function saveGlobalSfxOverrides(overrides: SfxOverrides): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(overrides));
+  } catch {
+    // Storage disabled or full — silently no-op rather than crash the editor.
+  }
+}

--- a/app/src/game/sfxOverrides.test.ts
+++ b/app/src/game/sfxOverrides.test.ts
@@ -1,0 +1,83 @@
+// Unit tests for SFX override resolution precedence and reset semantics
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+import type { VoiceParams } from '@liminal-hq/undertone';
+import {
+  createDefaultSfxOverrides,
+  resetEffect,
+  resolveVoiceParams,
+  type SfxEffectId,
+  type SfxOverrides
+} from './sfxOverrides';
+
+function makeParams(gainLevel: number): VoiceParams {
+  return {
+    soundType: 'sine',
+    gainLevel,
+    attack: 0.01,
+    decay: 0.1,
+    sustain: 0,
+    release: 0.05,
+    filterEnvAmount: 0,
+    filterAttack: 0,
+    filterDecay: 0,
+    filterSustain: 1,
+    filterRelease: 0,
+    slideTime: 0,
+    nudgeTime: 0
+  };
+}
+
+const DEFAULTS: Record<SfxEffectId, VoiceParams[]> = {
+  placeBuilding: [makeParams(0.8)],
+  bulldoze: [makeParams(0.7)],
+  error: [makeParams(0.5)],
+  undo: [makeParams(0.35)]
+};
+
+describe('createDefaultSfxOverrides', () => {
+  it('starts empty', () => {
+    expect(createDefaultSfxOverrides()).toEqual({});
+  });
+});
+
+describe('resolveVoiceParams', () => {
+  it('falls back to the built-in default when no override exists', () => {
+    const result = resolveVoiceParams('placeBuilding', DEFAULTS, {}, {});
+    expect(result).toBe(DEFAULTS.placeBuilding);
+  });
+
+  it('prefers a global override over the default', () => {
+    const global: SfxOverrides = { placeBuilding: [makeParams(0.5)] };
+    const result = resolveVoiceParams('placeBuilding', DEFAULTS, {}, global);
+    expect(result).toBe(global.placeBuilding);
+  });
+
+  it('prefers a city override over both the global override and the default', () => {
+    const city: SfxOverrides = { placeBuilding: [makeParams(0.3)] };
+    const global: SfxOverrides = { placeBuilding: [makeParams(0.5)] };
+    const result = resolveVoiceParams('placeBuilding', DEFAULTS, city, global);
+    expect(result).toBe(city.placeBuilding);
+  });
+});
+
+describe('resetEffect', () => {
+  it('removes only the given effect, leaving others untouched', () => {
+    const overrides: SfxOverrides = {
+      placeBuilding: [makeParams(0.3)],
+      bulldoze: [makeParams(0.6)]
+    };
+    const next = resetEffect(overrides, 'placeBuilding');
+    expect(next.placeBuilding).toBeUndefined();
+    expect(next.bulldoze).toBe(overrides.bulldoze);
+  });
+
+  it('does not mutate the original overrides object', () => {
+    const overrides: SfxOverrides = { placeBuilding: [makeParams(0.3)] };
+    resetEffect(overrides, 'placeBuilding');
+    expect(overrides.placeBuilding).toBeDefined();
+  });
+});

--- a/app/src/game/sfxOverrides.ts
+++ b/app/src/game/sfxOverrides.ts
@@ -1,0 +1,41 @@
+// Player-customisable sound-effect voice-stack overrides: types and resolution order
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import type { VoiceParams } from '@liminal-hq/undertone';
+
+export type SfxEffectId = 'placeBuilding' | 'bulldoze' | 'error' | 'undo';
+
+export const SFX_EFFECT_IDS: SfxEffectId[] = ['placeBuilding', 'bulldoze', 'error', 'undo'];
+
+export const SFX_EFFECT_LABELS: Record<SfxEffectId, string> = {
+  placeBuilding: 'Place Building',
+  bulldoze: 'Bulldoze',
+  error: 'Error',
+  undo: 'Undo'
+};
+
+/** Whole-voice-stack overrides, keyed by effect id. Saving replaces an effect's entire stack. */
+export type SfxOverrides = Partial<Record<SfxEffectId, VoiceParams[]>>;
+
+export function createDefaultSfxOverrides(): SfxOverrides {
+  return {};
+}
+
+/** Resolution order: city override -> global override -> built-in default. */
+export function resolveVoiceParams(
+  id: SfxEffectId,
+  defaults: Record<SfxEffectId, VoiceParams[]>,
+  cityOverrides: SfxOverrides,
+  globalOverrides: SfxOverrides
+): VoiceParams[] {
+  return cityOverrides[id] ?? globalOverrides[id] ?? defaults[id];
+}
+
+/** Removes one effect's override from both scopes, reverting it to the built-in default. */
+export function resetEffect(overrides: SfxOverrides, id: SfxEffectId): SfxOverrides {
+  const next = { ...overrides };
+  delete next[id];
+  return next;
+}

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -53,6 +53,9 @@ import { initMinimap } from './ui/minimap';
 import { initBudgetModal } from './ui/budgetModal';
 import { initSettingsModal } from './ui/settingsModal';
 import { initBylawsModal } from './ui/bylawsModal';
+import { initSfx } from './ui/sfx';
+import { initSfxEditorModal } from './ui/sfxEditor';
+import { loadGlobalSfxOverrides, saveGlobalSfxOverrides } from './game/globalSfxStore';
 import { initNewsTicker } from './ui/newsTicker';
 import type { RadioWidget } from './ui/radio';
 import { initLoadingScreen } from './ui/loadingScreen';
@@ -109,6 +112,7 @@ appRoot.innerHTML = `
         </div>
       </details>
       <button id="pause-btn" class="ribbon-btn" title="Pause (hotkey Space)" aria-label="Pause">⏸</button>
+      <button id="mute-btn" class="ribbon-btn" title="Mute sound effects" aria-label="Mute sound effects">🔊</button>
       <button id="budget-modal-btn" class="ribbon-btn" title="Open the budget screen" aria-label="Open budget">📊</button>
       <button id="bylaws-modal-btn" class="ribbon-btn" title="Open city bylaws" aria-label="Open bylaws">📜</button>
       <details class="ribbon-menu">
@@ -178,6 +182,7 @@ const speedFastBtn = requireElement<HTMLButtonElement>('#speed-fast');
 const speedLudicrousBtn = requireElement<HTMLButtonElement>('#speed-ludicrous');
 const speedSummaryEl = requireElement<HTMLElement>('#speed-summary');
 const pauseBtn = requireElement<HTMLButtonElement>('#pause-btn');
+const muteBtn = requireElement<HTMLButtonElement>('#mute-btn');
 const saveBtn = requireElement<HTMLButtonElement>('#save-btn');
 const loadBtn = requireElement<HTMLButtonElement>('#load-btn');
 const downloadBtn = requireElement<HTMLButtonElement>('#download-btn');
@@ -450,6 +455,7 @@ function performUndo(): void {
       const message = daysRewound >= 1 ? `Undone — rewound ${formatDaySpan(daysRewound)}` : 'Undone';
       notifications.publish({ id: 'undo', message, sticky: false });
       minimap?.markDirty();
+      sfx?.playUndo();
     }
   });
 }
@@ -574,6 +580,7 @@ let hotkeys: HotkeyController | null = null;
 let minimap: ReturnType<typeof initMinimap> | null = null;
 let radioController: RadioWidget | null = null;
 let newsTicker: ReturnType<typeof initNewsTicker> | null = null;
+let sfx: ReturnType<typeof initSfx> | null = null;
 const PAN_SPEEDS = {
   slow: 420,
   normal: 700,
@@ -698,6 +705,7 @@ function applyCurrentTool(tilePos: Position) {
     return;
   }
   const result = bridge.send(applyToolCmd(activeTool, tilePos.x, tilePos.y, strokeId));
+  sfx?.playToolResult(activeTool, result.success);
   if (!result.success && result.message) {
     showToast(result.message);
   } else if (result.success) {
@@ -1287,6 +1295,15 @@ function gameLoop(renderer: MapRenderer, hud: ReturnType<typeof createHud>) {
     );
   };
 
+  const syncMuteButton = () => {
+    const muted = state.settings.audio.sfxMuted;
+    muteBtn.textContent = muted ? '🔇' : '🔊';
+    const label = muted ? 'Unmute sound effects' : 'Mute sound effects';
+    muteBtn.title = label;
+    muteBtn.setAttribute('aria-label', label);
+    muteBtn.classList.toggle('active', muted);
+  };
+
   const applySettings = (
     nextSettings: GameState['settings'],
     options: { skipHotkeyReload?: boolean } = {}
@@ -1311,6 +1328,7 @@ function gameLoop(renderer: MapRenderer, hud: ReturnType<typeof createHud>) {
     }
     updatePendingPenaltyBtn();
     radioController?.setVolume(state.settings.audio.radioVolume ?? 1);
+    syncMuteButton();
     const shouldReloadHotkeys = hotkeysChanged || !hotkeys;
     if (!options.skipHotkeyReload && shouldReloadHotkeys) {
       rebuildHotkeys();
@@ -1318,6 +1336,22 @@ function gameLoop(renderer: MapRenderer, hud: ReturnType<typeof createHud>) {
   };
 
   let settingsModal: ReturnType<typeof initSettingsModal> | null = null;
+
+  sfx = initSfx({
+    getVolume: () => (state.settings.audio.sfxMuted ? 0 : (state.settings.audio.sfxVolume ?? 1)),
+    getCityOverrides: () => state.settings.sfxOverrides,
+    getGlobalOverrides: loadGlobalSfxOverrides
+  });
+
+  const sfxEditorModal = initSfxEditorModal({
+    sfx,
+    getCityOverrides: () => state.settings.sfxOverrides,
+    getGlobalOverrides: loadGlobalSfxOverrides,
+    onSaveCity: (next) => {
+      state.settings.sfxOverrides = next;
+    },
+    onSaveGlobal: saveGlobalSfxOverrides
+  });
 
   minimap = initMinimap({
     root: wrapper,
@@ -1333,7 +1367,8 @@ function gameLoop(renderer: MapRenderer, hud: ReturnType<typeof createHud>) {
 
   settingsModal = initSettingsModal({
     getSettings: () => state.settings,
-    onApply: (next) => applySettings(next)
+    onApply: (next) => applySettings(next),
+    onOpenSfxEditor: () => sfxEditorModal.open()
   });
 
   treasuryChip.addEventListener('click', () => budgetModal.open());
@@ -1433,6 +1468,11 @@ function gameLoop(renderer: MapRenderer, hud: ReturnType<typeof createHud>) {
   speedFastBtn.addEventListener('click', () => setSimSpeed('fast'));
   speedLudicrousBtn.addEventListener('click', () => setSimSpeed('ludicrous'));
   pauseBtn.addEventListener('click', () => togglePause());
+  muteBtn.addEventListener('click', () => {
+    state.settings.audio.sfxMuted = !state.settings.audio.sfxMuted;
+    syncMuteButton();
+  });
+  syncMuteButton();
   setSimSpeed(simSpeed, { silent: true });
   updatePendingPenaltyBtn();
 

--- a/app/src/style.css
+++ b/app/src/style.css
@@ -19,4 +19,5 @@
 @import './styles/modals/budget-ledger.css';
 @import './styles/modals/bylaws.css';
 @import './styles/modals/settings.css';
+@import './styles/modals/sfxEditor.css';
 @import './styles/loading-screen.css';

--- a/app/src/styles/modals/sfxEditor.css
+++ b/app/src/styles/modals/sfxEditor.css
@@ -1,0 +1,99 @@
+.sfx-editor-modal {
+  padding: 14px 14px 16px;
+  gap: 12px;
+  background: linear-gradient(180deg, #0f1b2f 0%, #0a1425 100%);
+  width: min(90vw, 720px);
+}
+
+.sfx-editor-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.sfx-editor-title {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.sfx-editor-subtitle {
+  color: var(--text-dim);
+  font-size: 12px;
+  max-width: 420px;
+}
+
+.sfx-editor-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  overflow: auto;
+  padding: 0 2px 6px;
+}
+
+.sfx-editor-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.sfx-editor-row > span:first-child {
+  flex: 1 1 160px;
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
+.sfx-editor-row input[type='range'] {
+  flex: 1;
+  accent-color: var(--accent);
+}
+
+.sfx-editor-row-label {
+  flex: 1;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.sfx-editor-value {
+  color: var(--accent);
+  font-size: 12px;
+  text-align: right;
+  min-width: 48px;
+}
+
+.sfx-editor-reset-all {
+  align-self: flex-end;
+  margin-top: 8px;
+}
+
+.sfx-editor-edit-title {
+  font-weight: 700;
+  color: var(--text);
+  font-size: 15px;
+}
+
+.sfx-editor-layer {
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sfx-editor-layer legend {
+  color: var(--accent);
+  font-weight: 700;
+  font-size: 13px;
+  padding: 0 6px;
+}
+
+.sfx-editor-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding-top: 8px;
+}

--- a/app/src/ui/settingsModal.ts
+++ b/app/src/ui/settingsModal.ts
@@ -4,6 +4,7 @@ import { defaultHotkeys, HotkeyAction } from './hotkeys';
 interface SettingsModalOptions {
   getSettings: () => GameSettings;
   onApply: (settings: GameSettings) => void;
+  onOpenSfxEditor?: () => void;
 }
 
 const PAN_SPEED_LABELS: Record<PanSpeedPreset, string> = {
@@ -98,7 +99,7 @@ function createToggleRow(options: {
 }
 
 export function initSettingsModal(options: SettingsModalOptions) {
-  const { getSettings, onApply } = options;
+  const { getSettings, onApply, onOpenSfxEditor } = options;
   let backdrop: HTMLDivElement | null = null;
   let escHandler: ((e: KeyboardEvent) => void) | null = null;
   const cleanup = () => {
@@ -328,7 +329,7 @@ export function initSettingsModal(options: SettingsModalOptions) {
     });
     input.append(invertPanRow, panSpeedRow, shiftScrollRow, ctrlScrollRow, zoomRow, edgeScrollRow);
 
-    const audio = createSection('Audio', 'Radio volume and future effects.');
+    const audio = createSection('Audio', 'Radio and sound effect volume.');
     const radioRow = document.createElement('div');
     radioRow.className = 'settings-row';
     const radioLabel = document.createElement('div');
@@ -353,18 +354,38 @@ export function initSettingsModal(options: SettingsModalOptions) {
     sfxRow.className = 'settings-row';
     const sfxLabel = document.createElement('div');
     sfxLabel.className = 'settings-label';
-    sfxLabel.textContent = 'Sound effects (stub)';
+    sfxLabel.textContent = 'Sound effects';
     const sfxDesc = document.createElement('div');
     sfxDesc.className = 'settings-description';
-    sfxDesc.textContent = 'Placeholder control for future effects.';
+    sfxDesc.textContent = 'Volume for placement, bulldoze, and error sounds.';
     const sfxSlider = document.createElement('input');
     sfxSlider.type = 'range';
     sfxSlider.min = '0';
     sfxSlider.max = '100';
     sfxSlider.value = Math.round((draft.audio.sfxVolume ?? 1) * 100).toString();
-    sfxSlider.disabled = true;
+    sfxSlider.addEventListener('input', () => {
+      const next = Math.max(0, Math.min(100, Number(sfxSlider.value)));
+      draft.audio.sfxVolume = next / 100;
+      onApply(draft);
+    });
     sfxRow.append(sfxLabel, sfxDesc, sfxSlider);
-    audio.append(radioRow, sfxRow);
+
+    const sfxEditorRow = document.createElement('div');
+    sfxEditorRow.className = 'settings-row';
+    const sfxEditorLabel = document.createElement('div');
+    sfxEditorLabel.className = 'settings-label';
+    sfxEditorLabel.textContent = 'Customize sound effects';
+    const sfxEditorDesc = document.createElement('div');
+    sfxEditorDesc.className = 'settings-description';
+    sfxEditorDesc.textContent = 'Edit, preview, and save your own version of each sound.';
+    const sfxEditorBtn = document.createElement('button');
+    sfxEditorBtn.type = 'button';
+    sfxEditorBtn.className = 'secondary';
+    sfxEditorBtn.textContent = '🎚️ Edit Sound Effects';
+    sfxEditorBtn.addEventListener('click', () => onOpenSfxEditor?.());
+    sfxEditorRow.append(sfxEditorLabel, sfxEditorDesc, sfxEditorBtn);
+
+    audio.append(radioRow, sfxRow, sfxEditorRow);
 
     const accessibility = createSection('Accessibility', 'Make the HUD easier to parse.');
     const reducedMotionRow = createToggleRow({

--- a/app/src/ui/sfx.test.ts
+++ b/app/src/ui/sfx.test.ts
@@ -1,0 +1,130 @@
+// Unit tests for SFX dispatch, throttling/priority, muting, and preview
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const playSpy = vi.fn();
+
+vi.mock('@liminal-hq/undertone', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@liminal-hq/undertone')>();
+  return {
+    ...actual,
+    stack: vi.fn(() => ({ play: playSpy }))
+  };
+});
+
+import { Tool } from '../game/toolTypes';
+import { initSfx } from './sfx';
+
+function createFakeAudioContext(): AudioContext {
+  const gainNode = { connect: vi.fn(), gain: { value: 0 } };
+  return {
+    createGain: vi.fn(() => gainNode),
+    destination: {},
+    state: 'running',
+    resume: vi.fn(async () => {})
+  } as unknown as AudioContext;
+}
+
+function initTestSfx(overrides: Partial<Parameters<typeof initSfx>[0]> = {}) {
+  return initSfx({
+    getVolume: () => 1,
+    getCityOverrides: () => ({}),
+    getGlobalOverrides: () => ({}),
+    createAudioContext: createFakeAudioContext,
+    ...overrides
+  });
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+});
+
+describe('playToolResult dispatch', () => {
+  it('plays the error sound whenever the tool result failed, regardless of tool', () => {
+    initTestSfx().playToolResult(Tool.Road, false);
+    expect(playSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('plays bulldoze on a successful Bulldoze', () => {
+    initTestSfx().playToolResult(Tool.Bulldoze, true);
+    expect(playSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('plays nothing for a successful Inspect', () => {
+    initTestSfx().playToolResult(Tool.Inspect, true);
+    expect(playSpy).not.toHaveBeenCalled();
+  });
+
+  it('plays placeBuilding for any other successful tool', () => {
+    initTestSfx().playToolResult(Tool.Road, true);
+    expect(playSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('volume and muting', () => {
+  it('skips playing entirely and never constructs an AudioContext when volume is 0', () => {
+    const createAudioContext = vi.fn(createFakeAudioContext);
+    const sfx = initTestSfx({ getVolume: () => 0, createAudioContext });
+    sfx.playToolResult(Tool.Road, true);
+    expect(playSpy).not.toHaveBeenCalled();
+    expect(createAudioContext).not.toHaveBeenCalled();
+  });
+
+  it('creates the AudioContext lazily, once, and reuses it across plays', () => {
+    const createAudioContext = vi.fn(createFakeAudioContext);
+    const sfx = initTestSfx({ createAudioContext });
+    sfx.playToolResult(Tool.Road, true);
+    sfx.playUndo();
+    expect(createAudioContext).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('priority and throttling', () => {
+  it('placeBuilding (priority 1) never throttles, even called back-to-back', () => {
+    const sfx = initTestSfx();
+    for (let i = 0; i < 5; i++) {
+      sfx.playToolResult(Tool.Road, true);
+    }
+    expect(playSpy).toHaveBeenCalledTimes(5);
+  });
+
+  it('throttles rapid repeated bulldoze calls within the cooldown window', () => {
+    let now = 1000;
+    vi.spyOn(performance, 'now').mockImplementation(() => now);
+    const sfx = initTestSfx();
+
+    sfx.playToolResult(Tool.Bulldoze, true); // plays
+    now += 10; // within the 50ms cooldown
+    sfx.playToolResult(Tool.Bulldoze, true); // throttled
+    now += 10; // still within cooldown (20ms elapsed)
+    sfx.playToolResult(Tool.Bulldoze, true); // throttled
+    now += 40; // 60ms elapsed since the first play — past cooldown
+    sfx.playToolResult(Tool.Bulldoze, true); // plays
+
+    expect(playSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('preview', () => {
+  it('bypasses throttling', () => {
+    let now = 1000;
+    vi.spyOn(performance, 'now').mockImplementation(() => now);
+    const sfx = initTestSfx();
+
+    sfx.playToolResult(Tool.Bulldoze, true); // plays, sets the bulldoze cooldown
+    now += 1; // well within the cooldown
+    sfx.preview('bulldoze'); // should play anyway — preview ignores throttling
+
+    expect(playSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('plays a draft params array when one is given, instead of the saved/default version', () => {
+    const sfx = initTestSfx();
+    sfx.preview('placeBuilding', []);
+    expect(playSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/ui/sfx.ts
+++ b/app/src/ui/sfx.ts
@@ -1,0 +1,115 @@
+// Plays the game's procedural sound effects via @liminal-hq/undertone
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { stack, type AudioContextLike, type VoiceParams } from '@liminal-hq/undertone';
+import { Tool } from '../game/toolTypes';
+import { resolveVoiceParams, type SfxEffectId, type SfxOverrides } from '../game/sfxOverrides';
+import { DEFAULT_SFX_VOICES, voiceFromParams } from './sfxDefinitions';
+
+/** Sounds other than the priority-1 placeBuilding "plop" get a minimum replay
+ * interval so a fast drag-stroke doesn't stack overlapping copies into mush. */
+const THROTTLE_MS: Partial<Record<SfxEffectId, number>> = {
+  bulldoze: 50,
+  error: 80,
+  undo: 80
+};
+
+export interface SfxController {
+  playToolResult(tool: Tool, success: boolean): void;
+  playUndo(): void;
+  /** Plays a draft (unsaved) voice stack immediately, bypassing throttling — for the editor's preview button. */
+  preview(id: SfxEffectId, draftParams?: VoiceParams[]): void;
+}
+
+export interface SfxOptions {
+  getVolume: () => number;
+  getCityOverrides: () => SfxOverrides;
+  getGlobalOverrides: () => SfxOverrides;
+  /** Injectable for tests; defaults to the real AudioContext constructor. */
+  createAudioContext?: () => AudioContext;
+}
+
+/** Wraps a real AudioContext so every voice routes through one master GainNode instead
+ * of straight to ctx.destination — Undertone's SoundEffect.play() has no volume knob
+ * of its own, so this is the only way a settings slider can control playback volume. */
+function createMasterGainContext(audioContext: AudioContext): { ctx: AudioContextLike; masterGain: GainNode } {
+  const masterGain = audioContext.createGain();
+  masterGain.connect(audioContext.destination);
+  const ctx: AudioContextLike = {
+    get currentTime() {
+      return audioContext.currentTime;
+    },
+    get sampleRate() {
+      return audioContext.sampleRate;
+    },
+    destination: masterGain,
+    createOscillator: () => audioContext.createOscillator(),
+    createGain: () => audioContext.createGain(),
+    createBiquadFilter: () => audioContext.createBiquadFilter(),
+    createBufferSource: () => audioContext.createBufferSource(),
+    createBuffer: (numChannels, length, sampleRate) => audioContext.createBuffer(numChannels, length, sampleRate)
+  };
+  return { ctx, masterGain };
+}
+
+export function initSfx(options: SfxOptions): SfxController {
+  let lazy: { audioContext: AudioContext; ctx: AudioContextLike; masterGain: GainNode } | undefined;
+  const lastPlayedAt: Partial<Record<SfxEffectId, number>> = {};
+
+  function ensure() {
+    if (!lazy) {
+      const audioContext = (options.createAudioContext ?? (() => new AudioContext()))();
+      const { ctx, masterGain } = createMasterGainContext(audioContext);
+      lazy = { audioContext, ctx, masterGain };
+    }
+    lazy.masterGain.gain.value = options.getVolume();
+    return lazy;
+  }
+
+  function playParams(params: VoiceParams[]): void {
+    if (options.getVolume() <= 0) return;
+    const { audioContext, ctx } = ensure();
+    if (audioContext.state === 'suspended') {
+      void audioContext.resume();
+    }
+    stack(...params.map(voiceFromParams)).play(ctx);
+  }
+
+  function resolveParams(id: SfxEffectId): VoiceParams[] {
+    return resolveVoiceParams(id, DEFAULT_SFX_VOICES, options.getCityOverrides(), options.getGlobalOverrides());
+  }
+
+  function play(id: SfxEffectId): void {
+    const minInterval = THROTTLE_MS[id];
+    if (minInterval !== undefined) {
+      const now = performance.now();
+      if (now - (lastPlayedAt[id] ?? -Infinity) < minInterval) return;
+      lastPlayedAt[id] = now;
+    }
+    playParams(resolveParams(id));
+  }
+
+  return {
+    playToolResult(tool, success) {
+      if (!success) {
+        play('error');
+        return;
+      }
+      if (tool === Tool.Bulldoze) {
+        play('bulldoze');
+        return;
+      }
+      if (tool === Tool.Inspect) return;
+      // Priority-1 sound: always plays, never throttled.
+      playParams(resolveParams('placeBuilding'));
+    },
+    playUndo() {
+      play('undo');
+    },
+    preview(id, draftParams) {
+      playParams(draftParams ?? resolveParams(id));
+    }
+  };
+}

--- a/app/src/ui/sfxDefinitions.test.ts
+++ b/app/src/ui/sfxDefinitions.test.ts
@@ -1,0 +1,51 @@
+// Unit tests for the built-in default SFX voice definitions and params<->Voice reconstruction
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+import { note, sound } from '@liminal-hq/undertone';
+import { DEFAULT_SFX_VOICES, voiceFromParams } from './sfxDefinitions';
+import { SFX_EFFECT_IDS } from '../game/sfxOverrides';
+
+describe('DEFAULT_SFX_VOICES', () => {
+  it('defines a non-empty voice stack for every known effect id', () => {
+    for (const id of SFX_EFFECT_IDS) {
+      expect(DEFAULT_SFX_VOICES[id].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('placeBuilding has three layers (thunk, sparkle, click)', () => {
+    expect(DEFAULT_SFX_VOICES.placeBuilding).toHaveLength(3);
+  });
+});
+
+describe('voiceFromParams', () => {
+  it('round-trips a pitched voice: params -> Voice -> getParams() matches', () => {
+    const original = note('c2').sound('triangle').attack(0.001).decay(0.1).lpf(220).getParams();
+    const rebuilt = voiceFromParams(original).getParams();
+    expect(rebuilt).toEqual(original);
+  });
+
+  it('round-trips a noise voice with no pitch', () => {
+    const original = sound('white').attack(0).decay(0.02).gain(0.4).getParams();
+    const rebuilt = voiceFromParams(original).getParams();
+    expect(rebuilt).toEqual(original);
+    expect(rebuilt.pitch).toBeUndefined();
+  });
+
+  it('round-trips every built-in default voice exactly', () => {
+    for (const id of SFX_EFFECT_IDS) {
+      for (const params of DEFAULT_SFX_VOICES[id]) {
+        expect(voiceFromParams(params).getParams()).toEqual(params);
+      }
+    }
+  });
+
+  it('omits the filter entirely when filterCutoff is undefined', () => {
+    const original = note('a4').getParams();
+    expect(original.filterCutoff).toBeUndefined();
+    const rebuilt = voiceFromParams(original).getParams();
+    expect(rebuilt.filterCutoff).toBeUndefined();
+  });
+});

--- a/app/src/ui/sfxDefinitions.ts
+++ b/app/src/ui/sfxDefinitions.ts
@@ -1,0 +1,109 @@
+// Built-in default sound effects (ported from @liminal-hq/undertone's own tuned demo presets)
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { note, sound, Voice, type VoiceParams } from '@liminal-hq/undertone';
+import type { SfxEffectId } from '../game/sfxOverrides';
+
+export const DEFAULT_SFX_VOICES: Record<SfxEffectId, VoiceParams[]> = {
+  placeBuilding: [
+    note('c2')
+      .sound('triangle')
+      .attack(0.001)
+      .decay(0.1)
+      .sustain(0)
+      .release(0.05)
+      .gain(0.9)
+      .lpf(220)
+      .lpenv(5)
+      .lpa(0.001)
+      .lpd(0.08)
+      .lps(0)
+      .lpr(0.05)
+      .slide(0.07)
+      .getParams(),
+    note('c6')
+      .sound('sine')
+      .attack(0.001)
+      .decay(0.15)
+      .sustain(0)
+      .release(0.1)
+      .gain(0.3)
+      .lpf(2000)
+      .lpenv(8)
+      .lpa(0.001)
+      .lpd(0.06)
+      .lps(0)
+      .lpr(0.1)
+      .nudge(0.02)
+      .getParams(),
+    sound('white').attack(0).decay(0.02).sustain(0).release(0.01).gain(0.4).lpf(4000).lpenv(0).getParams()
+  ],
+  bulldoze: [
+    note('a1')
+      .sound('sawtooth')
+      .attack(0.001)
+      .decay(0.14)
+      .sustain(0)
+      .release(0.08)
+      .gain(0.7)
+      .lpf(180)
+      .lpenv(3)
+      .lpa(0.001)
+      .lpd(0.1)
+      .lps(0)
+      .lpr(0.08)
+      .slide(0.12)
+      .getParams(),
+    sound('brown').attack(0.001).decay(0.1).sustain(0.1).release(0.12).gain(0.5).lpf(900).lpenv(0).getParams()
+  ],
+  error: [
+    note('a2')
+      .sound('square')
+      .attack(0.001)
+      .decay(0.12)
+      .sustain(0)
+      .release(0.08)
+      .gain(0.5)
+      .lpf(600)
+      .lpenv(0)
+      .slide(0.15)
+      .getParams()
+  ],
+  undo: [
+    note('a4')
+      .sound('square')
+      .attack(0.001)
+      .decay(0.08)
+      .sustain(0)
+      .release(0.04)
+      .gain(0.35)
+      .lpf(2200)
+      .slide(0.05)
+      .getParams()
+  ]
+};
+
+/** Mechanically reconstructs a Voice from a raw params object — every field maps to one setter. */
+export function voiceFromParams(params: VoiceParams): Voice {
+  const base = params.pitch !== undefined ? note(params.pitch) : sound(params.soundType);
+  let voice = base
+    .sound(params.soundType)
+    .attack(params.attack)
+    .decay(params.decay)
+    .sustain(params.sustain)
+    .release(params.release)
+    .gain(params.gainLevel)
+    .lpenv(params.filterEnvAmount)
+    .lpa(params.filterAttack)
+    .lpd(params.filterDecay)
+    .lps(params.filterSustain)
+    .lpr(params.filterRelease)
+    .slide(params.slideTime)
+    .nudge(params.nudgeTime);
+  if (params.filterCutoff !== undefined) {
+    voice = voice.lpf(params.filterCutoff);
+  }
+  return voice;
+}

--- a/app/src/ui/sfxEditor.test.ts
+++ b/app/src/ui/sfxEditor.test.ts
@@ -1,0 +1,162 @@
+// Unit tests for the in-game sound effects editor modal
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SFX_EFFECT_IDS } from '../game/sfxOverrides';
+import type { SfxOverrides } from '../game/sfxOverrides';
+import { DEFAULT_SFX_VOICES } from './sfxDefinitions';
+import { initSfxEditorModal, type SfxEditorOptions } from './sfxEditor';
+import type { SfxController } from './sfx';
+
+function createFakeSfx(): SfxController {
+  return {
+    playToolResult: vi.fn(),
+    playUndo: vi.fn(),
+    preview: vi.fn()
+  };
+}
+
+function initTestEditor(overrides: Partial<SfxEditorOptions> = {}) {
+  const sfx = createFakeSfx();
+  const onSaveCity = vi.fn();
+  const onSaveGlobal = vi.fn();
+  const editor = initSfxEditorModal({
+    sfx,
+    getCityOverrides: () => ({}),
+    getGlobalOverrides: () => ({}),
+    onSaveCity,
+    onSaveGlobal,
+    ...overrides
+  });
+  return { editor, sfx, onSaveCity, onSaveGlobal };
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('list view', () => {
+  it('shows a row for every known effect when opened', () => {
+    const { editor } = initTestEditor();
+    editor.open();
+    const rows = document.querySelectorAll('.sfx-editor-row-label');
+    expect(rows).toHaveLength(SFX_EFFECT_IDS.length);
+  });
+
+  it('preview button plays the resolved (saved or default) version, not a draft', () => {
+    const { editor, sfx } = initTestEditor();
+    editor.open();
+    const previewBtn = document.querySelectorAll('.sfx-editor-row button')[0] as HTMLButtonElement;
+    previewBtn.click();
+    expect(sfx.preview).toHaveBeenCalledWith(SFX_EFFECT_IDS[0]);
+  });
+
+  it('reset clears the effect from both scopes', () => {
+    const cityOverrides: SfxOverrides = { placeBuilding: DEFAULT_SFX_VOICES.placeBuilding };
+    const { editor, onSaveCity, onSaveGlobal } = initTestEditor({ getCityOverrides: () => cityOverrides });
+    editor.open();
+    const resetBtn = document.querySelectorAll('.sfx-editor-row button')[2] as HTMLButtonElement;
+    resetBtn.click();
+    expect(onSaveCity).toHaveBeenCalledWith({});
+    expect(onSaveGlobal).toHaveBeenCalledWith({});
+  });
+
+  it('reset all clears every effect from both scopes', () => {
+    const { editor, onSaveCity, onSaveGlobal } = initTestEditor();
+    editor.open();
+    const resetAllBtn = document.querySelector<HTMLButtonElement>('.sfx-editor-reset-all');
+    resetAllBtn?.click();
+    expect(onSaveCity).toHaveBeenCalledWith({});
+    expect(onSaveGlobal).toHaveBeenCalledWith({});
+  });
+});
+
+describe('edit view', () => {
+  it('renders one layer section per voice in the stack (placeBuilding has 3)', () => {
+    const { editor } = initTestEditor();
+    editor.open();
+    const editBtn = document.querySelectorAll('.sfx-editor-row button')[1] as HTMLButtonElement;
+    editBtn.click();
+    const layers = document.querySelectorAll('.sfx-editor-layer');
+    expect(layers).toHaveLength(DEFAULT_SFX_VOICES.placeBuilding.length);
+  });
+
+  it('preview plays the in-progress draft, not just the saved version', () => {
+    const { editor, sfx } = initTestEditor();
+    editor.open();
+    const editBtn = document.querySelectorAll('.sfx-editor-row button')[1] as HTMLButtonElement;
+    editBtn.click();
+    const previewBtn = document.querySelector<HTMLButtonElement>('.sfx-editor-actions button');
+    previewBtn?.click();
+    expect(sfx.preview).toHaveBeenCalledWith('placeBuilding', expect.any(Array));
+    const draftArg = (sfx.preview as ReturnType<typeof vi.fn>).mock.calls[0][1];
+    expect(draftArg).toHaveLength(DEFAULT_SFX_VOICES.placeBuilding.length);
+  });
+
+  it('save to city calls onSaveCity with the effect set to the edited stack', () => {
+    const { editor, onSaveCity } = initTestEditor();
+    editor.open();
+    const editBtn = document.querySelectorAll('.sfx-editor-row button')[1] as HTMLButtonElement;
+    editBtn.click();
+    const [, saveCityBtn] = document.querySelectorAll<HTMLButtonElement>('.sfx-editor-actions button');
+    saveCityBtn.click();
+    expect(onSaveCity).toHaveBeenCalledWith(
+      expect.objectContaining({ placeBuilding: expect.any(Array) })
+    );
+  });
+
+  it('save globally calls onSaveGlobal with the effect set to the edited stack', () => {
+    const { editor, onSaveGlobal } = initTestEditor();
+    editor.open();
+    const editBtn = document.querySelectorAll('.sfx-editor-row button')[1] as HTMLButtonElement;
+    editBtn.click();
+    const [, , saveGlobalBtn] = document.querySelectorAll<HTMLButtonElement>('.sfx-editor-actions button');
+    saveGlobalBtn.click();
+    expect(onSaveGlobal).toHaveBeenCalledWith(
+      expect.objectContaining({ placeBuilding: expect.any(Array) })
+    );
+  });
+
+  it('editing a slider updates the draft passed to preview', () => {
+    const { editor, sfx } = initTestEditor();
+    editor.open();
+    const editBtn = document.querySelectorAll('.sfx-editor-row button')[1] as HTMLButtonElement;
+    editBtn.click();
+
+    const gainSlider = Array.from(document.querySelectorAll<HTMLInputElement>('input[type="range"]')).find(
+      (input) => input.previousElementSibling?.textContent === 'Gain (0-1)'
+    );
+    expect(gainSlider).toBeDefined();
+    gainSlider!.value = '0.42';
+    gainSlider!.dispatchEvent(new Event('input'));
+
+    const previewBtn = document.querySelector<HTMLButtonElement>('.sfx-editor-actions button');
+    previewBtn?.click();
+    const draftArg = (sfx.preview as ReturnType<typeof vi.fn>).mock.calls[0][1];
+    expect(draftArg[0].gainLevel).toBeCloseTo(0.42);
+  });
+
+  it('cancel discards the draft and returns to the list view without saving', () => {
+    const { editor, onSaveCity, onSaveGlobal } = initTestEditor();
+    editor.open();
+    const editBtn = document.querySelectorAll('.sfx-editor-row button')[1] as HTMLButtonElement;
+    editBtn.click();
+    const buttons = document.querySelectorAll<HTMLButtonElement>('.sfx-editor-actions button');
+    buttons[buttons.length - 1].click(); // Cancel is last
+    expect(onSaveCity).not.toHaveBeenCalled();
+    expect(onSaveGlobal).not.toHaveBeenCalled();
+    expect(document.querySelectorAll('.sfx-editor-row-label')).toHaveLength(SFX_EFFECT_IDS.length);
+  });
+});
+
+describe('close behaviour', () => {
+  it('the Close button removes the modal from the DOM', () => {
+    const { editor } = initTestEditor();
+    editor.open();
+    expect(document.querySelector('.modal-backdrop')).not.toBeNull();
+    document.querySelector<HTMLButtonElement>('.modal-close')?.click();
+    expect(document.querySelector('.modal-backdrop')).toBeNull();
+  });
+});

--- a/app/src/ui/sfxEditor.ts
+++ b/app/src/ui/sfxEditor.ts
@@ -1,0 +1,315 @@
+// The in-game sound effects editor: per-layer voice parameters, preview, save/reset
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import type { SoundType, VoiceParams } from '@liminal-hq/undertone';
+import {
+  SFX_EFFECT_IDS,
+  SFX_EFFECT_LABELS,
+  resetEffect,
+  resolveVoiceParams,
+  type SfxEffectId,
+  type SfxOverrides
+} from '../game/sfxOverrides';
+import { DEFAULT_SFX_VOICES } from './sfxDefinitions';
+import type { SfxController } from './sfx';
+
+const SOUND_TYPES: SoundType[] = ['sine', 'triangle', 'square', 'sawtooth', 'white', 'pink', 'brown'];
+const NOISE_TYPES = new Set<SoundType>(['white', 'pink', 'brown']);
+
+interface FieldConfig {
+  key: keyof VoiceParams;
+  label: string;
+  min: number;
+  max: number;
+  step: number;
+}
+
+// lpf uses 0 as a "no filter" sentinel — filterCutoff is undefined below that, matching
+// how Undertone itself treats an absent filterCutoff as "skip creating a filter at all".
+const FIELDS: FieldConfig[] = [
+  { key: 'attack', label: 'Attack (s)', min: 0, max: 1, step: 0.001 },
+  { key: 'decay', label: 'Decay (s)', min: 0, max: 1, step: 0.001 },
+  { key: 'sustain', label: 'Sustain (0-1)', min: 0, max: 1, step: 0.01 },
+  { key: 'release', label: 'Release (s)', min: 0, max: 1, step: 0.001 },
+  { key: 'gainLevel', label: 'Gain (0-1)', min: 0, max: 1, step: 0.01 },
+  { key: 'filterCutoff', label: 'Filter cutoff (Hz, 0 = off)', min: 0, max: 8000, step: 10 },
+  { key: 'filterEnvAmount', label: 'Filter env amount (Hz)', min: 0, max: 8000, step: 10 },
+  { key: 'filterAttack', label: 'Filter attack (s)', min: 0, max: 1, step: 0.001 },
+  { key: 'filterDecay', label: 'Filter decay (s)', min: 0, max: 1, step: 0.001 },
+  { key: 'filterSustain', label: 'Filter sustain (0-1)', min: 0, max: 1, step: 0.01 },
+  { key: 'filterRelease', label: 'Filter release (s)', min: 0, max: 1, step: 0.001 },
+  { key: 'slideTime', label: 'Slide (s)', min: 0, max: 1, step: 0.001 },
+  { key: 'nudgeTime', label: 'Nudge (s)', min: 0, max: 1, step: 0.001 }
+];
+
+function fieldValue(params: VoiceParams, key: keyof VoiceParams): number {
+  const value = params[key];
+  return typeof value === 'number' ? value : 0;
+}
+
+function setFieldValue(params: VoiceParams, key: keyof VoiceParams, value: number): void {
+  if (key === 'filterCutoff') {
+    params.filterCutoff = value > 0 ? value : undefined;
+    return;
+  }
+  (params as unknown as Record<string, number>)[key] = value;
+}
+
+export interface SfxEditorOptions {
+  sfx: SfxController;
+  getCityOverrides: () => SfxOverrides;
+  getGlobalOverrides: () => SfxOverrides;
+  onSaveCity: (next: SfxOverrides) => void;
+  onSaveGlobal: (next: SfxOverrides) => void;
+}
+
+export function initSfxEditorModal(options: SfxEditorOptions) {
+  const { sfx, getCityOverrides, getGlobalOverrides, onSaveCity, onSaveGlobal } = options;
+  let backdrop: HTMLDivElement | null = null;
+  let escHandler: ((event: KeyboardEvent) => void) | null = null;
+  let body: HTMLDivElement | null = null;
+
+  const cleanup = () => {
+    if (escHandler) {
+      window.removeEventListener('keydown', escHandler);
+      escHandler = null;
+    }
+    if (backdrop) {
+      backdrop.remove();
+      backdrop = null;
+    }
+    body = null;
+  };
+
+  function resolveCurrent(id: SfxEffectId): VoiceParams[] {
+    return resolveVoiceParams(id, DEFAULT_SFX_VOICES, getCityOverrides(), getGlobalOverrides());
+  }
+
+  function renderListView(): void {
+    if (!body) return;
+    body.innerHTML = '';
+
+    for (const id of SFX_EFFECT_IDS) {
+      const row = document.createElement('div');
+      row.className = 'sfx-editor-row';
+
+      const label = document.createElement('div');
+      label.className = 'sfx-editor-row-label';
+      label.textContent = SFX_EFFECT_LABELS[id];
+
+      const previewBtn = document.createElement('button');
+      previewBtn.type = 'button';
+      previewBtn.className = 'secondary';
+      previewBtn.textContent = '▶ Preview';
+      previewBtn.addEventListener('click', () => sfx.preview(id));
+
+      const editBtn = document.createElement('button');
+      editBtn.type = 'button';
+      editBtn.className = 'secondary';
+      editBtn.textContent = '✏️ Edit';
+      editBtn.addEventListener('click', () => renderEditView(id));
+
+      const resetBtn = document.createElement('button');
+      resetBtn.type = 'button';
+      resetBtn.className = 'secondary';
+      resetBtn.textContent = '↺ Reset';
+      resetBtn.addEventListener('click', () => {
+        onSaveCity(resetEffect(getCityOverrides(), id));
+        onSaveGlobal(resetEffect(getGlobalOverrides(), id));
+        renderListView();
+      });
+
+      row.append(label, previewBtn, editBtn, resetBtn);
+      body.appendChild(row);
+    }
+
+    const resetAllBtn = document.createElement('button');
+    resetAllBtn.type = 'button';
+    resetAllBtn.className = 'secondary sfx-editor-reset-all';
+    resetAllBtn.textContent = '↺↺ Reset All';
+    resetAllBtn.addEventListener('click', () => {
+      onSaveCity({});
+      onSaveGlobal({});
+      renderListView();
+    });
+    body.appendChild(resetAllBtn);
+  }
+
+  function renderEditView(id: SfxEffectId): void {
+    if (!body) return;
+    const bodyEl = body;
+    bodyEl.innerHTML = '';
+
+    // Deep clone so edits don't mutate the live saved/default params until Save is pressed.
+    const draft: VoiceParams[] = resolveCurrent(id).map((params) => ({ ...params }));
+
+    const heading = document.createElement('div');
+    heading.className = 'sfx-editor-edit-title';
+    heading.textContent = `Editing: ${SFX_EFFECT_LABELS[id]}`;
+    bodyEl.appendChild(heading);
+
+    draft.forEach((params, layerIndex) => {
+      const section = document.createElement('fieldset');
+      section.className = 'sfx-editor-layer';
+      const legend = document.createElement('legend');
+      legend.textContent = `Layer ${layerIndex + 1}`;
+      section.appendChild(legend);
+
+      const soundRow = document.createElement('label');
+      soundRow.className = 'sfx-editor-row';
+      const soundLabel = document.createElement('span');
+      soundLabel.textContent = 'Sound';
+      const soundSelect = document.createElement('select');
+      for (const type of SOUND_TYPES) {
+        const option = document.createElement('option');
+        option.value = type;
+        option.textContent = NOISE_TYPES.has(type) ? `${type} noise` : type;
+        option.selected = type === params.soundType;
+        soundSelect.appendChild(option);
+      }
+      soundSelect.addEventListener('change', () => {
+        params.soundType = soundSelect.value as SoundType;
+      });
+      soundRow.append(soundLabel, soundSelect);
+      section.appendChild(soundRow);
+
+      const pitchRow = document.createElement('label');
+      pitchRow.className = 'sfx-editor-row';
+      const pitchLabel = document.createElement('span');
+      pitchLabel.textContent = 'Note (ignored for noise)';
+      const pitchInput = document.createElement('input');
+      pitchInput.type = 'text';
+      pitchInput.value = typeof params.pitch === 'string' ? params.pitch : (params.pitch?.toString() ?? 'c4');
+      pitchInput.addEventListener('input', () => {
+        params.pitch = pitchInput.value;
+      });
+      pitchRow.append(pitchLabel, pitchInput);
+      section.appendChild(pitchRow);
+
+      for (const field of FIELDS) {
+        const row = document.createElement('label');
+        row.className = 'sfx-editor-row';
+        const nameSpan = document.createElement('span');
+        nameSpan.textContent = field.label;
+        const rangeInput = document.createElement('input');
+        rangeInput.type = 'range';
+        rangeInput.min = String(field.min);
+        rangeInput.max = String(field.max);
+        rangeInput.step = String(field.step);
+        rangeInput.value = String(fieldValue(params, field.key));
+        const valueSpan = document.createElement('span');
+        valueSpan.className = 'sfx-editor-value';
+        valueSpan.textContent = rangeInput.value;
+        rangeInput.addEventListener('input', () => {
+          setFieldValue(params, field.key, Number(rangeInput.value));
+          valueSpan.textContent = rangeInput.value;
+        });
+        row.append(nameSpan, rangeInput, valueSpan);
+        section.appendChild(row);
+      }
+
+      bodyEl.appendChild(section);
+    });
+
+    const actions = document.createElement('div');
+    actions.className = 'sfx-editor-actions';
+
+    const previewBtn = document.createElement('button');
+    previewBtn.type = 'button';
+    previewBtn.className = 'secondary';
+    previewBtn.textContent = '▶ Preview';
+    previewBtn.addEventListener('click', () => sfx.preview(id, draft));
+
+    const saveCityBtn = document.createElement('button');
+    saveCityBtn.type = 'button';
+    saveCityBtn.className = 'primary';
+    saveCityBtn.textContent = '💾 Save to this city';
+    saveCityBtn.addEventListener('click', () => {
+      onSaveCity({ ...getCityOverrides(), [id]: draft });
+      renderListView();
+    });
+
+    const saveGlobalBtn = document.createElement('button');
+    saveGlobalBtn.type = 'button';
+    saveGlobalBtn.className = 'primary';
+    saveGlobalBtn.textContent = '🌐 Save globally';
+    saveGlobalBtn.addEventListener('click', () => {
+      onSaveGlobal({ ...getGlobalOverrides(), [id]: draft });
+      renderListView();
+    });
+
+    const resetBtn = document.createElement('button');
+    resetBtn.type = 'button';
+    resetBtn.className = 'secondary';
+    resetBtn.textContent = '↺ Reset';
+    resetBtn.addEventListener('click', () => {
+      onSaveCity(resetEffect(getCityOverrides(), id));
+      onSaveGlobal(resetEffect(getGlobalOverrides(), id));
+      renderListView();
+    });
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.className = 'secondary';
+    cancelBtn.textContent = '✕ Cancel';
+    cancelBtn.addEventListener('click', () => renderListView());
+
+    actions.append(previewBtn, saveCityBtn, saveGlobalBtn, resetBtn, cancelBtn);
+    bodyEl.appendChild(actions);
+  }
+
+  const open = () => {
+    if (backdrop) return;
+
+    backdrop = document.createElement('div');
+    backdrop.className = 'modal-backdrop';
+
+    const modal = document.createElement('div');
+    modal.className = 'modal sfx-editor-modal';
+    modal.setAttribute('role', 'dialog');
+    modal.setAttribute('aria-modal', 'true');
+    modal.setAttribute('aria-label', 'Sound effects editor');
+
+    const header = document.createElement('div');
+    header.className = 'sfx-editor-header';
+    const title = document.createElement('div');
+    title.className = 'sfx-editor-title';
+    title.textContent = 'Sound Effects';
+    const subtitle = document.createElement('div');
+    subtitle.className = 'sfx-editor-subtitle';
+    subtitle.textContent = 'Preview, customize, and save your own version of each sound.';
+    const titleBlock = document.createElement('div');
+    titleBlock.append(title, subtitle);
+
+    const closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.textContent = 'Close';
+    closeBtn.className = 'secondary modal-close';
+
+    header.append(titleBlock, closeBtn);
+
+    body = document.createElement('div');
+    body.className = 'sfx-editor-body';
+
+    modal.append(header, body);
+    backdrop.appendChild(modal);
+    document.body.appendChild(backdrop);
+
+    renderListView();
+
+    escHandler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') cleanup();
+    };
+    window.addEventListener('keydown', escHandler);
+
+    closeBtn.addEventListener('click', cleanup);
+    backdrop.addEventListener('click', (event) => {
+      if (event.target === backdrop) cleanup();
+    });
+    modal.addEventListener('click', (event) => event.stopPropagation());
+  };
+
+  return { open, close: cleanup };
+}

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
       "name": "city-sim-1000",
       "version": "0.1.0",
       "dependencies": {
+        "@liminal-hq/undertone": "^0.1.1",
         "@tauri-apps/api": "^2.0.0",
         "pixi.js": "^8.1.5",
         "tauri-plugin-city-sim": "workspace:*",
@@ -323,6 +324,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@liminal-hq/undertone": ["@liminal-hq/undertone@0.1.1", "", {}, "sha512-ni3PLLgP7Mqj2CU0bMz9iee3InAu5Oy49Frbi1jxSsLZtgGLcXlRck8G+dgiImtlaN2uM1UynYV9473sP4Dn6Q=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 


### PR DESCRIPTION
## Summary
- **Wires up `@liminal-hq/undertone`** (a zero-dependency procedural Web Audio SFX synth) into the game, activating the long-dormant `sfxVolume` setting for the first time.
- **Four built-in sound effects**: Place Building, Bulldoze, Error, Undo — triggered from the two existing clean hook points (`applyCurrentTool`, `performUndo`). Cash-in/milestone/power-on/notification sounds have no equivalent instrumentation point in `economy.ts`/`narrativeManager.ts` today, so those are out of scope here — separate follow-up work.
- **Place Building is priority 1**: it always plays, unthrottled, on every successful non-bulldoze placement. Bulldoze/Error/Undo get a short per-effect cooldown so a fast drag-stroke doesn't stack overlapping copies into mush.
- **A full in-game SFX editor**, reachable from Settings → Audio: every voice layer of every effect (2-3 layers each) is tunable — sound type, note, ADSR, filter cutoff + envelope, pitch slide — with a live Preview button. Edits save either **to the current city** (rides the normal save file) or **globally across every city** (a new `localStorage`-backed store). Resolution order: city override → global override → built-in default. Reset (per effect) and Reset All revert cleanly.
- **A quick 🔊/🔇 mute toggle** in the top ribbon next to Pause, independent of the saved volume slider.
- Filed #150 ("Epic: In-game tutorial") seeded with a callout for the new mute button, for whenever an onboarding flow gets built.

### User-facing changes
- Settings → Audio: the sound-effects volume slider now actually works, plus a new "🎚️ Edit Sound Effects" button.
- New 🔊/🔇 mute button in the status ribbon.
- Building placement, bulldozing, failed actions, and undo all have real sound now.

### Maintainer-facing changes
- New `app/src/game/sfxOverrides.ts` (types + resolution order), `app/src/game/globalSfxStore.ts` (the localStorage-backed global scope — a deliberate first for this codebase; documented inline and in `SPEC.md` §6.6 as the one exception to IndexedDB-only persistence), `app/src/ui/sfxDefinitions.ts` (built-in voice definitions + params↔Voice reconstruction), `app/src/ui/sfx.ts` (playback/throttle controller), `app/src/ui/sfxEditor.ts` (the editor modal).
- `GameSettings` gains `sfxOverrides`; `AudioSettings` gains `sfxMuted`. Both ride the existing settings-merge/save-file plumbing with zero new persistence code needed for the city-scoped half.

### Documentation
- `SPEC.md`: new "Sound Effects" subsection under §6.4 Tools, a persistence note under §6.6, and the stale "Sound effects & music" roadmap line removed (radio already shipped, this PR ships the SFX half).
- `app/public/manual.html`: new "Sound Effects" section, mute button called out in "The status ribbon".

## Test plan
- [x] `bun run lint` (tsc --noEmit) passes
- [x] `bun run test` — 248/248 tests pass, including 6 new test files covering: override resolution precedence, the localStorage global store, built-in voice definitions + params↔Voice round-tripping, the playback controller's dispatch/throttle/priority/mute logic, and the full editor modal (list view, edit view, preview, save-to-city, save-globally, reset, reset-all, cancel, close)
- [ ] **Manual, real-browser verification is still needed** (I can't hear audio myself): place a building, bulldoze a tile, force a failed placement, and undo — confirm each fires the right sound and that the volume slider/mute button/editor all work as expected in a real browser.