### PR TITLE
Surface WASM init failures on the loading screen instead of hanging forever

### DIFF
--- a/app/src/game/protocol/events.ts
+++ b/app/src/game/protocol/events.ts
@@ -48,4 +48,10 @@ export type FromSim =
   | { type: 'Narrative'; data: NarrativeEvent }
   | { type: 'CommandResult'; success: boolean; message?: string }
   | { type: 'TickStats'; data: TickStats }
-  | { type: 'HistoryChanged'; data: HistoryFlags };
+  | { type: 'HistoryChanged'; data: HistoryFlags }
+  /**
+   * TS/worker-only — not mirrored from the Rust side. The engine can't have
+   * emitted anything yet if this fires: it means the WASM module itself
+   * failed to load/instantiate/boot, so `Ready` will never arrive.
+   */
+  | { type: 'InitError'; message: string };

--- a/app/src/game/wasmSimBridge.test.ts
+++ b/app/src/game/wasmSimBridge.test.ts
@@ -18,7 +18,7 @@ import { Tool } from './toolTypes';
 class FakeWorker {
   sent: { type: string; payload?: Record<string, unknown> }[] = [];
   onmessage: ((e: MessageEvent) => void) | null = null;
-  onerror = null;
+  onerror: ((e: ErrorEvent) => void) | null = null;
   postMessage(msg: { type: string; payload?: Record<string, unknown> }): void {
     this.sent.push(msg);
   }
@@ -197,5 +197,29 @@ describe('WasmSimBridge undo/redo', () => {
     // step_result must be gone, leaving the undone stats in place.
     bridge.step(1 / 20);
     expect(state.money).toBe(1111);
+  });
+
+  it('translates a worker init_error message into an InitError event', () => {
+    const { worker, events } = makeBridge();
+    worker.emit({ type: 'init_error', message: 'WASM instantiation failed' });
+    const initErrors = events.filter(e => e.type === 'InitError');
+    expect(initErrors).toHaveLength(1);
+    expect(initErrors[0]).toMatchObject({ type: 'InitError', message: 'WASM instantiation failed' });
+  });
+
+  it('translates a worker onerror into an InitError event', () => {
+    const { worker, events } = makeBridge();
+    worker.onerror?.({ message: 'script error' } as ErrorEvent);
+    const initErrors = events.filter(e => e.type === 'InitError');
+    expect(initErrors).toHaveLength(1);
+    expect(initErrors[0]).toMatchObject({ type: 'InitError', message: 'script error' });
+  });
+
+  it('falls back to a generic message when worker onerror has no message', () => {
+    const { worker, events } = makeBridge();
+    worker.onerror?.({ message: '' } as ErrorEvent);
+    const initErrors = events.filter(e => e.type === 'InitError');
+    expect(initErrors).toHaveLength(1);
+    expect(initErrors[0]).toMatchObject({ type: 'InitError', message: 'Worker failed to start' });
   });
 });

--- a/app/src/game/wasmSimBridge.test.ts
+++ b/app/src/game/wasmSimBridge.test.ts
@@ -222,4 +222,15 @@ describe('WasmSimBridge undo/redo', () => {
     expect(initErrors).toHaveLength(1);
     expect(initErrors[0]).toMatchObject({ type: 'InitError', message: 'Worker failed to start' });
   });
+
+  it('reports InitError without Ready ever having arrived, matching a real boot failure', () => {
+    // Unlike makeBridge(), this never emits 'ready' first — reproducing the
+    // actual ordering a WASM instantiation failure produces on a real boot.
+    const worker = new FakeWorker();
+    const state = createInitialState(8, 8, 1);
+    const events: FromSim[] = [];
+    new WasmSimBridge(state, { createWorker: () => worker as unknown as Worker }).onMessage(msg => events.push(msg));
+    worker.emit({ type: 'init_error', message: 'WASM instantiation failed' });
+    expect(events).toEqual([{ type: 'InitError', message: 'WASM instantiation failed' }]);
+  });
 });

--- a/app/src/game/wasmSimBridge.ts
+++ b/app/src/game/wasmSimBridge.ts
@@ -59,6 +59,7 @@ interface WorkerHistoryFlags {
 
 type WorkerToMain =
   | { type: 'ready';        history: WorkerHistoryFlags }
+  | { type: 'init_error';   message: string }
   | { type: 'step_result';  bytes: Uint8Array; stats: SimStats; mutationSeq: number }
   | { type: 'apply_result'; success: boolean; history: WorkerHistoryFlags }
   | { type: 'undo_result';  happened: false; history: WorkerHistoryFlags }
@@ -143,6 +144,12 @@ export class WasmSimBridge implements SimBridge {
       new Worker(new URL('../workers/wasmSim.worker.ts', import.meta.url), { type: 'module' });
     this.worker.onmessage = (e: MessageEvent<WorkerToMain>) => {
       this.handleWorkerMsg(e.data);
+    };
+    // Catches worker-thread failures the 'init' handler's own try/catch
+    // can't (a syntax error, the module failing to load at all) — without
+    // this, such a failure is silent and 'Ready' simply never arrives.
+    this.worker.onerror = (event: ErrorEvent) => {
+      this.handler?.({ type: 'InitError', message: event.message || 'Worker failed to start' });
     };
     // Seed the engine with the mirror's natural terrain (water/trees from the
     // TS generator) — from here on the engine is the single source of truth
@@ -344,6 +351,9 @@ export class WasmSimBridge implements SimBridge {
         this.worker.postMessage({ type: 'set_policies', payload: this.state.policies });
         this.syncHistoryFlags(msg.history);
         this.handler?.({ type: 'Ready' });
+        break;
+      case 'init_error':
+        this.handler?.({ type: 'InitError', message: msg.message });
         break;
       case 'step_result':
         this.pendingTileBuffer = msg.bytes;

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -414,18 +414,29 @@ const loadingScreen = initLoadingScreen(document.body);
 // A stuck loading screen with no devtools access (a phone, most often) would
 // otherwise be a silent dead end — surface anything that happens before the
 // engine is up directly on the one screen we know is actually being looked at.
-window.addEventListener('error', (event) => {
+// Only relevant during boot, so both listeners come off once the outcome (Ready
+// or InitError) is known — nothing after that point should still be routed here.
+function onBootError(event: ErrorEvent): void {
   loadingScreen.showError(`Error: ${event.message}`);
-});
-window.addEventListener('unhandledrejection', (event) => {
-  loadingScreen.showError(`Unhandled rejection: ${String(event.reason)}`);
-});
+}
+function onBootRejection(event: PromiseRejectionEvent): void {
+  const reason = event.reason;
+  loadingScreen.showError(`Unhandled rejection: ${reason instanceof Error ? reason.message : String(reason)}`);
+}
+window.addEventListener('error', onBootError);
+window.addEventListener('unhandledrejection', onBootRejection);
+function stopBootErrorWatch(): void {
+  window.removeEventListener('error', onBootError);
+  window.removeEventListener('unhandledrejection', onBootRejection);
+}
 
 function wireBridge(b: SimBridge): void {
   b.onMessage((msg: FromSim) => {
     if (msg.type === 'Ready') {
+      stopBootErrorWatch();
       loadingScreen.complete();
     } else if (msg.type === 'InitError') {
+      stopBootErrorWatch();
       loadingScreen.showError(msg.message);
     } else if (msg.type === 'Alert') {
       notifications.publish({

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -411,10 +411,22 @@ const bridge: SimBridge = isTauri ? new TauriSimBridge(state) : new WasmSimBridg
 
 const loadingScreen = initLoadingScreen(document.body);
 
+// A stuck loading screen with no devtools access (a phone, most often) would
+// otherwise be a silent dead end — surface anything that happens before the
+// engine is up directly on the one screen we know is actually being looked at.
+window.addEventListener('error', (event) => {
+  loadingScreen.showError(`Error: ${event.message}`);
+});
+window.addEventListener('unhandledrejection', (event) => {
+  loadingScreen.showError(`Unhandled rejection: ${String(event.reason)}`);
+});
+
 function wireBridge(b: SimBridge): void {
   b.onMessage((msg: FromSim) => {
     if (msg.type === 'Ready') {
       loadingScreen.complete();
+    } else if (msg.type === 'InitError') {
+      loadingScreen.showError(msg.message);
     } else if (msg.type === 'Alert') {
       notifications.publish({
         id: msg.data.kind,

--- a/app/src/styles/loading-screen.css
+++ b/app/src/styles/loading-screen.css
@@ -133,3 +133,23 @@
   text-transform: uppercase;
   min-height: 1.2em;
 }
+
+.ls-elapsed {
+  font-size: 0.62rem;
+  color: #4c6b87;
+  margin-top: 4px;
+}
+
+.ls-error {
+  margin-top: 16px;
+  padding: 10px 14px;
+  max-width: 90vw;
+  border: 1px solid #f08c42;
+  border-radius: 8px;
+  background: rgba(240, 140, 66, 0.1);
+  color: #ffcc9a;
+  font-size: 0.68rem;
+  line-height: 1.5;
+  text-align: left;
+  word-break: break-word;
+}

--- a/app/src/ui/loadingScreen.ts
+++ b/app/src/ui/loadingScreen.ts
@@ -87,6 +87,14 @@ function buildSkylineHtml(): string {
 export interface LoadingScreen {
   /** Call this when the bridge fires { type: 'Ready' }. */
   complete(): void;
+  /**
+   * Shows a persistent, on-screen error and stops the stage-label rotation —
+   * for failures that mean 'Ready' will never arrive (WASM init failure, an
+   * uncaught worker error). No devtools access on a phone means an error that
+   * only reaches the console is invisible; this is the one place a player
+   * stuck on this screen is guaranteed to be looking at.
+   */
+  showError(message: string): void;
 }
 
 export function initLoadingScreen(root: HTMLElement): LoadingScreen {
@@ -105,6 +113,8 @@ export function initLoadingScreen(root: HTMLElement): LoadingScreen {
         </div>
       </div>
       <div class="ls-stage" id="ls-stage">${STAGES[0]}</div>
+      <div class="ls-elapsed" id="ls-elapsed">0s</div>
+      <div class="ls-error" id="ls-error" hidden></div>
     </div>
   `;
   root.appendChild(overlay);
@@ -117,9 +127,24 @@ export function initLoadingScreen(root: HTMLElement): LoadingScreen {
     stageEl.textContent = STAGES[stageIdx];
   }, 700);
 
+  // A live elapsed-time counter is the one piece of "what is it currently
+  // doing" a player stuck here (often with no devtools access, e.g. on a
+  // phone) can always read: it distinguishes a genuine hang from just being
+  // slow, without needing anything from the actual boot sequence.
+  const startedAt = Date.now();
+  const elapsedEl = overlay.querySelector<HTMLElement>('#ls-elapsed')!;
+  const elapsedInterval = setInterval(() => {
+    elapsedEl.textContent = `${Math.round((Date.now() - startedAt) / 1000)}s`;
+  }, 1000);
+
+  const teardown = () => {
+    clearInterval(stageInterval);
+    clearInterval(elapsedInterval);
+  };
+
   return {
     complete() {
-      clearInterval(stageInterval);
+      teardown();
       stageEl.textContent = 'Ready!';
 
       const fill = overlay.querySelector<HTMLElement>('#ls-bar-fill')!;
@@ -132,6 +157,14 @@ export function initLoadingScreen(root: HTMLElement): LoadingScreen {
         overlay.style.transition = 'opacity 350ms ease';
         overlay.style.opacity = '0';
       }, 250);
+    },
+    showError(message: string) {
+      if (!overlay.isConnected) return; // Already completed/removed — nothing to show this on.
+      teardown();
+      stageEl.textContent = 'Failed to start';
+      const errorEl = overlay.querySelector<HTMLElement>('#ls-error')!;
+      errorEl.textContent = message;
+      errorEl.hidden = false;
     },
   };
 }

--- a/app/src/ui/loadingScreen.ts
+++ b/app/src/ui/loadingScreen.ts
@@ -142,8 +142,18 @@ export function initLoadingScreen(root: HTMLElement): LoadingScreen {
     clearInterval(elapsedInterval);
   };
 
+  // Once the outcome is settled (success or failure), ignore anything else —
+  // `overlay.isConnected` alone isn't enough, since the fade-out after
+  // complete() leaves the overlay attached for ~600ms, and a later unrelated
+  // error/rejection could otherwise flash "Failed to start" over a boot that
+  // already succeeded, or a second failure could overwrite the first (and
+  // usually more diagnostic) error message.
+  let settled = false;
+
   return {
     complete() {
+      if (settled) return;
+      settled = true;
       teardown();
       stageEl.textContent = 'Ready!';
 
@@ -159,7 +169,8 @@ export function initLoadingScreen(root: HTMLElement): LoadingScreen {
       }, 250);
     },
     showError(message: string) {
-      if (!overlay.isConnected) return; // Already completed/removed — nothing to show this on.
+      if (settled) return;
+      settled = true;
       teardown();
       stageEl.textContent = 'Failed to start';
       const errorEl = overlay.querySelector<HTMLElement>('#ls-error')!;

--- a/app/src/workers/wasmSim.worker.ts
+++ b/app/src/workers/wasmSim.worker.ts
@@ -269,8 +269,12 @@ self.onmessage = async (e: MessageEvent<MainToWorker>) => {
         // init — the bridge follows up with 'load_snapshot'/'import_legacy'.
         if (msg.payload.terrain) host.set_natural_terrain(msg.payload.terrain);
         if (msg.payload.policies) applyPolicies(host, msg.payload.policies);
-        self.postMessage({ type: 'ready', history: historyFlags(host) });
+        // Posting 'ready' must be the last statement in this block — once the
+        // main thread has been told we're up, nothing after this may throw
+        // into the catch below, or it would post 'init_error' for a boot that
+        // already succeeded.
         startStepLoop();
+        self.postMessage({ type: 'ready', history: historyFlags(host) });
       } catch (err) {
         self.postMessage({ type: 'init_error', message: err instanceof Error ? err.message : String(err) });
       }

--- a/app/src/workers/wasmSim.worker.ts
+++ b/app/src/workers/wasmSim.worker.ts
@@ -257,15 +257,23 @@ self.onmessage = async (e: MessageEvent<MainToWorker>) => {
   const msg = e.data;
   switch (msg.type) {
     case 'init': {
-      await init();
-      host = new SimHost(msg.payload.width, msg.payload.height, msg.payload.seed);
-      // Terrain must land before the first step so placement validation and
-      // wilderness see the real water/tree map. Saves are NOT loaded through
-      // init — the bridge follows up with 'load_snapshot'/'import_legacy'.
-      if (msg.payload.terrain) host.set_natural_terrain(msg.payload.terrain);
-      if (msg.payload.policies) applyPolicies(host, msg.payload.policies);
-      self.postMessage({ type: 'ready', history: historyFlags(host) });
-      startStepLoop();
+      // Nothing has booted yet if this throws (unsupported WASM feature,
+      // fetch failure, out of memory on a constrained device) — surface it
+      // rather than leaving the main thread waiting for a 'ready' that will
+      // never arrive.
+      try {
+        await init();
+        host = new SimHost(msg.payload.width, msg.payload.height, msg.payload.seed);
+        // Terrain must land before the first step so placement validation and
+        // wilderness see the real water/tree map. Saves are NOT loaded through
+        // init — the bridge follows up with 'load_snapshot'/'import_legacy'.
+        if (msg.payload.terrain) host.set_natural_terrain(msg.payload.terrain);
+        if (msg.payload.policies) applyPolicies(host, msg.payload.policies);
+        self.postMessage({ type: 'ready', history: historyFlags(host) });
+        startStepLoop();
+      } catch (err) {
+        self.postMessage({ type: 'init_error', message: err instanceof Error ? err.message : String(err) });
+      }
       break;
     }
     case 'apply_tool': {


### PR DESCRIPTION
## Summary
- **Root cause**: the WASM worker's `init()` call had no error handling, and neither the worker nor its `Worker` instance had any error-surfacing mechanism, so any WASM instantiation failure (unsupported feature, fetch failure, OOM) was a silent unhandled rejection — the loading screen just waits forever for a `Ready` message that never arrives, with zero signal, especially bad with no devtools access (e.g. a phone).
- **Worker-side catch**: `wasmSim.worker.ts` wraps the `init()` call in try/catch and posts a new `init_error` message on failure instead of throwing silently; posting `ready` is now the last statement in that block, so a boot that already succeeded can never additionally post `init_error`.
- **Bridge-side catch**: `WasmSimBridge` translates `init_error` into a new `FromSim` event, `InitError`, and also attaches `worker.onerror` to catch genuinely uncaught worker-thread errors the same way.
- **Main-thread catch**: `main.ts` adds global `window.addEventListener('error'/'unhandledrejection')` handlers so any other uncaught failure before the engine is up gets surfaced too; both come off once the outcome (`Ready`/`InitError`) is known.
- **User-visible fix**: `loadingScreen.ts` gains a persistent `showError()` panel (wired to all of the above) plus a live elapsed-time counter, so a stuck player has both a concrete error message and a way to tell "hung" from "just slow." A `settled` latch prevents a later unrelated error from overwriting an already-shown error, or from flashing "Failed to start" over a boot that already succeeded during the brief fade-out window.

### User-facing changes
- The loading screen now shows a live elapsed-time counter and, if startup fails for any reason, a persistent on-screen error message instead of hanging indefinitely.

### Known limitations
- Only the WASM boot path (`WasmSimBridge`) gets this explicit try/catch → `InitError` treatment. `TauriSimBridge`'s native boot failures aren't covered by the same mechanism and rely on however `tauri-plugin-city-sim`'s JS bindings surface failures, which may not always produce an uncaught `window`-level error/rejection. Scoped out since the originally reported symptom is on the WASM/browser path (a phone); worth revisiting if a Tauri boot-failure report ever surfaces.

## Test plan
- [x] `bun run lint` — clean
- [x] `bun run test` — all 30 test files / 252 tests pass, including 4 new tests in `wasmSimBridge.test.ts` covering the `init_error` → `InitError` translation, the `worker.onerror` → `InitError` translation, the fallback message when `onerror` has no message, and a dedicated test reproducing the real ordering (`init_error` arriving with no prior `ready`).
- [ ] Manual on-device confirmation that this resolves the originally reported stuck-loading-screen symptom is still pending — this fix improves error visibility/diagnostics regardless of the original cause, but its sufficiency for that specific case is unverified until retested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnxdyzXk3wbY1cJ12oaHVT
