### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "city-sim-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "city-sim-protocol",
  "criterion",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "city-sim-protocol"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "postcard",
  "serde",
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "city-sim-wasm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "city-sim-core",
  "city-sim-protocol",
@@ -3401,7 +3401,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-city-sim"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "city-sim-core",
  "city-sim-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Scott Morris"]
 license = "MIT"

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "city-sim-1000",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
     },
     "app": {
       "name": "city-sim-1000",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@liminal-hq/undertone": "^0.1.1",
         "@tauri-apps/api": "^2.0.0",


### PR DESCRIPTION
## Summary
- Bumps `app/package.json` and the Rust workspace's `Cargo.toml` (and their lockfiles) from `0.1.0` to `0.2.0`.
- Minor bump (not a patch) since v0.1.0: this batch adds real new user-facing functionality — procedural sound effects with a full in-game editor, including a code view for hand-editing voice chains (#151, #154) — alongside several bug fixes: the radio popover viewport-clamp (#148), consolidated currency formatting (#147), and a loading-screen fix that now surfaces WASM init failures instead of hanging forever (#152).
- Prep step before tagging `v0.2.0`, which triggers the release workflow.

## Test plan
- [x] `./scripts/check-release-versions.sh` — synchronised at `0.2.0`
- [x] `bun run lint` — clean
- [x] `bun run test` — all 31 test files / 266 tests pass
- [x] `cargo check --workspace` / `cargo test --workspace` (via the `city-sim-1000-dev-wasm:latest` Docker image) — clean, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnxdyzXk3wbY1cJ12oaHVT