### PR TITLE
Drop the redundant tag-push trigger from gh-pages.yml

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v*'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- `gh-pages.yml` triggered on both `push: branches: [main]` and `push: tags: v*`. A release tag always points at a commit already on `main`, so the tag push only ever raced a duplicate deploy against the one the main-push trigger just kicked off.
- Observed with `v0.3.0`: the main-push deploy succeeded and went live; the tag-push deploy fired ~40s later and failed outright (GitHub Pages' `github-pages` environment rejects a second concurrent deployment) — a red X in Actions with no effect on the live site.
- Removes the `tags:` trigger; `main`-push and `workflow_dispatch` remain, matching what the README already documents.
- `release.yml` (tag → GitHub Release creation) is untouched — it has its own independent `push: tags: v*` trigger.

## Test plan
- No functional change to the built site; this only prunes a redundant CI trigger. Verified by reading `release.yml` to confirm it doesn't share a trigger block with `gh-pages.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)