### PR TITLE
Fix MCP screenshot tool returning solid black

### DIFF
--- a/app/src/rendering/renderer.ts
+++ b/app/src/rendering/renderer.ts
@@ -98,6 +98,14 @@ export class MapRenderer {
   }
 
   async init(resizeTo: HTMLElement) {
+    // MCP mode's screenshot tool reads the canvas back via toDataURL() from
+    // outside Pixi's own render loop (in response to an async WS message).
+    // WebGL clears/swaps its drawing buffer after presenting a frame by
+    // default, so without preserveDrawingBuffer that readback sees a
+    // blank buffer — solid black regardless of what was actually rendered.
+    // Only enabled in MCP mode: it costs an extra GPU buffer copy per
+    // frame, not worth paying in normal play.
+    const mcpMode = new URLSearchParams(window.location.search).has('mcp');
     await this.app.init({
       background: '#0b1424',
       resizeTo,
@@ -105,7 +113,8 @@ export class MapRenderer {
       // Cap device-pixel-ratio scaling at 2x — retina-sharp without paying
       // the full uncapped cost on DPR-3 mobile devices (Pixi v8 defaults to
       // window.devicePixelRatio with no cap).
-      resolution: Math.min(window.devicePixelRatio, 2)
+      resolution: Math.min(window.devicePixelRatio, 2),
+      ...(mcpMode ? { preserveDrawingBuffer: true } : {})
     });
     this.parent.appendChild(this.app.canvas);
     this.app.stage.addChild(this.container);

--- a/app/src/rendering/renderer.ts
+++ b/app/src/rendering/renderer.ts
@@ -114,7 +114,7 @@ export class MapRenderer {
       // the full uncapped cost on DPR-3 mobile devices (Pixi v8 defaults to
       // window.devicePixelRatio with no cap).
       resolution: Math.min(window.devicePixelRatio, 2),
-      ...(mcpMode ? { preserveDrawingBuffer: true } : {})
+      preserveDrawingBuffer: mcpMode
     });
     this.parent.appendChild(this.app.canvas);
     this.app.stage.addChild(this.container);


### PR DESCRIPTION
## Summary

- **Root cause**: `mcpBridge.ts`'s `screenshot` handler reads the game canvas via `canvas.toDataURL()`, but WebGL clears its drawing buffer after each frame presents by default. The handler runs asynchronously (triggered by a WS message from the MCP server, not from inside Pixi's own render loop), so by the time it reads back the canvas the buffer is already empty — solid black regardless of what was actually on screen. Confirmed by sampling the raw pre-fix output directly: an exact, uniform colour with no relation to camera position or game content.
- **Fix**: pass `preserveDrawingBuffer: true` to Pixi's `Application.init()`, which keeps the drawing buffer contents around for readback instead of clearing them.
- **Scoping**: only enabled when `?mcp` is present in the URL (the same gate `mcpBridge.ts` itself uses), since it costs an extra GPU buffer copy every frame — not worth paying in normal play.

### User-facing changes

None — this only affects the MCP dev-tooling screenshot capability, gated behind `?mcp`.

## Test plan

- [x] `bun run lint` passes
- [x] Manually confirmed: before the fix, `mcp__city-sim__screenshot` returned solid black regardless of game state/camera position; after the fix, it returns the actual rendered terrain/buildings