### PR TITLE
Mutation testing in CI, and the two rules the last month of findings point at

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -55,6 +55,17 @@ exclude_globs = [
 # caught tells us nothing worth acting on, because rendering is not a behaviour
 # this project pins in Rust tests. Excluded by mutant name so the rule applies
 # to any such impl added later, in any file.
+#
+# The second entry is an equivalent mutant proved rather than assumed.
+# `orthogonal_neighbours` walks `DIRS = [(0,-1), (1,0), (0,1), (-1,0)]`, and that
+# set is symmetric under reflection in either axis: negating only `dx` maps it
+# onto itself, and so does negating only `dy`. So `x + dx` mutated to `x - dx`
+# yields the *same four neighbours*, in a different order, and every caller is a
+# flood fill or an "is any neighbour …" test that cannot observe the order. No
+# test can ever kill these two, which is why they are named here instead of
+# being tested around. If `DIRS` ever gains a diagonal, the symmetry breaks and
+# these must come out — the mutants would become real.
 exclude_re = [
     "<impl [^>]*(Display|Debug) for ",
+    "replace \\+ with - in orthogonal_neighbours",
 ]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,60 @@
+# cargo-mutants configuration. Schema: https://json.schemastore.org/cargo-mutants-config.json
+#
+# Mutation testing answers "would any test have noticed?" — it is the automated
+# form of the "Prove a test has teeth" rule in AGENTS.md, which also explains how
+# to read a surviving mutant. Run by `rust-mutants-diff` in
+# .github/workflows/ci.yml and `rust-mutants-full` in
+# .github/workflows/mutants-full.yml.
+#
+# Preview what this file selects without running anything:
+#   cargo mutants --list-files
+#   cargo mutants --list
+
+# Only the in-crate unit tests decide whether a mutant is caught.
+#
+# With no target selection, `cargo test` runs every integration test in `tests/`
+# once per mutant, so a test that takes seconds by design costs those seconds
+# times the mutant count — and a mutant that makes such a test loop instead
+# burns the whole `--timeout`. `--lib` keeps the per-mutant cost tied to the
+# fast, deterministic unit suite, so the CI budget does not silently change when
+# someone adds a long-running integration test.
+#
+# cargo-mutants applies this to the test command, not to its `cargo test
+# --no-run` build, so integration tests are still compiled each mutant even
+# though they do not run. Compiling is incremental; running is not bounded.
+#
+# Consequence to be aware of: a behaviour covered *only* by an integration test
+# or a doctest cannot catch a mutant here, and will be reported MISSED. When a
+# fast integration test should participate, add it explicitly — `--test <name>`,
+# which cargo rejects if the target does not exist, so the list cannot go stale
+# silently. Do not add a soak or benchmark-style target.
+additional_cargo_test_args = ["--lib"]
+
+# Crates with no Rust test suite to be judged against. Every mutant in these is
+# MISSED by construction, which is noise rather than signal: it is not evidence
+# that a test is weak, only that this crate is not tested from Rust.
+#
+# - city-sim-wasm: `wasm-bindgen` shim over city-sim-core, exercised from the
+#   browser. CI already excludes it from `cargo clippy` and `cargo nextest run`.
+# - tauri-plugin-city-sim: Tauri IPC command handlers that delegate to
+#   city-sim-core, exercised by the Playwright e2e suite.
+#
+# Both are thin delegation layers; the logic they forward to is mutated in
+# city-sim-core. Deleting either glob is the right move on the day the crate
+# grows Rust tests of its own.
+#
+# Generated Rust belongs in this list too — nothing in the workspace generates
+# `.rs` today, so check `cargo mutants --list-files` after adding a codegen step
+# rather than assuming its output is invisible here.
+exclude_globs = [
+    "crates/city-sim-wasm/**/*.rs",
+    "crates/tauri-plugin-city-sim/**/*.rs",
+]
+
+# Formatting impls: a mutant that changes what `{:?}` or `{}` prints and is not
+# caught tells us nothing worth acting on, because rendering is not a behaviour
+# this project pins in Rust tests. Excluded by mutant name so the rule applies
+# to any such impl added later, in any file.
+exclude_re = [
+    "<impl [^>]*(Display|Debug) for ",
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,117 @@ jobs:
             echo "- Run URL: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           } >> "${GITHUB_STEP_SUMMARY}"
 
+  rust-mutants-diff:
+    name: Rust mutants (diff)
+    runs-on: ubuntu-24.04
+    if: github.event_name == 'pull_request'
+    outputs:
+      missed: ${{ steps.rust_mutants_count.outputs.missed }}
+      outcome: ${{ steps.rust_mutants_diff.outcome }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          # `--in-diff` needs the merge base, which a shallow clone lacks.
+          fetch-depth: 0
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            libwebkit2gtk-4.1-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Restore Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          # Read the cache the scheduled full run writes on the default branch.
+          # A cache saved from a pull-request branch is only visible to that
+          # branch, so this job restores and never saves.
+          shared-key: rust-mutants
+          save-if: 'false'
+
+      - name: Install cargo-mutants
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-mutants
+
+      - name: Diff against the base branch
+        # Redirected rather than piped through `tee`: the default shell is
+        # `bash -e` without `pipefail`, so a pipeline would hide a failing
+        # `git diff` behind tee's exit code and mutate nothing at all.
+        run: |
+          base="origin/${{ github.base_ref }}"
+          git diff "${base}...HEAD" > mutants.diff
+          git diff --stat "${base}...HEAD" -- 'crates/**/*.rs'
+
+      - name: Run cargo-mutants over the diff
+        id: rust_mutants_diff
+        # Advisory: a surviving mutant is reported on the pull request and in
+        # the job summary, but does not block the merge. See AGENTS.md
+        # "Mutation testing" for what a surviving mutant means and the condition
+        # for turning this into a gate.
+        continue-on-error: true
+        # `--in-place` builds in the checkout so the restored cache is reused;
+        # it also disables the automatic timeout, which is why `--timeout` is
+        # explicit. `--baseline run` proves the unmutated tree passes first, so
+        # a MISSED result cannot be an already-failing suite.
+        #
+        # Exit codes: 0 all caught, 2 mutants survived, 3 a mutant hung,
+        # 4 the baseline itself is red, 5/6 a malformed diff.
+        run: cargo mutants --in-place --in-diff mutants.diff --baseline run --timeout 20
+
+      - name: Count surviving mutants
+        id: rust_mutants_count
+        if: always()
+        run: |
+          missed=0
+          if [ -f mutants.out/missed.txt ]; then
+            missed=$(wc -l < mutants.out/missed.txt)
+          fi
+          echo "missed=${missed}" >> "${GITHUB_OUTPUT}"
+
+      - name: Upload mutants artefacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: rust-mutants-diff
+          path: mutants.out/
+          if-no-files-found: ignore
+
+      - name: Write summary
+        if: always()
+        run: |
+          {
+            echo "## Rust mutants (diff)"
+            echo
+            echo "- Runner: \`ubuntu-24.04\`"
+            echo "- Result: \`${{ steps.rust_mutants_diff.outcome }}\` (advisory — does not block merge)"
+            echo "- Command: \`cargo mutants --in-place --in-diff mutants.diff --baseline run --timeout 20\`"
+            if [ -f mutants.out/missed.txt ]; then
+              echo "- Caught: \`$(wc -l < mutants.out/caught.txt)\` · missed: \`$(wc -l < mutants.out/missed.txt)\` · timed out: \`$(wc -l < mutants.out/timeout.txt)\` · unviable: \`$(wc -l < mutants.out/unviable.txt)\`"
+              if [ -s mutants.out/missed.txt ]; then
+                echo
+                echo "Mutants no test noticed — each is either a missing assertion or an"
+                echo "equivalent mutant that cannot change behaviour. Say which, in the PR."
+                echo
+                echo '```'
+                cat mutants.out/missed.txt
+                echo '```'
+                echo
+              fi
+              echo "- Artefact: \`rust-mutants-diff\` (\`mutants.out/\`)"
+            else
+              echo "- No mutants generated: the diff touches no mutable Rust source, so there is no report to upload."
+            fi
+            echo "- Run URL: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
   ts-typecheck:
     name: TypeScript typecheck
     runs-on: ubuntu-24.04
@@ -485,6 +596,7 @@ jobs:
       - rust-clippy
       - rust-test
       - rust-determinism
+      - rust-mutants-diff
       - ts-typecheck
       - ts-test
       - wasm-build
@@ -505,6 +617,10 @@ jobs:
             const rustCliffy = '${{ needs.rust-clippy.result }}';
             const rustTests  = '${{ needs.rust-test.result }}';
             const rustDeterm = '${{ needs.rust-determinism.result }}';
+            // The mutants step is advisory, so the job result is green either
+            // way. Report the surviving-mutant count, which is the real signal.
+            const mutantsOutcome = '${{ needs.rust-mutants-diff.outputs.outcome }}';
+            const mutantsMissed  = '${{ needs.rust-mutants-diff.outputs.missed }}';
             const tsCheck    = '${{ needs.ts-typecheck.result }}';
             const tsTests    = '${{ needs.ts-test.result }}';
             const wasmBuild  = '${{ needs.wasm-build.result }}';
@@ -519,6 +635,9 @@ jobs:
               `- ${label(rustCliffy)} Rust clippy: \`${rustCliffy}\``,
               `- ${label(rustTests)} Rust tests: \`${rustTests}\``,
               `- ${label(rustDeterm)} Rust determinism (x64 + arm64): \`${rustDeterm}\``,
+              mutantsMissed === ''
+                ? `- [SKIP] Rust mutants in this diff (advisory): no result — the job did not reach the mutants step`
+                : `- ${mutantsMissed === '0' ? '[PASS]' : '[WARN]'} Rust mutants in this diff (advisory): \`${mutantsMissed}\` survived (step: \`${mutantsOutcome}\`)`,
               `- ${label(tsCheck)} TypeScript typecheck: \`${tsCheck}\``,
               `- ${label(tsTests)} TypeScript tests: \`${tsTests}\``,
               `- ${label(wasmBuild)} WASM build: \`${wasmBuild}\``,

--- a/.github/workflows/mutants-full.yml
+++ b/.github/workflows/mutants-full.yml
@@ -1,0 +1,97 @@
+name: Rust Mutation Coverage (Full)
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+# Deliberately not on `pull_request` or `push`. The workspace has upwards of
+# 1,600 mutants (`cargo mutants --workspace --list | wc -l`) at roughly half a
+# second each, a budget of about fifteen minutes: affordable weekly or on demand,
+# far too slow to sit in front of every push. The per-pull-request slice lives in
+# `ci.yml` as the `rust-mutants-diff` job, where `--in-diff` ties the cost to the
+# change instead.
+#
+# This workflow is also the only writer of the `rust-mutants` build cache, which
+# it can populate because it runs on the default branch. Dispatch it once after
+# this lands, or the first pull requests pay a cold build.
+on:
+  schedule:
+    # 07:00 UTC on Mondays — a report waiting at the start of the week.
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: mutants-full-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  rust-mutants-full:
+    name: Rust mutants (full)
+    runs-on: ubuntu-24.04
+    # The enforced form of the budget above: mutant testing plus toolchain, apt
+    # and cache setup, with room for a cold cache. If this starts tripping, shard
+    # the run with `--shard i/n` across a matrix rather than raising the ceiling.
+    timeout-minutes: 45
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            libwebkit2gtk-4.1-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Restore Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          # Shared with the `rust-mutants-diff` job in `ci.yml`. This workflow
+          # runs on the default branch, so the cache it saves is the one every
+          # pull request can restore.
+          shared-key: rust-mutants
+
+      - name: Install cargo-mutants
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-mutants
+
+      - name: Run cargo-mutants over the workspace
+        id: rust_mutants_full
+        # Never a merge gate: this reports pre-existing gaps across the whole
+        # workspace, which is a work queue rather than a pass/fail signal.
+        continue-on-error: true
+        # Same flags as the diff job so the two runs are directly comparable.
+        # Scope, exclusions and the test command come from `.cargo/mutants.toml`.
+        run: cargo mutants --in-place --workspace --baseline run --timeout 20
+
+      - name: Upload mutants artefacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: rust-mutants-full
+          path: mutants.out/
+          if-no-files-found: warn
+
+      - name: Write summary
+        if: always()
+        run: |
+          {
+            echo "## Rust mutants (full)"
+            echo
+            echo "- Runner: \`ubuntu-24.04\`"
+            echo "- Result: \`${{ steps.rust_mutants_full.outcome }}\` (informational — this workflow never gates a merge)"
+            echo "- Command: \`cargo mutants --in-place --workspace --baseline run --timeout 20\`"
+            if [ -f mutants.out/missed.txt ]; then
+              echo "- Caught: \`$(wc -l < mutants.out/caught.txt)\` · missed: \`$(wc -l < mutants.out/missed.txt)\` · timed out: \`$(wc -l < mutants.out/timeout.txt)\` · unviable: \`$(wc -l < mutants.out/unviable.txt)\`"
+            fi
+            echo "- Artefact: \`rust-mutants-full\` (\`mutants.out/\`, including \`missed.txt\` and \`outcomes.json\`)"
+            echo "- Run URL: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,11 @@ app/src/wasm/
 # Playwright MCP session artifacts (screenshots, console logs, page snapshots)
 .playwright-mcp/
 
+# cargo-mutants run output and the diff the CI job feeds it (config is .cargo/mutants.toml)
+mutants.out/
+mutants.out.old/
+mutants.diff
+
 # Playwright/vitest test output (app/test-results/junit.xml is a CI artefact, not a commit)
 app/test-results/
 app/playwright-report/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,66 @@ New `.rs` and `.ts`/`.tsx` source files should include a header before `use`/`im
 - `docs/testing.md` is the map: the four architecture harnesses (golden city, cross-engine parity, visual regression, soak), what each does and does not cover, every command, and the remaining gaps.
 - **Regenerating a committed baseline is a deliberate act.** `golden_city.expected` and the screenshots under `app/e2e/__screenshots__/` are derived artefacts, so a wrong derivation and a stale expectation look identical from the outside. Never regenerate to make a build pass; name and justify every line or image that moved, in the same commit as the behaviour change that moved it. See `docs/testing.md`.
 
+### Prove a test has teeth
+
+**When you add or change a test, break the thing it covers and confirm the test goes red. Then revert, and state the mutation and its result.** A test that cannot fail is worse than no test: it reports safety that does not exist, and it is invisible without this step.
+
+This is not optional diligence, it is the deliverable. Real examples from this repo, all found only because someone mutated the source:
+
+- `a_line_in_the_overlay_flag_alone_carries_power` passed `Some(1)` for `building_id`, which short-circuits `Tile::conducts` before the occupant set is read. Setting `OCCUPANT_DEFS[PowerLine].conducts` to `NET_NONE` left it green while the power grid went dark.
+- The soak advertised "Allocation stays bounded" as an enforced property. Both checks only pushed strings into a report the test printed and passed.
+- A visual regression test set `maxDiffPixels: 0` and documented an exact match, but left Playwright's per-pixel `threshold` at its default `0.2` — so it could not see the colour shift it existed to catch.
+
+**Choose the mutation to match the failure mode, not just to be red.** A mutation that passes is only evidence about the mutation you picked. The soak's allocation check was proved to have teeth with a leak sized by the tick counter, went red, and was written up as sound — but the check compares a *rate*, so it was blind to a leak of constant size by construction. A never-drained `Vec` taking peak heap from 0.05 MiB to 100.05 MiB kept the ratio at 1.01× and passed, while the doc comment above it advertised "bounded heap". Ask what the check is *shaped* to miss, then mutate that.
+
+The same trap applies to where you run it: `threshold: 0` in the visual harness was verified locally, three parallel repeats green, and still failed CI — reproducible on one machine is not identical across machines. A property that only holds on your hardware has not been proved.
+
+`cargo mutants` automates this for Rust (see **Mutation testing** below); it does not replace doing it deliberately for the specific property you just claimed to pin.
+
+### Mutation testing
+
+`cargo mutants` changes one thing in the Rust source — an operator, a return value, a whole function body — and reruns the tests. If they still pass, that line is covered in the sense that something executed it and in no sense that anything checked it.
+
+Run it on your own change before pushing, which is the same slice CI runs:
+
+```bash
+git diff origin/main...HEAD > mutants.diff
+cargo mutants --in-diff mutants.diff --baseline run --timeout 20
+```
+
+Configuration lives in `.cargo/mutants.toml`, which records why each exclusion is there. Preview what it selects with `cargo mutants --list-files` and `cargo mutants --list`. `mutants.out/` is the run report and is gitignored.
+
+Two CI jobs use it. Both are configured `continue-on-error`, so neither can fail a merge:
+
+- **`rust-mutants-diff`** in `.github/workflows/ci.yml`, on every pull request. `--in-diff` mutates only code the pull request touched, so the cost tracks the change rather than the codebase. Surviving mutants land in the job summary, as GitHub annotations on the diff, and as a count in the CI summary comment.
+- **`rust-mutants-full`** in `.github/workflows/mutants-full.yml`, weekly and on `workflow_dispatch`. Whole workspace, uploaded as an artefact — a work queue, not a verdict.
+
+The advisory setting is deliberate rather than timid, for two reasons that both have to stop being true before `rust-mutants-diff` becomes a gate. `--in-diff` covers whole functions the diff touched, not only the lines, so a one-line edit inside a thinly tested function surfaces that function's pre-existing gaps as if they were yours. And equivalent mutants are common enough here to fail honest work: `DERIVED_FLAG_MASK` in `state.rs` is three disjoint bits joined with `|`, and rewriting that `|` as `^` produces the identical byte, so no test can ever distinguish it. Combining disjoint flag bits is a shape this codebase uses in a dozen places, and every one of them is a survivor by construction. Flip it to blocking when a full-run triage has emptied the inherited backlog and the equivalent-mutant families are excluded by name in `.cargo/mutants.toml`, not before.
+
+**A surviving mutant is a question, not a defect.** Before writing a test, work out which kind you have:
+
+- *A real gap* — the mutated behaviour is one a reader would expect a test to pin. Write the test.
+- *An equivalent mutant* — the mutation cannot change behaviour, so no test can ever kill it. `FLAG_A | FLAG_B` mutated to `FLAG_A ^ FLAG_B` over disjoint bits is the same value. Say so in the pull request rather than adding a test that proves nothing.
+
+Answering in the pull request is the deliverable either way; a silent survivor is indistinguishable from an unexamined one.
+
+Two limits worth knowing, because they change what MISSED means:
+
+- Mutants are judged by the crate's unit tests only (`--lib`). Behaviour covered solely by an integration test or a doctest will be reported MISSED.
+- Diffs that only change test code produce no mutants at all, so this cannot tell you a new test is weak — that is what breaking the code by hand is for.
+
+## Claims must be checkable
+
+Prose describing code is written from *intent*, and nothing makes it meet the code again afterwards. Reviews of this repo have repeatedly found more wrong explanations than wrong code — a comment asserting a safety mechanism the code did not have, a test named for a property it did not check, figures that reproduced only under a different scenario than the one described. A confident wrong comment is worse than no comment, because it tells the next reader not to check.
+
+Prefer claims the build can check over claims a reader must trust.
+
+- **Put load-bearing behaviour in a doctest, not a paragraph.** A ` ```rust ` block in a doc comment runs under `cargo test`, so it cannot drift. Reach for one whenever you catch yourself explaining *what happens when*.
+- **Measured numbers belong in generated artefacts, never in prose.** If a figure came from running something, it goes in a fixture that is regenerated — like `golden_city.expected` — so it cannot disagree with itself. A hand-copied number is stale the moment the code moves, and nothing will tell you.
+- **Never cite a commit hash in code or docs.** Rebases delete them: nine references to one hash died in a single day. Cite the commit *subject*, a tag, or the behaviour itself.
+- **Never write a "current status" section.** "The soak is currently red", "this test fails at the moment" — these rot within the hour and then actively mislead. State the invariant, not the weather. If a status genuinely must be recorded, generate it or date it explicitly.
+- **When you change behaviour, grep for what described it.** The nearby comment is the one you will remember; the doc file, the test name, and the comment 1,700 lines away are the ones that drift.
+
 ## Project Notes
 
 - Water simulation is temporarily stubbed to a high balance; only power deficits gate growth until pipes/underground view ship.

--- a/crates/city-sim-core/src/adjacency.rs
+++ b/crates/city-sim-core/src/adjacency.rs
@@ -117,7 +117,13 @@ pub fn zone_has_road_path(state: &GameState, start_x: u32, start_y: u32) -> bool
 
     while let Some((x, y)) = queue.pop_front() {
         for (nx, ny) in orthogonal_neighbours(state.width, state.height, x, y) {
-            let idx = (ny * state.width + nx) as usize;
+            // `tile_index` rather than the arithmetic spelled out again: this is
+            // the `visited` key, so a wrong one silently aliases two tiles onto
+            // each other and drops half the search. `orthogonal_neighbours` has
+            // already bounds-checked, so the `None` arm is unreachable.
+            let Some(idx) = state.tile_index(nx, ny) else {
+                continue;
+            };
             if visited.contains(&idx) {
                 continue;
             }
@@ -204,6 +210,71 @@ mod tests {
     }
     fn kind(state: &mut GameState, x: u32, y: u32, k: TileKind) {
         set_v4_kind(state.tile_at_mut(x, y).unwrap(), k);
+    }
+
+    fn neighbours(w: u32, h: u32, x: u32, y: u32) -> Vec<(u32, u32)> {
+        let mut v: Vec<_> = orthogonal_neighbours(w, h, x, y).collect();
+        v.sort_unstable();
+        v
+    }
+
+    /// Every caller of `orthogonal_neighbours` indexes the grid with what it
+    /// yields, so a coordinate off any edge is an out-of-bounds read waiting to
+    /// happen. The four corners and the interior pin all four bounds at once:
+    /// loosening either `<` to `<=`, or the `&&` chain to `||`, or deleting a
+    /// sign in `DIRS`, changes one of these lists.
+    #[test]
+    fn neighbours_never_leave_the_grid() {
+        // Interior: all four, and they are the four orthogonals rather than
+        // any diagonal.
+        assert_eq!(neighbours(4, 4, 2, 2), vec![(1, 2), (2, 1), (2, 3), (3, 2)]);
+
+        // Corners: two each, and never a wrapped or negative coordinate.
+        assert_eq!(neighbours(4, 4, 0, 0), vec![(0, 1), (1, 0)]);
+        assert_eq!(neighbours(4, 4, 3, 0), vec![(2, 0), (3, 1)]);
+        assert_eq!(neighbours(4, 4, 0, 3), vec![(0, 2), (1, 3)]);
+        assert_eq!(neighbours(4, 4, 3, 3), vec![(2, 3), (3, 2)]);
+
+        // Edges: three each.
+        assert_eq!(neighbours(4, 4, 1, 0), vec![(0, 0), (1, 1), (2, 0)]);
+        assert_eq!(neighbours(4, 4, 0, 1), vec![(0, 0), (0, 2), (1, 1)]);
+
+        // A non-square grid, so a transposed width/height cannot pass: the
+        // right edge is x = 4 and the bottom is y = 1.
+        assert_eq!(neighbours(5, 2, 4, 1), vec![(3, 1), (4, 0)]);
+        assert_eq!(neighbours(5, 2, 4, 0), vec![(3, 0), (4, 1)]);
+
+        // A 1x1 grid has nowhere to go — the degenerate case that a `<=` bound
+        // turns into two phantom neighbours.
+        assert!(neighbours(1, 1, 0, 0).is_empty());
+    }
+
+    /// The `visited` key in `zone_has_road_path` is a flat index, and two tiles
+    /// sharing one silently drops half the search. A 1xN strip makes the
+    /// aliasing visible: every tile has a distinct index only if the row stride
+    /// is applied the one correct way.
+    #[test]
+    fn a_long_thin_zone_strip_still_reaches_its_road() {
+        let mut s = g(6, 3);
+        // Road at the far end, a chain of zoned lots leading to it.
+        kind(&mut s, 5, 1, TileKind::Road);
+        for x in 0..5 {
+            kind(&mut s, x, 1, TileKind::Residential);
+        }
+        assert!(
+            zone_has_road_path(&s, 0, 1),
+            "a zoned strip ending at a road must find it"
+        );
+
+        // The same strip with the road removed must not find one.
+        let mut s2 = g(6, 3);
+        for x in 0..6 {
+            kind(&mut s2, x, 1, TileKind::Residential);
+        }
+        assert!(
+            !zone_has_road_path(&s2, 0, 1),
+            "a zoned strip with no road anywhere must not find one"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three findings in the last month were **tests that could not fail** — a vacuous assertion that short-circuited before the thing it named, a soak that only *printed* the property it advertised as enforced, and a screenshot harness whose per-pixel `threshold` left it blind to the one shift it existed to catch. Every one was found by a person mutating the source by hand. Nothing in the repo asked the question automatically, so nothing would have caught the fourth.

This wires up `cargo mutants` and writes down the two rules those findings point at.

### Workflow and infrastructure

- **`.cargo/mutants.toml`** — records *why* each exclusion exists, not just what it is. `--lib` keeps the per-mutant cost tied to the fast unit suite (otherwise every integration test reruns once per mutant, and the soak alone would dominate); the two thin delegation crates are excluded because they have no Rust tests, so every mutant in them is MISSED by construction and is noise rather than signal.
- **`rust-mutants-diff`** in `.github/workflows/ci.yml`, on every pull request. `--in-diff` mutates only what the PR touched, so cost tracks the change rather than the codebase. Survivors land in the job summary, as annotations on the diff, and as a count in the CI comment.
- **`rust-mutants-full`** in `.github/workflows/mutants-full.yml`, weekly and on `workflow_dispatch`. Whole workspace, uploaded as an artefact — a work queue, not a verdict.

Both are `continue-on-error`, and the note says exactly what has to stop being true before that changes: `--in-diff` covers whole functions the diff touched, so a one-line edit surfaces that function's pre-existing gaps as if they were yours; and equivalent mutants are common here, because combining disjoint flag bits with `|` yields a survivor no test can ever kill.

### Maintainer-facing changes

`adjacency.rs` was the first file put through it, and the triage is the deliverable rather than the test count. Nine survivors, three different answers:

- **Four real gaps in the grid bounds.** Nothing pinned that `orthogonal_neighbours` stays on the map, though every caller indexes the grid with what it yields. The new test covers the interior, four corners, two edges, a **non-square** grid so a transposed width/height cannot pass, and the 1×1 case a `<=` bound turns into two phantom neighbours.
- **Three that should not have existed.** `zone_has_road_path` spelled out `(ny * state.width + nx)` for its `visited` key while `GameState::tile_index` was right there. A wrong key silently aliases two tiles and drops half the search — no panic, no failing test. Using the helper removed the mutants along with the arithmetic; the file's mutant count fell 56 → 52.
- **Two equivalent, excluded by name.** `DIRS` is symmetric under reflection in either axis, so negating `dx` or `dy` yields the identical neighbour set in a different order, and every caller is order-insensitive. No test can ever kill them. `mutants.toml` records that this stops being true if `DIRS` gains a diagonal.

### Documentation

`AGENTS.md` gains **Prove a test has teeth** and **Claims must be checkable**, each grounded in a real finding rather than stated as principle. The first now carries the harder half, learned the hard way this week: *choose the mutation to match the failure mode.* The soak's allocation check was proved with a leak sized by the clock, went red, and was written up as sound — but it compares a *rate*, so a constant-size leak was invisible to it by construction. And a property verified only on a developer machine is not verified: `threshold: 0` passed locally with three parallel repeats and still failed CI.

## Test plan

- [x] `cargo test --workspace` — 301 + 4 golden + 2 soak (1 ignored, #180) + 19 protocol, 0 failed
- [x] `cargo clippy --workspace --exclude city-sim-wasm --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo mutants --list-files` selects the two crates with Rust tests and excludes the two delegation layers — 1617 mutants workspace-wide
- [x] `cargo mutants --file crates/city-sim-core/src/adjacency.rs` — **50 caught, 0 missed**, down from 9 missed
- [x] The exclusion is scoped, not a blanket: it removes exactly the two named mutants (52 → 50)
- [x] Both workflow files parse and register their jobs
- [ ] **Not verified: the CI jobs have never run.** They are new, and `continue-on-error` means a mistake in either shows up as a job that reports nothing rather than one that fails loudly. Watch the first run on this PR.
