### PR TITLE
Fork the legacy save-import wire layout off the live tile buffer

### DIFF
--- a/crates/city-sim-core/src/import.rs
+++ b/crates/city-sim-core/src/import.rs
@@ -23,7 +23,8 @@
 //!   defaults and are recomputed within one tick / recompute interval.
 
 use city_sim_protocol::commands::Policies;
-use city_sim_protocol::tile_buffer::{decode_happiness, TileBufferOffsets, BYTES_PER_TILE};
+use city_sim_protocol::legacy_tile_buffer::{LegacyTileBufferOffsets, LEGACY_BYTES_PER_TILE};
+use city_sim_protocol::tile_buffer::decode_happiness;
 use city_sim_protocol::tile_kind::TileKind;
 
 use crate::buildings::{
@@ -79,7 +80,7 @@ pub fn from_tile_buffer(
     stats: ImportStats,
 ) -> Result<GameState, ImportError> {
     let n = (width as usize) * (height as usize);
-    let expected = n * BYTES_PER_TILE;
+    let expected = n * LEGACY_BYTES_PER_TILE;
     if buffer.len() != expected {
         return Err(ImportError::BadLength {
             actual: buffer.len(),
@@ -88,7 +89,7 @@ pub fn from_tile_buffer(
             height,
         });
     }
-    let o = TileBufferOffsets::for_size(n);
+    let o = LegacyTileBufferOffsets::for_size(n);
 
     let mut state = GameState::new(width, height, seed);
     state.money = stats.money;
@@ -192,9 +193,9 @@ mod tests {
     /// that the wire derivation and the v4 decode are inverses.
     fn encode_tiles(state: &GameState) -> Vec<u8> {
         let n = state.tiles.len();
-        let o = TileBufferOffsets::for_size(n);
+        let o = LegacyTileBufferOffsets::for_size(n);
         let lookup = StructureLookup::new(state);
-        let mut buf = vec![0u8; n * BYTES_PER_TILE];
+        let mut buf = vec![0u8; n * LEGACY_BYTES_PER_TILE];
         for (i, tile) in state.tiles.iter().enumerate() {
             let kind = wire_kind(tile, &lookup);
             buf[o.kind + i] = kind as u8;
@@ -323,7 +324,7 @@ mod tests {
     #[test]
     fn rejects_invalid_kind_byte() {
         let n = 4 * 4;
-        let mut buf = vec![0u8; n * BYTES_PER_TILE];
+        let mut buf = vec![0u8; n * LEGACY_BYTES_PER_TILE];
         buf[0] = 250; // not a TileKind
         let err = from_tile_buffer(
             4,

--- a/crates/city-sim-protocol/src/legacy_tile_buffer.rs
+++ b/crates/city-sim-protocol/src/legacy_tile_buffer.rs
@@ -1,0 +1,102 @@
+// legacy_tile_buffer.rs — frozen v4 tile-buffer layout, for legacy save import only.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+//! The wire layout every `.citysim` JSON save was ever encoded against, before
+//! the live wire moved to the occupant-strata representation (`docs/tile-model.md`,
+//! #177's TS/wire follow-up). `city_sim_core::import::from_tile_buffer` decodes
+//! exactly this shape via `crate::migrate::tile_from_v4`.
+//!
+//! **This module must never change again.** The live wire format
+//! (`crate::tile_buffer`) is free to evolve; this one exists so old saves keep
+//! importing byte-for-byte no matter how the live format moves on. If a save
+//! format ever needs to change, it gets a new module, not an edit to this one.
+//!
+//! Layout — byte-for-byte identical to the pre-migration live format:
+//!
+//! ```text
+//! | kind[N]  u8  | flags[N]  u8  | happiness[N]  u8  | elevation[N]  u8  | building_id[N*2]  u16le | underground_kind[N]  u8 | wilderness[N]  u8 |
+//! |--- N --------|--- N ---------|--- N --------------|--- N --------------|--- N*2 ------------------|--- N -------------------|--- N --------------|
+//! ```
+//!
+//! Where N = W × H. All multi-byte values are little-endian.
+//! `underground_kind` uses 0xFF as the "no underground" sentinel (0 = `TileKind::Land`).
+//! `happiness`/`wilderness` share the live format's codecs
+//! (`crate::tile_buffer::{encode_happiness, decode_happiness, encode_eco, decode_eco}`)
+//! — those aren't part of the kind/flags spelling this module freezes.
+
+/// Number of bytes per tile in the frozen legacy buffer (1+1+1+1+2+1+1 = 8).
+pub const LEGACY_BYTES_PER_TILE: usize = 8;
+
+/// Byte offsets of each field array in the frozen legacy layout.
+pub struct LegacyTileBufferOffsets {
+    /// `kind[N]`             — TileKind u8 values.
+    pub kind: usize,
+    /// `flags[N]`            — bit-packed boolean fields (see `legacy_flags`).
+    pub flags: usize,
+    /// `happiness[N]`        — happiness quantised to u8 (0 = 0.0, 255 = 2.0).
+    pub happiness: usize,
+    /// `elevation[N]`        — signed elevation as i8.
+    pub elevation: usize,
+    /// `building_id[N*2]`    — building ID as u16le (0 = no building).
+    pub building_id: usize,
+    /// `underground_kind[N]` — TileKind u8 of buried tile (0xFF = none; 0 = `TileKind::Land`).
+    pub underground_kind: usize,
+    /// `wilderness[N]`       — per-tile eco value quantised to u8 (128 = neutral).
+    pub wilderness: usize,
+}
+
+impl LegacyTileBufferOffsets {
+    pub const fn for_size(n: usize) -> Self {
+        Self {
+            kind: 0,
+            flags: n,
+            happiness: n * 2,
+            elevation: n * 3,
+            building_id: n * 4,
+            underground_kind: n * 6,
+            wilderness: n * 7,
+        }
+    }
+
+    pub const fn total_bytes(n: usize) -> usize {
+        n * LEGACY_BYTES_PER_TILE
+    }
+}
+
+/// Bit positions within the legacy `flags` byte.
+pub mod legacy_flags {
+    pub const POWERED: u8 = 1 << 0;
+    pub const WATERED: u8 = 1 << 1;
+    pub const ABANDONED: u8 = 1 << 2;
+    pub const ROAD_UNDERLAY: u8 = 1 << 3;
+    pub const RAIL_UNDERLAY: u8 = 1 << 4;
+    pub const POWER_OVERLAY: u8 = 1 << 5;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn offsets_for_64x64() {
+        let n = 64 * 64; // 4096
+        let off = LegacyTileBufferOffsets::for_size(n);
+        assert_eq!(off.kind, 0);
+        assert_eq!(off.flags, 4096);
+        assert_eq!(off.happiness, 8192);
+        assert_eq!(off.elevation, 12288);
+        assert_eq!(off.building_id, 16384);
+        assert_eq!(off.underground_kind, 24576);
+        assert_eq!(off.wilderness, 28672);
+        assert_eq!(LegacyTileBufferOffsets::total_bytes(n), 32768);
+    }
+
+    #[test]
+    fn bytes_per_tile_matches_layout() {
+        // kind(1) + flags(1) + happiness(1) + elevation(1) + building_id(2)
+        //   + underground_kind(1) + wilderness(1) = 8
+        assert_eq!(LEGACY_BYTES_PER_TILE, 8);
+    }
+}

--- a/crates/city-sim-protocol/src/lib.rs
+++ b/crates/city-sim-protocol/src/lib.rs
@@ -5,5 +5,6 @@
 
 pub mod commands;
 pub mod events;
+pub mod legacy_tile_buffer;
 pub mod tile_buffer;
 pub mod tile_kind;


### PR DESCRIPTION
## Summary
- **Decouples old-save import from the live wire format**, ahead of a follow-up PR that changes the live format: `crates/city-sim-protocol/src/legacy_tile_buffer.rs` is a byte-for-byte, permanently-frozen copy of today's `tile_buffer.rs` layout (`LegacyTileBufferOffsets`, `LEGACY_BYTES_PER_TILE`, `legacy_flags`).
- **`import.rs::from_tile_buffer`** now decodes against the frozen legacy module instead of the live one — no logic change, `migrate.rs::tile_from_v4` (the v4→strata decode) is untouched.

Part 1 of finishing the tile-model migration `docs/tile-model.md`'s own "Migration" section deferred: the live wire buffer is about to move from the derived `kind`+`flags` spelling to the engine's real occupant-strata representation (this PR's stack continues in `legacy-wire-fork` → `live-wire-flip` → ...). Legacy `.citysim` JSON saves are encoded against the current `kind`+`flags` shape and must keep importing byte-for-byte no matter how the live format changes next, so this PR exists purely to make that safe *before* anything else moves.

### Maintainer-facing changes
- New frozen module `crates/city-sim-protocol/src/legacy_tile_buffer.rs`, doc-commented as permanently frozen — only `import.rs` may depend on it.

## Test plan
- [x] `cargo test --workspace` passes unchanged (byte-identical layout ⇒ zero behaviour change)
- [x] `cargo check --workspace`
- [x] `cargo fmt --check`
