### PR TITLE
Decode the live wire into strata on the TS side, behind a shim

### DIFF
--- a/app/src/game/adjacency.test.ts
+++ b/app/src/game/adjacency.test.ts
@@ -197,7 +197,7 @@ describe('adjacency — water carriers exclude hydro lines', () => {
     state.money = 50000;
 
     const piped = getTile(state, 0, 0)!;
-    piped.underground = TileKind.WaterPipe;
+    piped.legacyUnderground = TileKind.WaterPipe;
     expect(isWaterCarrier(piped)).toBe(true);
 
     applyTool(state, Tool.Road, 1, 0);

--- a/app/src/game/adjacency.ts
+++ b/app/src/game/adjacency.ts
@@ -107,7 +107,7 @@ export function isPowerCarrier(tile: Tile | undefined): boolean {
  */
 export function isWaterCarrier(tile: Tile | undefined): boolean {
   if (!tile) return false;
-  if (tile.underground === TileKind.WaterPipe) return true;
+  if (tile.legacyUnderground === TileKind.WaterPipe) return true;
   if (tile.buildingId !== undefined) return true; // Buildings carry water
   if (tile.kind === TileKind.Road || tile.roadUnderlay) return true;
   if (tile.kind === TileKind.Rail || tile.railUnderlay) return true;

--- a/app/src/game/gameState.ts
+++ b/app/src/game/gameState.ts
@@ -8,6 +8,7 @@ import { BylawState, DEFAULT_BYLAWS } from './bylaws';
 import { createDefaultPolicies, type Policies } from './protocol/commands';
 import { defaultHotkeys, type HotkeyBindings } from '../ui/hotkeys';
 import { createDefaultSfxOverrides, type SfxOverrides } from './sfxOverrides';
+import { Terrain, ZoneDensity } from './protocol/occupants';
 import type { BudgetHistory } from './economy';
 import type { EducationStats } from './education';
 import type { BuildingInstance } from './buildings/state';
@@ -45,9 +46,19 @@ export interface Tile {
   powered: boolean;
   watered: boolean;
   abandoned?: boolean;
-  underground?: TileKind;
+  /**
+   * @deprecated shim field, renamed from `underground` (now the strata
+   * field below) to avoid a name collision. Populated from `underground`/
+   * `Occupant.Pipe` by `wasmSimBridge.ts`/`tauriSimBridge.ts` during the
+   * strangler window — removed once every consumer reads the strata fields
+   * directly.
+   */
+  legacyUnderground?: TileKind;
+  /** @deprecated shim field — see `legacyUnderground`'s note. */
   roadUnderlay?: boolean;
+  /** @deprecated shim field — see `legacyUnderground`'s note. */
   railUnderlay?: boolean;
+  /** @deprecated shim field — see `legacyUnderground`'s note. */
   powerOverlay?: boolean;
   powerPlantType?: PowerPlantType;
   powerPlantId?: number;
@@ -55,6 +66,17 @@ export interface Tile {
   /** Per-tile wilderness intensity, 0–1 (0.5 = neutral). From the sim's eco field. */
   wilderness?: number;
   services: TileServiceState;
+
+  /** What the ground itself is, `Land` | `Water`. Mirrors Rust's `Tile::terrain`. */
+  terrain: Terrain;
+  /** Underground stratum occupant bits (`Occupant.Pipe`/`Subway`/`Fibre`). Mirrors Rust's `Tile::underground`. */
+  underground: number;
+  /** Surface stratum occupant bits (`Occupant.Road`/`Rail`/zone tags/`Structure`). Mirrors Rust's `Tile::surface`. */
+  surface: number;
+  /** Overhead stratum occupant bits (`Occupant.PowerLine`/`Trees`). Mirrors Rust's `Tile::overhead`. */
+  overhead: number;
+  /** Zone density — not read by any system yet, carried for parity with Rust. */
+  density: ZoneDensity;
 }
 
 export type MinimapMode = 'base' | 'power' | 'water' | 'alerts' | 'education' | 'wilderness' | 'underground';
@@ -321,13 +343,19 @@ export function createInitialState(width = 64, height = 64, seed?: number): Game
     for (let x = 0; x < width; x++) {
       const edge = x < 3 || y < 3 || x > width - 4 || y > height - 4;
       const isWater = (x - width / 2) ** 2 + (y - height / 2) ** 2 < 180 && (x + y) % 5 === 0;
+      const water = edge || isWater;
       tiles.push({
-        kind: edge ? TileKind.Water : isWater ? TileKind.Water : TileKind.Land,
+        kind: water ? TileKind.Water : TileKind.Land,
         elevation: 0,
         happiness: 1,
         powered: false,
         watered: false,
-        services: createTileServiceState()
+        services: createTileServiceState(),
+        terrain: water ? Terrain.Water : Terrain.Land,
+        underground: 0,
+        surface: 0,
+        overhead: 0,
+        density: ZoneDensity.Low
       });
     }
   }

--- a/app/src/game/parity/engines.ts
+++ b/app/src/game/parity/engines.ts
@@ -27,8 +27,25 @@ import { Simulation } from '../simulation';
 import { applyTool } from '../tools';
 import { Tool } from '../toolTypes';
 import { tileKindFromU8, tileKindToU8 } from '../protocol/tileKind';
-import { BYTES_PER_TILE, FLAGS, tileBufferOffsets } from '../protocol/tileBuffer';
+import {
+  BYTES_PER_TILE,
+  tileBufferOffsets,
+  decodeUndergroundBits,
+  decodeSurfaceBits,
+  decodeOverheadBits,
+  STATUS
+} from '../protocol/tileBuffer';
+import { LEGACY_FLAGS } from '../protocol/legacyTileBuffer';
+import { Terrain } from '../protocol/occupants';
+import { legacyKind, legacyFlags, legacyUndergroundKind } from '../protocol/legacyProjection';
 import { factsFromWire, TileFacts } from './tileFacts';
+
+interface WireBuilding {
+  id: number;
+  kind: number;
+  originX: number;
+  originY: number;
+}
 
 /**
  * TS `Tool` → the Rust `#[repr(u8)]` discriminant.
@@ -118,6 +135,7 @@ interface SimHostInstance {
   set_natural_terrain(kinds: Uint8Array): void;
   step(dt: number): void;
   tile_buffer(): Uint8Array;
+  buildings_json(): string;
   money(): number;
   population(): number;
   jobs(): number;
@@ -202,21 +220,38 @@ export function rustEngine(width: number, height: number, seed: number): Engine 
     facts() {
       const buf = host.tile_buffer();
       const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+      // The live wire no longer carries a resolved kind byte per tile — a
+      // `Structure` occupant says only that a building stands here, not
+      // which one (#177's TS/wire follow-up). `buildings_json` is the only
+      // source for that now, same as `wasmSimBridge.ts`'s decode.
+      const wireBuildings: WireBuilding[] = JSON.parse(host.buildings_json());
+      const structureKindById = new Map<number, TileKind>();
+      for (const b of wireBuildings) {
+        const kind = tileKindFromU8(b.kind);
+        if (kind !== undefined) structureKindById.set(b.id, kind);
+      }
+      const structureKindOf = (id: number) => structureKindById.get(id);
+
       const out: TileFacts[] = [];
       for (let i = 0; i < n; i++) {
-        const kind = tileKindFromU8(buf[off.kind + i]);
-        if (kind === undefined) throw new Error(`rust emitted unknown kind ${buf[off.kind + i]}`);
-        const undergroundByte = buf[off.undergroundKind + i];
-        const underground =
-          undergroundByte === 0xff ? undefined : tileKindFromU8(undergroundByte);
-        out.push(
-          factsFromWire(
-            kind,
-            buf[off.flags + i],
-            view.getUint16(off.buildingId + i * 2, true),
-            underground
-          )
-        );
+        const terrain = (buf[off.status + i] & STATUS.WATER_TERRAIN) !== 0 ? Terrain.Water : Terrain.Land;
+        const surface = decodeSurfaceBits(buf[off.surface + i]);
+        const overhead = decodeOverheadBits(buf[off.overhead + i]);
+        const underground = decodeUndergroundBits(buf[off.underground + i]);
+        const buildingIdRaw = view.getUint16(off.buildingId + i * 2, true);
+        const buildingId = buildingIdRaw === 0 ? undefined : buildingIdRaw;
+
+        const kind = legacyKind({ terrain, surface, overhead, buildingId, structureKindOf });
+        const flags = legacyFlags({ terrain, surface, overhead, buildingId, structureKindOf }, kind);
+        const flagBits =
+          ((buf[off.status + i] & STATUS.POWERED) !== 0 ? LEGACY_FLAGS.POWERED : 0) |
+          ((buf[off.status + i] & STATUS.WATERED) !== 0 ? LEGACY_FLAGS.WATERED : 0) |
+          ((buf[off.status + i] & STATUS.ABANDONED) !== 0 ? LEGACY_FLAGS.ABANDONED : 0) |
+          (flags.roadUnderlay ? LEGACY_FLAGS.ROAD_UNDERLAY : 0) |
+          (flags.railUnderlay ? LEGACY_FLAGS.RAIL_UNDERLAY : 0) |
+          (flags.powerOverlay ? LEGACY_FLAGS.POWER_OVERLAY : 0);
+
+        out.push(factsFromWire(kind, flagBits, buildingIdRaw, legacyUndergroundKind(underground)));
       }
       return out;
     }
@@ -240,12 +275,12 @@ export function tsEngine(width: number, height: number, seed: number): Engine {
   const flagsOf = (x: number, y: number): number => {
     const tile = getTile(state, x, y)!;
     let bits = 0;
-    if (tile.powered) bits |= FLAGS.POWERED;
-    if (tile.watered) bits |= FLAGS.WATERED;
-    if (tile.abandoned) bits |= FLAGS.ABANDONED;
-    if (tile.roadUnderlay) bits |= FLAGS.ROAD_UNDERLAY;
-    if (tile.railUnderlay) bits |= FLAGS.RAIL_UNDERLAY;
-    if (tile.powerOverlay) bits |= FLAGS.POWER_OVERLAY;
+    if (tile.powered) bits |= LEGACY_FLAGS.POWERED;
+    if (tile.watered) bits |= LEGACY_FLAGS.WATERED;
+    if (tile.abandoned) bits |= LEGACY_FLAGS.ABANDONED;
+    if (tile.roadUnderlay) bits |= LEGACY_FLAGS.ROAD_UNDERLAY;
+    if (tile.railUnderlay) bits |= LEGACY_FLAGS.RAIL_UNDERLAY;
+    if (tile.powerOverlay) bits |= LEGACY_FLAGS.POWER_OVERLAY;
     return bits;
   };
 
@@ -282,7 +317,7 @@ export function tsEngine(width: number, height: number, seed: number): Engine {
               tile.kind,
               flagsOf(x, y),
               tile.buildingId ?? 0,
-              tile.underground === TileKind.WaterPipe ? TileKind.WaterPipe : undefined
+              tile.legacyUnderground === TileKind.WaterPipe ? TileKind.WaterPipe : undefined
             )
           );
         }

--- a/app/src/game/parity/tileFacts.ts
+++ b/app/src/game/parity/tileFacts.ts
@@ -26,7 +26,7 @@
  */
 
 import { TileKind } from '../gameState';
-import { FLAGS } from '../protocol/tileBuffer';
+import { LEGACY_FLAGS as FLAGS } from '../protocol/legacyTileBuffer';
 
 /** Zone tags, in the order the wire kind byte spells them. */
 export const ZONE_KINDS: ReadonlySet<TileKind> = new Set([

--- a/app/src/game/persistence.ts
+++ b/app/src/game/persistence.ts
@@ -24,8 +24,10 @@ import {
 } from './protocol/commands';
 import type { ClientState } from './clientState';
 import type { LegacyEngineImport } from '../workers/wasmSim.worker';
-import { BYTES_PER_TILE, FLAGS, encodeHappiness, tileBufferOffsets } from './protocol/tileBuffer';
+import { encodeHappiness } from './protocol/tileBuffer';
+import { LEGACY_BYTES_PER_TILE, LEGACY_FLAGS, legacyTileBufferOffsets } from './protocol/legacyTileBuffer';
 import { tileKindToU8 } from './protocol/tileKind';
+import { tileFromV4 } from './protocol/legacyProjection';
 
 export function serialize(state: GameState): string {
   return JSON.stringify(state);
@@ -57,16 +59,32 @@ export function deserialize(payload: string): GameState {
       parsed.services.definitions[id] = def;
     }
   });
-  parsed.tiles = parsed.tiles.map((tile: any) => ({
-    ...tile,
-    powered: tile.powered ?? false,
-    watered: tile.watered ?? false,
-    underground: tile.underground,
-    powerPlantType: tile.powerPlantType,
-    powerPlantId: tile.powerPlantId,
-    buildingId: tile.buildingId ?? tile.powerPlantId,
-    services: tile.services ?? createTileServiceState()
-  }));
+  parsed.tiles = parsed.tiles.map((tile: any) => {
+    const buildingId = tile.buildingId ?? tile.powerPlantId;
+    const base = {
+      ...tile,
+      powered: tile.powered ?? false,
+      watered: tile.watered ?? false,
+      powerPlantType: tile.powerPlantType,
+      powerPlantId: tile.powerPlantId,
+      buildingId,
+      services: tile.services ?? createTileServiceState()
+    };
+    // `terrain` only exists on a tile written after this migration — a save
+    // from before it has no strata at all, and its `underground` key is the
+    // old `TileKind | undefined` field, not the new occupant bitset. Decode
+    // that v4 spelling into strata, same as `migrate::tile_from_v4` does for
+    // the Rust-side importer. A tile that already has `terrain` already has
+    // everything strata-shaped needs — nothing to decode.
+    if (tile.terrain !== undefined) return base;
+    const strata = tileFromV4(
+      tile.kind,
+      { roadUnderlay: tile.roadUnderlay, railUnderlay: tile.railUnderlay, powerOverlay: tile.powerOverlay },
+      tile.underground,
+      buildingId
+    );
+    return { ...base, legacyUnderground: tile.underground, ...strata };
+  });
   parsed.buildings = (parsed.buildings ?? []).map((building: any) => {
     const state = building.state ?? createBuildingState();
     if (state.health === undefined) state.health = 100;
@@ -406,25 +424,25 @@ export function decodeLegacySave(json: string): GameState {
  */
 export function buildLegacyEngineImport(state: GameState): LegacyEngineImport {
   const n = state.width * state.height;
-  const o = tileBufferOffsets(n);
-  const tiles = new Uint8Array(n * BYTES_PER_TILE);
+  const o = legacyTileBufferOffsets(n);
+  const tiles = new Uint8Array(n * LEGACY_BYTES_PER_TILE);
   for (let i = 0; i < n; i++) {
     const tile = state.tiles[i];
     tiles[o.kind + i] = tileKindToU8(tile.kind);
     tiles[o.flags + i] =
-      (tile.powered ? FLAGS.POWERED : 0) |
-      (tile.watered ? FLAGS.WATERED : 0) |
-      (tile.abandoned ? FLAGS.ABANDONED : 0) |
-      (tile.roadUnderlay ? FLAGS.ROAD_UNDERLAY : 0) |
-      (tile.railUnderlay ? FLAGS.RAIL_UNDERLAY : 0) |
-      (tile.powerOverlay ? FLAGS.POWER_OVERLAY : 0);
+      (tile.powered ? LEGACY_FLAGS.POWERED : 0) |
+      (tile.watered ? LEGACY_FLAGS.WATERED : 0) |
+      (tile.abandoned ? LEGACY_FLAGS.ABANDONED : 0) |
+      (tile.roadUnderlay ? LEGACY_FLAGS.ROAD_UNDERLAY : 0) |
+      (tile.railUnderlay ? LEGACY_FLAGS.RAIL_UNDERLAY : 0) |
+      (tile.powerOverlay ? LEGACY_FLAGS.POWER_OVERLAY : 0);
     tiles[o.happiness + i] = encodeHappiness(tile.happiness);
     tiles[o.elevation + i] = tile.elevation & 0xff;
     const buildingId = tile.buildingId ?? 0;
     tiles[o.buildingId + i * 2] = buildingId & 0xff;
     tiles[o.buildingId + i * 2 + 1] = (buildingId >> 8) & 0xff;
     tiles[o.undergroundKind + i] =
-      tile.underground === undefined ? 0xff : tileKindToU8(tile.underground);
+      tile.legacyUnderground === undefined ? 0xff : tileKindToU8(tile.legacyUnderground);
     tiles[o.wilderness + i] = 128; // recomputed by the sim within one interval
   }
   return {

--- a/app/src/game/protocol/legacyProjection.ts
+++ b/app/src/game/protocol/legacyProjection.ts
@@ -1,0 +1,143 @@
+// legacyProjection.ts — TS port of the precedence Rust's (deleted) display.rs
+// wire_kind/wire_flags/wire_underground used to run.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+/**
+ * Temporary strangler-window scaffolding: `wasmSimBridge.ts`/`tauriSimBridge.ts`
+ * call this to populate `Tile`'s deprecated `kind`/`roadUnderlay`/`railUnderlay`/
+ * `powerOverlay`/`legacyUnderground` shim fields from the real strata, so
+ * consumers not yet converted to `terrain`/`underground`/`surface`/`overhead`
+ * keep working. Deleted, along with the shim fields themselves, once every
+ * consumer reads the strata directly.
+ *
+ * Mirrors `city_sim_core::display::{wire_kind, wire_flags, wire_underground}`
+ * exactly (as they were before deletion) — precedence: terrain > structure >
+ * zone > trees > line > rail > road > land.
+ */
+
+import { TileKind } from '../gameState';
+import { Occupant, Terrain, ZoneDensity, hasOccupant, withOccupant, zoneOccupant } from './occupants';
+
+const ZONE_KIND: Partial<Record<Occupant, TileKind>> = {
+  [Occupant.ZoneResidential]: TileKind.Residential,
+  [Occupant.ZoneCommercial]: TileKind.Commercial,
+  [Occupant.ZoneIndustrial]: TileKind.Industrial
+};
+
+export interface LegacyProjectionInput {
+  terrain: Terrain;
+  surface: number;
+  overhead: number;
+  buildingId?: number;
+  /** Resolves a building's template kind — `undefined` if not live. */
+  structureKindOf: (buildingId: number) => TileKind | undefined;
+}
+
+/**
+ * The v4 `kind` for one tile. `None` for a developed zone lot's structure
+ * lookup is deliberate: the lot carries a `building_id` and a
+ * `BuildingInstance` whose kind is e.g. `Residential`, but its occupant is a
+ * zone tag, not `Occupant.Structure` — see `zoneOccupant` below, which is
+ * what actually resolves it.
+ */
+export function legacyKind(t: LegacyProjectionInput): TileKind {
+  if (t.terrain === Terrain.Water) return TileKind.Water;
+  if (hasOccupant(t.surface, Occupant.Structure) && t.buildingId !== undefined) {
+    const structureKind = t.structureKindOf(t.buildingId);
+    if (structureKind !== undefined) return structureKind;
+  }
+  const zone = zoneOccupant(t.surface);
+  if (zone !== undefined) return ZONE_KIND[zone] as TileKind;
+  if (hasOccupant(t.overhead, Occupant.Trees)) return TileKind.Tree;
+  if (hasOccupant(t.overhead, Occupant.PowerLine)) return TileKind.PowerLine;
+  if (hasOccupant(t.surface, Occupant.Rail)) return TileKind.Rail;
+  if (hasOccupant(t.surface, Occupant.Road)) return TileKind.Road;
+  return TileKind.Land;
+}
+
+/**
+ * The v4 structural flags: true for whichever occupant is present but did not
+ * win `kind`. `powerOverlay` is unconditional whenever the `PowerLine`
+ * occupant is present, even when `kind` is already `PowerLine` — mirrors
+ * `wire_flags`'s note that `Tool::PowerLine` always set both historically.
+ */
+export function legacyFlags(t: LegacyProjectionInput, kind: TileKind) {
+  return {
+    roadUnderlay: hasOccupant(t.surface, Occupant.Road) && kind !== TileKind.Road,
+    railUnderlay: hasOccupant(t.surface, Occupant.Rail) && kind !== TileKind.Rail,
+    powerOverlay: hasOccupant(t.overhead, Occupant.PowerLine)
+  };
+}
+
+/** The v4 `underground` TileKind — `WaterPipe` or `undefined`. */
+export function legacyUndergroundKind(underground: number): TileKind | undefined {
+  return hasOccupant(underground, Occupant.Pipe) ? TileKind.WaterPipe : undefined;
+}
+
+/**
+ * The ten `TileKind`s that derive to the single `Structure` occupant. Mirrors
+ * `occupants::is_structure_kind`.
+ */
+const STRUCTURE_KINDS: ReadonlySet<TileKind> = new Set([
+  TileKind.HydroPlant,
+  TileKind.CoalPlant,
+  TileKind.WindTurbine,
+  TileKind.SolarFarm,
+  TileKind.WaterPump,
+  TileKind.WaterTower,
+  TileKind.ElementarySchool,
+  TileKind.HighSchool,
+  TileKind.Park,
+  TileKind.ParkLarge
+]);
+
+export interface V4Strata {
+  terrain: Terrain;
+  underground: number;
+  surface: number;
+  overhead: number;
+  density: ZoneDensity;
+}
+
+/**
+ * Decode a v4-shaped tile spelling into strata occupant bits. Mirrors
+ * `migrate::tile_from_v4` — used only to import old `.citysim` JSON saves
+ * (`persistence.ts`'s `deserialize`), which never encoded zone density, so
+ * `density` is always `Low` here (matches the Rust importer's documented
+ * fidelity limit).
+ */
+export function tileFromV4(
+  kind: TileKind,
+  flags: { roadUnderlay?: boolean; railUnderlay?: boolean; powerOverlay?: boolean },
+  underground: TileKind | undefined,
+  buildingId: number | undefined
+): V4Strata {
+  const hasPipe = underground === TileKind.WaterPipe;
+  const hasRoad = kind === TileKind.Road || !!flags.roadUnderlay;
+  const hasRail = kind === TileKind.Rail || !!flags.railUnderlay;
+  const hasLine = kind === TileKind.PowerLine || !!flags.powerOverlay;
+  const hasStructure = STRUCTURE_KINDS.has(kind) && buildingId !== undefined;
+
+  let undergroundBits = 0;
+  let surface = 0;
+  let overhead = 0;
+  undergroundBits = withOccupant(undergroundBits, Occupant.Pipe, hasPipe);
+  surface = withOccupant(surface, Occupant.Road, hasRoad);
+  surface = withOccupant(surface, Occupant.Rail, hasRail);
+  surface = withOccupant(surface, Occupant.ZoneResidential, kind === TileKind.Residential);
+  surface = withOccupant(surface, Occupant.ZoneCommercial, kind === TileKind.Commercial);
+  surface = withOccupant(surface, Occupant.ZoneIndustrial, kind === TileKind.Industrial);
+  surface = withOccupant(surface, Occupant.Structure, hasStructure);
+  overhead = withOccupant(overhead, Occupant.PowerLine, hasLine);
+  overhead = withOccupant(overhead, Occupant.Trees, kind === TileKind.Tree);
+
+  return {
+    terrain: kind === TileKind.Water ? Terrain.Water : Terrain.Land,
+    underground: undergroundBits,
+    surface,
+    overhead,
+    density: ZoneDensity.Low
+  };
+}

--- a/app/src/game/protocol/legacyTileBuffer.ts
+++ b/app/src/game/protocol/legacyTileBuffer.ts
@@ -1,0 +1,47 @@
+/**
+ * Frozen v4 tile-buffer layout — TS mirror of
+ * crates/city-sim-protocol/src/legacy_tile_buffer.rs.
+ *
+ * The wire layout every `.citysim` JSON save was ever encoded against,
+ * before the live wire moved to the occupant-strata representation. Used
+ * only by `persistence.ts`'s `buildLegacyEngineImport` (encoding *to* this
+ * shape for `SimHost.import_legacy`) and by `wasmSimBridge.ts`'s legacy
+ * import decode path, if either needs to read/write it directly.
+ *
+ * **This module must never change again.** The live wire format
+ * (`tileBuffer.ts`) is free to evolve; this one exists so old saves keep
+ * importing byte-for-byte no matter how the live format moves on.
+ *
+ *   kind[N]             u8   — TileKind u8 values
+ *   flags[N]            u8   — bit-packed booleans (see LEGACY_FLAGS)
+ *   happiness[N]        u8   — quantised 0–255 (0.0–2.0)
+ *   elevation[N]        u8   — unsigned elevation (0–255)
+ *   building_id[N]      u16  — building ID, little-endian (0 = none)
+ *   underground_kind[N] u8   — TileKind u8 of buried tile (0xFF = none)
+ *   wilderness[N]       u8   — per-tile eco value, quantised (128 = neutral)
+ *
+ * Total: N × 8 bytes.
+ */
+
+export const LEGACY_BYTES_PER_TILE = 8;
+
+export function legacyTileBufferOffsets(n: number) {
+  return {
+    kind: 0,
+    flags: n,
+    happiness: n * 2,
+    elevation: n * 3,
+    buildingId: n * 4, // u16le → occupies n*2 bytes starting here
+    undergroundKind: n * 6,
+    wilderness: n * 7
+  } as const;
+}
+
+export const LEGACY_FLAGS = {
+  POWERED: 1 << 0,
+  WATERED: 1 << 1,
+  ABANDONED: 1 << 2,
+  ROAD_UNDERLAY: 1 << 3,
+  RAIL_UNDERLAY: 1 << 4,
+  POWER_OVERLAY: 1 << 5
+} as const;

--- a/app/src/game/protocol/occupants.ts
+++ b/app/src/game/protocol/occupants.ts
@@ -1,0 +1,122 @@
+// occupants.ts — TS mirror of crates/city-sim-core/src/occupants.rs's occupant/stratum model.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+/**
+ * A physical layer of the map. Depth/height ordering is the discriminant
+ * order: underground → surface → overhead. Mirrors `Stratum` in
+ * `occupants.rs`.
+ */
+export enum Stratum {
+  Underground = 0,
+  Surface = 1,
+  Overhead = 2
+}
+
+/**
+ * One thing that can occupy a tile. Discriminants are absolute bit positions
+ * in an `OccupantSet` (a `number` used as a bitset here, matching Rust's
+ * `u16`), grouped by stratum. **Never reorder these** — they must stay in
+ * lockstep with `Occupant` in `crates/city-sim-core/src/occupants.rs`, and
+ * with the wire byte layout in `tileBuffer.ts`.
+ */
+export enum Occupant {
+  // --- Underground: bits 0-2 ---
+  Pipe = 0,
+  /** Reserved. No tool or TileKind exists for this yet. */
+  Subway = 1,
+  /** Reserved. No tool or TileKind exists for this yet. */
+  Fibre = 2,
+  // --- Surface: bits 3-8 ---
+  Road = 3,
+  Rail = 4,
+  ZoneResidential = 5,
+  ZoneCommercial = 6,
+  ZoneIndustrial = 7,
+  Structure = 8,
+  // --- Overhead: bits 9-10 ---
+  PowerLine = 9,
+  Trees = 10
+}
+
+/** Number of occupants defined. Bits 11-15 of an OccupantSet are spare. */
+export const OCCUPANT_COUNT = 11;
+
+/** Every occupant, in bit order. */
+export const ALL_OCCUPANTS: readonly Occupant[] = [
+  Occupant.Pipe,
+  Occupant.Subway,
+  Occupant.Fibre,
+  Occupant.Road,
+  Occupant.Rail,
+  Occupant.ZoneResidential,
+  Occupant.ZoneCommercial,
+  Occupant.ZoneIndustrial,
+  Occupant.Structure,
+  Occupant.PowerLine,
+  Occupant.Trees
+];
+
+/** Bits 0-2. */
+export const UNDERGROUND_MASK = (1 << Occupant.Pipe) | (1 << Occupant.Subway) | (1 << Occupant.Fibre);
+/** Bits 3-8. */
+export const SURFACE_MASK =
+  (1 << Occupant.Road) |
+  (1 << Occupant.Rail) |
+  (1 << Occupant.ZoneResidential) |
+  (1 << Occupant.ZoneCommercial) |
+  (1 << Occupant.ZoneIndustrial) |
+  (1 << Occupant.Structure);
+/** Bits 9-10. */
+export const OVERHEAD_MASK = (1 << Occupant.PowerLine) | (1 << Occupant.Trees);
+/** The three zone tags — a tile carries at most one. */
+export const ZONE_MASK = (1 << Occupant.ZoneResidential) | (1 << Occupant.ZoneCommercial) | (1 << Occupant.ZoneIndustrial);
+
+/** The stratum an occupant belongs to. */
+export function strataOf(occupant: Occupant): Stratum {
+  const bit = 1 << occupant;
+  if (bit & UNDERGROUND_MASK) return Stratum.Underground;
+  if (bit & SURFACE_MASK) return Stratum.Surface;
+  return Stratum.Overhead;
+}
+
+/** Whether `set` (a bitset over `Occupant`) contains `occupant`. */
+export function hasOccupant(set: number, occupant: Occupant): boolean {
+  return (set & (1 << occupant)) !== 0;
+}
+
+/** `set` with `occupant`'s bit set or cleared. */
+export function withOccupant(set: number, occupant: Occupant, on: boolean): number {
+  return on ? set | (1 << occupant) : set & ~(1 << occupant);
+}
+
+/** Every occupant present in `set`, in bit order. */
+export function iterSet(set: number): Occupant[] {
+  return ALL_OCCUPANTS.filter((o) => hasOccupant(set, o));
+}
+
+/**
+ * The tile's land use, if it is zoned. Zones are mutually exclusive, and all
+ * three are surface occupants. Mirrors `Tile::zone_occupant` in Rust.
+ */
+export function zoneOccupant(surface: number): Occupant | undefined {
+  const bits = surface & ZONE_MASK;
+  if (bits === 1 << Occupant.ZoneResidential) return Occupant.ZoneResidential;
+  if (bits === 1 << Occupant.ZoneCommercial) return Occupant.ZoneCommercial;
+  if (bits === 1 << Occupant.ZoneIndustrial) return Occupant.ZoneIndustrial;
+  return undefined;
+}
+
+/** What the ground itself is, as distinct from anything occupying it. Mirrors `Terrain` in `occupants.rs`. */
+export enum Terrain {
+  Land = 0,
+  Water = 1
+}
+
+/** Zone density. Mirrors `ZoneDensity` in `state.rs`. Not read by any system yet. */
+export enum ZoneDensity {
+  Low = 0,
+  Medium = 1,
+  High = 2
+}

--- a/app/src/game/protocol/protocol.test.ts
+++ b/app/src/game/protocol/protocol.test.ts
@@ -17,7 +17,8 @@ import {
   tileKindFromU8,
   tileKindToU8,
 } from './tileKind';
-import { BYTES_PER_TILE, FLAGS, tileBufferOffsets, decodeHappiness, encodeHappiness, decodeEco, encodeEco, ECO_RANGE } from './tileBuffer';
+import { BYTES_PER_TILE, STATUS, tileBufferOffsets, decodeHappiness, encodeHappiness, decodeEco, encodeEco, ECO_RANGE } from './tileBuffer';
+import { LEGACY_BYTES_PER_TILE, LEGACY_FLAGS, legacyTileBufferOffsets } from './legacyTileBuffer';
 import parityFixture from './tileKindParity.json';
 
 // ---------------------------------------------------------------------------
@@ -68,22 +69,23 @@ describe('protocol: TileKind ↔ u8 parity with Rust', () => {
 // ---------------------------------------------------------------------------
 
 describe('protocol: tile buffer layout', () => {
-  it('BYTES_PER_TILE is 8', () => expect(BYTES_PER_TILE).toBe(8));
+  it('BYTES_PER_TILE is 9', () => expect(BYTES_PER_TILE).toBe(9));
 
   it('offsets for 64×64 map', () => {
     const n = 64 * 64;
     const off = tileBufferOffsets(n);
-    expect(off.kind).toBe(0);
-    expect(off.flags).toBe(4096);
-    expect(off.happiness).toBe(8192);
-    expect(off.elevation).toBe(12288);
-    expect(off.buildingId).toBe(16384);
-    expect(off.undergroundKind).toBe(24576);
-    expect(off.wilderness).toBe(28672);
+    expect(off.underground).toBe(0);
+    expect(off.surface).toBe(4096);
+    expect(off.overhead).toBe(8192);
+    expect(off.status).toBe(12288);
+    expect(off.happiness).toBe(16384);
+    expect(off.elevation).toBe(20480);
+    expect(off.buildingId).toBe(24576);
+    expect(off.wilderness).toBe(32768);
   });
 
-  it('FLAGS bitmask values are unique powers of 2', () => {
-    const vals = Object.values(FLAGS);
+  it('STATUS bitmask values (excluding the density field) are unique powers of 2', () => {
+    const vals = [STATUS.POWERED, STATUS.WATERED, STATUS.ABANDONED, STATUS.WATER_TERRAIN];
     const unique = new Set(vals);
     expect(unique.size).toBe(vals.length);
     for (const v of vals) {
@@ -104,5 +106,30 @@ describe('protocol: tile buffer layout', () => {
     expect(encodeEco(0)).toBe(128);
     expect(encodeEco(999)).toBe(encodeEco(ECO_RANGE));
     expect(encodeEco(-999)).toBe(encodeEco(-ECO_RANGE));
+  });
+});
+
+describe('protocol: frozen legacy tile buffer layout', () => {
+  it('LEGACY_BYTES_PER_TILE is 8', () => expect(LEGACY_BYTES_PER_TILE).toBe(8));
+
+  it('offsets for 64×64 map', () => {
+    const n = 64 * 64;
+    const off = legacyTileBufferOffsets(n);
+    expect(off.kind).toBe(0);
+    expect(off.flags).toBe(4096);
+    expect(off.happiness).toBe(8192);
+    expect(off.elevation).toBe(12288);
+    expect(off.buildingId).toBe(16384);
+    expect(off.undergroundKind).toBe(24576);
+    expect(off.wilderness).toBe(28672);
+  });
+
+  it('LEGACY_FLAGS bitmask values are unique powers of 2', () => {
+    const vals = Object.values(LEGACY_FLAGS);
+    const unique = new Set(vals);
+    expect(unique.size).toBe(vals.length);
+    for (const v of vals) {
+      expect(v & (v - 1)).toBe(0); // power of 2
+    }
   });
 });

--- a/app/src/game/protocol/tileBuffer.ts
+++ b/app/src/game/protocol/tileBuffer.ts
@@ -1,44 +1,68 @@
 /**
- * SoA tile buffer layout — TS mirror of crates/sim_protocol/src/tile_buffer.rs.
+ * SoA tile buffer layout — TS mirror of crates/city-sim-protocol/src/tile_buffer.rs.
  *
  * For an N-tile map (N = width × height) the flat ArrayBuffer is laid out as:
  *
- *   kind[N]             u8   — TileKind u8 values
- *   flags[N]            u8   — bit-packed booleans (see FLAGS)
- *   happiness[N]        u8   — quantised 0–255 (0.0–2.0)
- *   elevation[N]        u8   — unsigned elevation (0–255)
- *   building_id[N]      u16  — building ID, little-endian (0 = none)
- *   underground_kind[N] u8   — TileKind u8 of buried tile (0xFF = none)
- *   wilderness[N]       u8   — per-tile eco value, quantised (128 = neutral)
+ *   underground[N] u8   — Underground stratum occupant bits, absolute (no shift)
+ *   surface[N]     u8   — Surface stratum occupant bits, rebased >> 3
+ *   overhead[N]    u8   — Overhead stratum occupant bits, rebased >> 9
+ *   status[N]      u8   — POWERED | WATERED | ABANDONED | WATER_TERRAIN | density (see STATUS)
+ *   happiness[N]   u8   — quantised 0–255 (0.0–2.0)
+ *   elevation[N]   u8   — unsigned elevation (0–255)
+ *   building_id[N] u16  — building ID, little-endian (0 = none)
+ *   wilderness[N]  u8   — per-tile eco value, quantised (128 = neutral)
  *
- * Total: N × 8 bytes.
+ * Total: N × 9 bytes.
+ *
+ * `underground`/`surface`/`overhead` are each a dense, rebased slice of one
+ * stratum's occupant bits (see `protocol/occupants.ts`): `Occupant`'s
+ * discriminants are absolute bit positions grouped by stratum — 0-2
+ * underground, 3-8 surface, 9-10 overhead — so a reader reconstructs the
+ * tile's full occupant set as `underground | (surface << 3) | (overhead << 9)`.
  *
  * On the web path the buffer is a SharedArrayBuffer owned by the Worker.
  * The main thread reads it via typed array views without copying.
  */
 
-export const BYTES_PER_TILE = 8;
+export const BYTES_PER_TILE = 9;
 
 export function tileBufferOffsets(n: number) {
   return {
-    kind:            0,
-    flags:           n,
-    happiness:       n * 2,
-    elevation:       n * 3,
-    buildingId:      n * 4,   // u16le → occupies n*2 bytes starting here
-    undergroundKind: n * 6,   // TileKind u8 (0xFF = none; 0 = TileKind::Land)
-    wilderness:      n * 7,   // quantised eco value (see decodeEco)
+    underground: 0,
+    surface: n,
+    overhead: n * 2,
+    status: n * 3,
+    happiness: n * 4,
+    elevation: n * 5,
+    buildingId: n * 6, // u16le → occupies n*2 bytes starting here
+    wilderness: n * 8
   } as const;
 }
 
-export const FLAGS = {
-  POWERED:       1 << 0,
-  WATERED:       1 << 1,
-  ABANDONED:     1 << 2,
-  ROAD_UNDERLAY: 1 << 3,
-  RAIL_UNDERLAY: 1 << 4,
-  POWER_OVERLAY: 1 << 5,
+/** Bit positions within the `status` byte. */
+export const STATUS = {
+  POWERED: 1 << 0,
+  WATERED: 1 << 1,
+  ABANDONED: 1 << 2,
+  WATER_TERRAIN: 1 << 3,
+  DENSITY_SHIFT: 4,
+  DENSITY_MASK: 0b11 << 4
 } as const;
+
+/** Rebase a wire `underground` byte back to absolute `Occupant` bits — already absolute, no shift. */
+export function decodeUndergroundBits(byte: number): number {
+  return byte;
+}
+
+/** Rebase a wire `surface` byte back to absolute `Occupant` bits (`<< 3`). */
+export function decodeSurfaceBits(byte: number): number {
+  return byte << 3;
+}
+
+/** Rebase a wire `overhead` byte back to absolute `Occupant` bits (`<< 9`). */
+export function decodeOverheadBits(byte: number): number {
+  return byte << 9;
+}
 
 /** Decode a u8 happiness byte back to the [0, 2] float range. */
 export function decodeHappiness(u8: number): number {

--- a/app/src/game/saveContainer.test.ts
+++ b/app/src/game/saveContainer.test.ts
@@ -20,7 +20,7 @@ import { extractClientState } from './clientState';
 import { applyTool } from './tools';
 import { Tool } from './toolTypes';
 import { deleteSave, getSave, listSaveMetas, putSave, setIdbFactory } from './saveStore';
-import { BYTES_PER_TILE, FLAGS, tileBufferOffsets } from './protocol/tileBuffer';
+import { LEGACY_BYTES_PER_TILE, LEGACY_FLAGS, legacyTileBufferOffsets } from './protocol/legacyTileBuffer';
 import { tileKindToU8 } from './protocol/tileKind';
 
 function makeContainer(name?: string): SaveContainer {
@@ -81,10 +81,10 @@ describe('buildLegacyEngineImport', () => {
     state.tiles[10].roadUnderlay = true;
     const imp = buildLegacyEngineImport(state);
     const n = 64;
-    const o = tileBufferOffsets(n);
-    expect(imp.tiles).toHaveLength(n * BYTES_PER_TILE);
+    const o = legacyTileBufferOffsets(n);
+    expect(imp.tiles).toHaveLength(n * LEGACY_BYTES_PER_TILE);
     expect(imp.tiles[o.kind + 3 * 8 + 3]).toBe(tileKindToU8(state.tiles[3 * 8 + 3].kind));
-    expect(imp.tiles[o.flags + 10]).toBe(FLAGS.POWERED | FLAGS.WATERED | FLAGS.ROAD_UNDERLAY);
+    expect(imp.tiles[o.flags + 10]).toBe(LEGACY_FLAGS.POWERED | LEGACY_FLAGS.WATERED | LEGACY_FLAGS.ROAD_UNDERLAY);
     expect(imp.rngState).toEqual(state.rngState);
     expect(imp.seed).toBe(3);
     expect(imp.policies).toEqual(state.policies);
@@ -93,9 +93,9 @@ describe('buildLegacyEngineImport', () => {
   it('writes building ids little-endian and 0xFF for no underground', () => {
     const state = createInitialState(8, 8, 3);
     state.tiles[5].buildingId = 0x1234;
-    state.tiles[6].underground = state.tiles[6].kind; // any kind round-trips
+    state.tiles[6].legacyUnderground = state.tiles[6].kind; // any kind round-trips
     const imp = buildLegacyEngineImport(state);
-    const o = tileBufferOffsets(64);
+    const o = legacyTileBufferOffsets(64);
     expect(imp.tiles[o.buildingId + 5 * 2]).toBe(0x34);
     expect(imp.tiles[o.buildingId + 5 * 2 + 1]).toBe(0x12);
     expect(imp.tiles[o.undergroundKind + 7]).toBe(0xff);

--- a/app/src/game/simulation.ts
+++ b/app/src/game/simulation.ts
@@ -228,11 +228,11 @@ export class Simulation {
       bill(TileKind.PowerLine, tile.kind === TileKind.PowerLine || !!tile.powerOverlay,
         (u) => { maintenancePowerLines += u; });
 
-      if (tile.underground) {
-        const uUpkeep = MAINTENANCE[tile.underground];
+      if (tile.legacyUnderground) {
+        const uUpkeep = MAINTENANCE[tile.legacyUnderground];
         if (uUpkeep) {
           maintenance += uUpkeep;
-          if (tile.underground === TileKind.WaterPipe) maintenancePipes += uUpkeep;
+          if (tile.legacyUnderground === TileKind.WaterPipe) maintenancePipes += uUpkeep;
         }
       }
 

--- a/app/src/game/tauriSimBridge.ts
+++ b/app/src/game/tauriSimBridge.ts
@@ -19,15 +19,28 @@
  * Limitations (Phase 4; lifted in Phase 5):
  *   • loadState() restarts the sim from scratch (seed-only); full GameState
  *     serialisation arrives in P5-1.
- *   • Tile buffer carries TileKind only — per-tile power/water/happiness
- *     stats are absent until the Rust sim serialises them (P3+).
+ *   • The tick payload carries terrain/occupants/POWERED/WATERED/ABANDONED
+ *     per tile (see `TickEvent.tiles` in `guest-js/index.ts`), but not
+ *     happiness, elevation, wilderness or per-tile `building_id` — those
+ *     still need the Rust sim to serialise them (P3+).
+ *   • Because per-tile `building_id` is absent, a `Structure` occupant's
+ *     specific `TileKind` can never resolve here (`legacyKind`'s structure
+ *     branch needs it) — every structure tile decodes via the same
+ *     kind-precedence fallback a bare zone/road/rail/line tile would.
+ *     `event.buildings` (id/kind/origin, no footprint) isn't enough on its
+ *     own to fix this; it would need `building_id` on the wire too.
  */
 
 import type { GameState, Tile } from './gameState';
+import { TileKind } from './gameState';
 import type { SimBridge } from './simBridge';
 import type { SimCommand, CommandResult } from './protocol/commands';
 import type { FromSim } from './protocol/events';
 import { tileKindFromU8, tileKindToU8 } from './protocol/tileKind';
+import { Terrain, ZoneDensity } from './protocol/occupants';
+import { legacyKind, legacyFlags, legacyUndergroundKind } from './protocol/legacyProjection';
+import { STATUS } from './protocol/tileBuffer';
+import { createTileServiceState } from './services';
 import { Tool } from './toolTypes';
 import {
   start as pluginStart,
@@ -243,19 +256,53 @@ export class TauriSimBridge implements SimBridge {
       });
     }
 
-    // Tile kinds — resize the tiles array if dimensions changed
+    // Tiles — resize the array if dimensions changed
     const n = event.width * event.height;
     if (s.tiles.length !== n) {
       s.width  = event.width;
       s.height = event.height;
-      const fallback = s.tiles[0]?.kind ?? 'land';
-      s.tiles = Array.from({ length: n }, () => ({ kind: fallback } as Tile));
+      s.tiles = Array.from({ length: n }, () => makeBlankTile());
     }
+
+    // `event.buildings` is the only source for a Structure occupant's
+    // specific TileKind — the tile bytes only say a building stands there
+    // (#177's TS/wire follow-up), same as the WASM path.
+    const structureKindById = new Map<number, TileKind>();
+    for (const b of event.buildings) {
+      const kind = tileKindFromU8(b.kind);
+      if (kind !== undefined) structureKindById.set(b.id, kind);
+    }
+    const structureKindOf = (id: number) => structureKindById.get(id);
+
     for (let i = 0; i < n; i++) {
-      const kind = tileKindFromU8(event.tiles[i]);
-      if (kind !== undefined) {
-        s.tiles[i].kind = kind;
-      }
+      const tile = s.tiles[i];
+      const base = i * 4;
+      tile.underground = event.tiles[base];
+      tile.surface = event.tiles[base + 1] << 3;
+      tile.overhead = event.tiles[base + 2] << 9;
+      const status = event.tiles[base + 3];
+      tile.terrain = (status & STATUS.WATER_TERRAIN) !== 0 ? Terrain.Water : Terrain.Land;
+      tile.powered = (status & STATUS.POWERED) !== 0;
+      tile.watered = (status & STATUS.WATERED) !== 0;
+      tile.abandoned = (status & STATUS.ABANDONED) !== 0;
+      tile.density = ((status & STATUS.DENSITY_MASK) >> STATUS.DENSITY_SHIFT) as ZoneDensity;
+
+      // Shim fields — deleted, along with this whole block, once every
+      // consumer reads terrain/underground/surface/overhead directly.
+      const projectionInput = {
+        terrain: tile.terrain,
+        surface: tile.surface,
+        overhead: tile.overhead,
+        buildingId: tile.buildingId,
+        structureKindOf
+      };
+      const kind = legacyKind(projectionInput);
+      tile.kind = kind;
+      const flags = legacyFlags(projectionInput, kind);
+      tile.roadUnderlay = flags.roadUnderlay;
+      tile.railUnderlay = flags.railUnderlay;
+      tile.powerOverlay = flags.powerOverlay;
+      tile.legacyUnderground = legacyUndergroundKind(tile.underground);
     }
 
     // Forward TickStats to the UI handler
@@ -272,4 +319,21 @@ export class TauriSimBridge implements SimBridge {
       },
     });
   }
+}
+
+/** A bare land tile, for growing the mirror array when dimensions change — immediately overwritten by the decode loop. */
+function makeBlankTile(): Tile {
+  return {
+    kind: TileKind.Land,
+    elevation: 0,
+    happiness: 1,
+    powered: false,
+    watered: false,
+    services: createTileServiceState(),
+    terrain: Terrain.Land,
+    underground: 0,
+    surface: 0,
+    overhead: 0,
+    density: ZoneDensity.Low
+  };
 }

--- a/app/src/game/tools.test.ts
+++ b/app/src/game/tools.test.ts
@@ -96,7 +96,7 @@ describe('tools', () => {
     const pump = state.buildings.find((b) => b.templateId === template.id);
     expect(pump).toBeDefined();
     const pumpConnection = getTile(state, 0, 1)!;
-    pumpConnection.underground = TileKind.WaterPipe;
+    pumpConnection.legacyUnderground = TileKind.WaterPipe;
     const spent = initialMoney - state.money;
     expect(spent).toBeCloseTo(
       BUILD_COST[Tool.WindTurbine] + BUILD_COST[Tool.PowerLine] * 3 + template.cost
@@ -116,7 +116,7 @@ describe('tools', () => {
     const result = applyTool(state, Tool.WaterTower, 3, 3);
     expect(result.success).toBe(true);
     expect(state.buildings.filter((building) => building.templateId === template.id).length).toBe(1);
-    getTile(state, 5, 3)!.underground = TileKind.WaterPipe;
+    getTile(state, 5, 3)!.legacyUnderground = TileKind.WaterPipe;
     const ids = new Set<number>();
     const footprint: Array<[number, number]> = [
       [3, 3],

--- a/app/src/game/tools.ts
+++ b/app/src/game/tools.ts
@@ -132,11 +132,11 @@ function regradeAt(state: GameState, x: number, y: number, spelling: TileKind) {
   const before = getTile(state, x, y);
   if (!before) return;
   const hadLine = before.kind === TileKind.PowerLine || before.powerOverlay === true;
-  const underground = before.underground;
+  const underground = before.legacyUnderground;
   setTile(state, x, y, spelling);
   const tile = getTile(state, x, y);
   if (!tile) return;
-  tile.underground = underground;
+  tile.legacyUnderground = underground;
   if (hadLine) tile.powerOverlay = true;
 }
 
@@ -269,7 +269,7 @@ const registry: ToolRegistry = {
     state.money -= cost;
     const tile = getTile(state, x, y);
     if (tile) {
-      tile.underground = TileKind.WaterPipe;
+      tile.legacyUnderground = TileKind.WaterPipe;
     }
     return { success: true };
   },
@@ -289,9 +289,9 @@ const registry: ToolRegistry = {
     if (!tile) return { success: false };
 
     if (state.settings.minimap.mode === 'underground') {
-      if (tile.underground) {
+      if (tile.legacyUnderground) {
         state.money -= cost;
-        tile.underground = undefined;
+        tile.legacyUnderground = undefined;
         return { success: true };
       }
       return { success: true }; // Nothing to bulldoze underground
@@ -300,13 +300,13 @@ const registry: ToolRegistry = {
     state.money -= cost;
     if (tile.buildingId !== undefined) {
       removeBuilding(state, tile.buildingId);
-    } else if (tile.underground !== undefined) {
+    } else if (tile.legacyUnderground !== undefined) {
       // The engine reaches the buried pipe *before* the surface — `bulldoze`
       // in `commands.rs` tests `building_id`, then `underground`, then the
       // surface, and it has no notion of which minimap view is open. So a
       // click on a road with a pipe under it takes the pipe and leaves the
       // road. Mirrored here rather than corrected: `commands.rs` is canonical.
-      tile.underground = undefined;
+      tile.legacyUnderground = undefined;
     } else {
       // The bulldozer clears what stands on the ground — surface and overhead
       // together — and leaves the ground itself exactly as it was (#177 step

--- a/app/src/game/utilities/water.test.ts
+++ b/app/src/game/utilities/water.test.ts
@@ -23,7 +23,7 @@ describe('water network', () => {
 
     // Place Pipe at 3,1 (adjacent to tower at 2,1)
     const pipeTile = getTile(state, 3, 1)!;
-    pipeTile.underground = TileKind.WaterPipe;
+    pipeTile.legacyUnderground = TileKind.WaterPipe;
 
     // Ensure building status is active (towers need power)
     updateBuildingStates(state);
@@ -48,8 +48,8 @@ describe('water network', () => {
       tile.powered = true;
     });
 
-    getTile(state, 3, 1)!.underground = TileKind.WaterPipe;
-    getTile(state, 4, 1)!.underground = TileKind.WaterPipe;
+    getTile(state, 3, 1)!.legacyUnderground = TileKind.WaterPipe;
+    getTile(state, 4, 1)!.legacyUnderground = TileKind.WaterPipe;
 
     updateBuildingStates(state);
     recomputeWaterNetwork(state);

--- a/app/src/game/wasmSimBridge.ts
+++ b/app/src/game/wasmSimBridge.ts
@@ -22,8 +22,17 @@ import type { BudgetPolicy, SimCommand, CommandResult } from './protocol/command
 import { recordDailyBudget } from './economy';
 import type { FromSim } from './protocol/events';
 import type { SimStats } from '../workers/wasmSim.worker';
-import { tileBufferOffsets, decodeHappiness, FLAGS } from './protocol/tileBuffer';
+import {
+  tileBufferOffsets,
+  decodeHappiness,
+  decodeUndergroundBits,
+  decodeSurfaceBits,
+  decodeOverheadBits,
+  STATUS
+} from './protocol/tileBuffer';
 import { tileKindFromU8, tileKindToU8 } from './protocol/tileKind';
+import { Occupant, Terrain, ZoneDensity, hasOccupant } from './protocol/occupants';
+import { legacyKind, legacyFlags, legacyUndergroundKind } from './protocol/legacyProjection';
 import { Tool } from './toolTypes';
 
 // Mapping from TS string-valued Tool enum → Rust #[repr(u8)] discriminant.
@@ -69,20 +78,28 @@ type WorkerToMain =
   /** Posted only when the WASM's `Last-Modified` changes under a live page. */
   | { type: 'build_update'; build: { lastModified: string | null } }
   | { type: 'init_error';   message: string }
-  | { type: 'step_result';  bytes: Uint8Array; stats: SimStats; mutationSeq: number }
+  | { type: 'step_result';  bytes: Uint8Array; stats: SimStats; buildingsJson: string; mutationSeq: number }
   | { type: 'apply_result'; success: boolean; history: WorkerHistoryFlags }
   | { type: 'undo_result';  happened: false; history: WorkerHistoryFlags }
-  | { type: 'undo_result';  happened: true; bytes: Uint8Array; stats: SimStats; mutationSeq: number; history: WorkerHistoryFlags }
+  | { type: 'undo_result';  happened: true; bytes: Uint8Array; stats: SimStats; buildingsJson: string; mutationSeq: number; history: WorkerHistoryFlags }
   | { type: 'redo_result';  happened: false; history: WorkerHistoryFlags }
-  | { type: 'redo_result';  happened: true; bytes: Uint8Array; stats: SimStats; mutationSeq: number; history: WorkerHistoryFlags }
+  | { type: 'redo_result';  happened: true; bytes: Uint8Array; stats: SimStats; buildingsJson: string; mutationSeq: number; history: WorkerHistoryFlags }
   | { type: 'snapshot_result'; requestId: number; bytes: Uint8Array }
   | { type: 'load_result'; requestId: number; ok: false; error?: string }
   | {
       type: 'load_result'; requestId: number; ok: true;
       width: number; height: number; seed: number;
       policies: GameState['policies'];
-      bytes: Uint8Array; stats: SimStats; mutationSeq: number; history: WorkerHistoryFlags;
+      bytes: Uint8Array; stats: SimStats; buildingsJson: string; mutationSeq: number; history: WorkerHistoryFlags;
     };
+
+/** One entry decoded from a `buildingsJson` payload — see `SimHost::buildings_json` (Rust). */
+interface WireBuilding {
+  id: number;
+  kind: number;
+  originX: number;
+  originY: number;
+}
 
 export interface WasmSimBridgeConfig {
   ticksPerSecond?: number;
@@ -100,6 +117,7 @@ export class WasmSimBridge implements SimBridge {
   private handler: ((msg: FromSim) => void) | null = null;
   private speedMult = 1;
   private pendingTileBuffer: Uint8Array | null = null;
+  private pendingBuildingsJson = '';
   private pendingStats: SimStats | null = null;
   private pendingMutationSeq = 0;
   private pendingUndo: ((happened: boolean) => void) | null = null;
@@ -196,7 +214,7 @@ export class WasmSimBridge implements SimBridge {
       return this.consumeDirty();
     }
     if (this.pendingTileBuffer !== null) {
-      this.applyTileBuffer(this.pendingTileBuffer);
+      this.applyTileBuffer(this.pendingTileBuffer, this.pendingBuildingsJson);
       this.pendingTileBuffer = null;
       this.dirtySinceLastStep = true;
     }
@@ -373,6 +391,7 @@ export class WasmSimBridge implements SimBridge {
         break;
       case 'step_result':
         this.pendingTileBuffer = msg.bytes;
+        this.pendingBuildingsJson = msg.buildingsJson;
         this.pendingStats = msg.stats;
         this.pendingMutationSeq = msg.mutationSeq;
         break;
@@ -388,7 +407,7 @@ export class WasmSimBridge implements SimBridge {
         this.pendingTileBuffer = null;
         this.pendingStats = null;
         if (msg.happened) {
-          this.applyTileBuffer(msg.bytes);
+          this.applyTileBuffer(msg.bytes, msg.buildingsJson);
           this.updateStats(msg.stats);
           this.lastAppliedTick = msg.stats.tick;
           this.lastAppliedMutationSeq = msg.mutationSeq;
@@ -402,7 +421,7 @@ export class WasmSimBridge implements SimBridge {
         this.pendingTileBuffer = null;
         this.pendingStats = null;
         if (msg.happened) {
-          this.applyTileBuffer(msg.bytes);
+          this.applyTileBuffer(msg.bytes, msg.buildingsJson);
           this.updateStats(msg.stats);
           this.lastAppliedTick = msg.stats.tick;
           this.lastAppliedMutationSeq = msg.mutationSeq;
@@ -431,7 +450,7 @@ export class WasmSimBridge implements SimBridge {
         this.pendingStats = null;
         this.adoptDimensions(msg.width, msg.height, msg.seed);
         this.state.policies = msg.policies;
-        this.applyTileBuffer(msg.bytes);
+        this.applyTileBuffer(msg.bytes, msg.buildingsJson);
         this.updateStats(msg.stats);
         this.lastAppliedTick = msg.stats.tick;
         this.lastAppliedMutationSeq = msg.mutationSeq;
@@ -456,6 +475,11 @@ export class WasmSimBridge implements SimBridge {
       powered: false,
       watered: false,
       services: createTileServiceState(),
+      terrain: Terrain.Land,
+      underground: 0,
+      surface: 0,
+      overhead: 0,
+      density: ZoneDensity.Low,
     }));
   }
 
@@ -551,41 +575,65 @@ export class WasmSimBridge implements SimBridge {
     });
   }
 
-  private applyTileBuffer(bytes: Uint8Array): void {
+  private applyTileBuffer(bytes: Uint8Array, buildingsJson: string): void {
     const n = this.state.tiles.length;
     const o = tileBufferOffsets(n);
+
+    // The live wire no longer carries a resolved kind byte per tile (#177's
+    // TS/wire follow-up) — a `Structure` occupant says only that a building
+    // stands here, not which one. `buildings_json` is the only source for
+    // that now; parse it once and look up by id below.
+    const wireBuildings: WireBuilding[] = buildingsJson ? JSON.parse(buildingsJson) : [];
+    const structureKindById = new Map<number, TileKind>();
+    for (const b of wireBuildings) {
+      const kind = tileKindFromU8(b.kind);
+      if (kind !== undefined) structureKindById.set(b.id, kind);
+    }
+    const structureKindOf = (id: number) => structureKindById.get(id);
+
     for (let i = 0; i < n; i++) {
       const tile = this.state.tiles[i];
-      const rustKind = tileKindFromU8(bytes[o.kind + i]);
-      if (rustKind !== undefined) {
-        // The engine is seeded with natural terrain at init and every load
-        // path restores full state, so the buffer is the single source of
-        // truth for tile kinds — no display-side override.
-        tile.kind = rustKind;
-      }
-      const flags = bytes[o.flags + i];
-      tile.powered      = (flags & FLAGS.POWERED)       !== 0;
-      tile.watered      = (flags & FLAGS.WATERED)        !== 0;
-      tile.abandoned    = (flags & FLAGS.ABANDONED)      !== 0;
-      tile.roadUnderlay = (flags & FLAGS.ROAD_UNDERLAY)  !== 0;
-      tile.railUnderlay = (flags & FLAGS.RAIL_UNDERLAY)  !== 0;
-      tile.powerOverlay = (flags & FLAGS.POWER_OVERLAY)  !== 0;
+      tile.underground = decodeUndergroundBits(bytes[o.underground + i]);
+      tile.surface = decodeSurfaceBits(bytes[o.surface + i]);
+      tile.overhead = decodeOverheadBits(bytes[o.overhead + i]);
+      const status = bytes[o.status + i];
+      tile.terrain = (status & STATUS.WATER_TERRAIN) !== 0 ? Terrain.Water : Terrain.Land;
+      tile.powered = (status & STATUS.POWERED) !== 0;
+      tile.watered = (status & STATUS.WATERED) !== 0;
+      tile.abandoned = (status & STATUS.ABANDONED) !== 0;
+      tile.density = ((status & STATUS.DENSITY_MASK) >> STATUS.DENSITY_SHIFT) as ZoneDensity;
       tile.happiness = decodeHappiness(bytes[o.happiness + i]);
       tile.elevation = bytes[o.elevation + i];
       const bidBase = o.buildingId + i * 2;
       const bid = bytes[bidBase] | (bytes[bidBase + 1] << 8);
       tile.buildingId = bid === 0 ? undefined : bid;
-      const ugByte = bytes[o.undergroundKind + i];
-      tile.underground = ugByte === 0xFF ? undefined : tileKindFromU8(ugByte);
       // Normalised 0–1 (0.5 = neutral) for the overlay heatmap.
       tile.wilderness = bytes[o.wilderness + i] / 255;
+
+      // Shim fields — deleted, along with this whole block, once every
+      // consumer reads terrain/underground/surface/overhead directly.
+      const kind = legacyKind({
+        terrain: tile.terrain,
+        surface: tile.surface,
+        overhead: tile.overhead,
+        buildingId: tile.buildingId,
+        structureKindOf
+      });
+      tile.kind = kind;
+      const flags = legacyFlags(
+        { terrain: tile.terrain, surface: tile.surface, overhead: tile.overhead, buildingId: tile.buildingId, structureKindOf },
+        kind
+      );
+      tile.roadUnderlay = flags.roadUnderlay;
+      tile.railUnderlay = flags.railUnderlay;
+      tile.powerOverlay = flags.powerOverlay;
+      tile.legacyUnderground = legacyUndergroundKind(tile.underground);
     }
 
-    // Rebuild state.buildings so multi-tile sprite rendering has correct origins.
-    // Rust is authoritative; TS state.buildings is a display mirror only.
-    // Scanning in row-major order means the first occurrence of each buildingId
-    // is always the top-left (origin) tile of its footprint.
-    const seen = new Map<number, { kind: TileKind; x: number; y: number }>();
+    // Rebuild state.buildings directly from the parsed list — Rust is
+    // authoritative; TS state.buildings is a display mirror only. No more
+    // scanning tiles for first-occurrence origins: `buildings_json` already
+    // carries id, kind and origin.
     // Mirror of the engine's water opt-in gate (`GameState::has_water_system`):
     // until a pump, tower, or pipe exists, buildings don't require water.
     let hasWaterSystem = false;
@@ -594,22 +642,17 @@ export class WasmSimBridge implements SimBridge {
       if (
         tile.kind === TileKind.WaterPump ||
         tile.kind === TileKind.WaterTower ||
-        tile.underground === TileKind.WaterPipe
+        hasOccupant(tile.underground, Occupant.Pipe)
       ) {
         hasWaterSystem = true;
       }
-      if (tile.buildingId === undefined || seen.has(tile.buildingId)) continue;
-      seen.set(tile.buildingId, {
-        kind: tile.kind,
-        x: i % this.state.width,
-        y: Math.floor(i / this.state.width),
-      });
     }
-    this.state.buildings = Array.from(seen.entries()).map(([id, { kind, x, y }]) => {
+    this.state.buildings = wireBuildings.map((b) => {
+      const kind = tileKindFromU8(b.kind) ?? TileKind.Land;
       // Derive status from the tile flags the Rust buffer already set.
       // Avoids calling updateBuildingStates, which misreads water status for
       // zones in cities without water infrastructure.
-      const originTile = this.state.tiles[y * this.state.width + x];
+      const originTile = this.state.tiles[b.originY * this.state.width + b.originX];
       const template = getBuildingTemplate(kind as string);
       const bstate = createBuildingState();
       const needsPower = template ? template.requiresPower !== false : false;
@@ -620,7 +663,12 @@ export class WasmSimBridge implements SimBridge {
       } else if (needsWater && !originTile?.watered) {
         bstate.status = BuildingStatus.InactiveNoWater;
       }
-      return { id, templateId: kind as string, origin: { x, y }, state: bstate };
+      return {
+        id: b.id,
+        templateId: kind as string,
+        origin: { x: b.originX, y: b.originY },
+        state: bstate
+      };
     });
 
     // Recompute education coverage so the debug overlay and HUD stay current.

--- a/app/src/rendering/renderer.ts
+++ b/app/src/rendering/renderer.ts
@@ -232,7 +232,7 @@ export class MapRenderer {
 
           const hasNeighbour = (dx: number, dy: number) => {
             const t = getTile(state, x + dx, y + dy);
-            return t?.underground === TileKind.WaterPipe
+            return t?.legacyUnderground === TileKind.WaterPipe
               || t?.kind === TileKind.WaterPump
               || t?.kind === TileKind.WaterTower;
           };
@@ -386,7 +386,7 @@ export class MapRenderer {
 
       if (overlayMode === 'water' || overlayMode === 'underground') {
         if (tile.kind === TileKind.Water) return { color: 0x2f7be5, alpha: 0.32 };
-        if (tile.underground === TileKind.WaterPipe) {
+        if (tile.legacyUnderground === TileKind.WaterPipe) {
           return { color: tile.watered ? WATER_OVERLAY_COLOUR : 0x888888, alpha: 0.6 };
         }
         if (tile.kind === TileKind.WaterPipe) return { color: WATER_OVERLAY_COLOUR, alpha: 0.38 }; // Legacy check

--- a/app/src/ui/minimap.ts
+++ b/app/src/ui/minimap.ts
@@ -359,7 +359,7 @@ export function initMinimap(options: MinimapOptions): MinimapController {
     }
 
     if (settings.mode === 'underground') {
-      if (tile.underground === TileKind.WaterPipe) return '#4cc3ff';
+      if (tile.legacyUnderground === TileKind.WaterPipe) return '#4cc3ff';
       if (tile.kind === TileKind.Water) return '#1f68d6';
       if (tile.watered) return 'rgba(76, 195, 255, 0.55)';
       // Fade others

--- a/app/src/workers/wasmSim.worker.ts
+++ b/app/src/workers/wasmSim.worker.ts
@@ -188,7 +188,11 @@ function startStepLoop(): void {
     host.step(dt);
     const bytes = host.tile_buffer();
     const stats = gatherStats(host);
-    self.postMessage({ type: 'step_result', bytes, stats, mutationSeq }, { transfer: [bytes.buffer as ArrayBuffer] });
+    const buildingsJson = host.buildings_json();
+    self.postMessage(
+      { type: 'step_result', bytes, stats, buildingsJson, mutationSeq },
+      { transfer: [bytes.buffer as ArrayBuffer] },
+    );
   }, STEP_INTERVAL_MS);
 }
 
@@ -371,8 +375,9 @@ self.onmessage = async (e: MessageEvent<MainToWorker>) => {
       if (happened) {
         const bytes = host.tile_buffer();
         const stats = gatherStats(host);
+        const buildingsJson = host.buildings_json();
         self.postMessage(
-          { type: 'undo_result', happened: true, bytes, stats, mutationSeq, history: historyFlags(host) },
+          { type: 'undo_result', happened: true, bytes, stats, buildingsJson, mutationSeq, history: historyFlags(host) },
           { transfer: [bytes.buffer as ArrayBuffer] },
         );
       } else {
@@ -386,8 +391,9 @@ self.onmessage = async (e: MessageEvent<MainToWorker>) => {
       if (happened) {
         const bytes = host.tile_buffer();
         const stats = gatherStats(host);
+        const buildingsJson = host.buildings_json();
         self.postMessage(
-          { type: 'redo_result', happened: true, bytes, stats, mutationSeq, history: historyFlags(host) },
+          { type: 'redo_result', happened: true, bytes, stats, buildingsJson, mutationSeq, history: historyFlags(host) },
           { transfer: [bytes.buffer as ArrayBuffer] },
         );
       } else {
@@ -456,6 +462,7 @@ function postLoadResult(h: SimHost, requestId: number): void {
       policies: JSON.parse(h.policies_json()) as WorkerPolicies,
       bytes,
       stats: gatherStats(h),
+      buildingsJson: h.buildings_json(),
       mutationSeq,
       history: historyFlags(h),
     },

--- a/crates/city-sim-wasm/src/lib.rs
+++ b/crates/city-sim-wasm/src/lib.rs
@@ -443,4 +443,44 @@ impl SimHost {
         }
         buf
     }
+
+    /// The building list as JSON (`Vec<WireBuilding>`) — `id`, template
+    /// `kind` (as the `TileKind` u8, matching every other wire use of
+    /// `TileKind`), and footprint origin.
+    ///
+    /// The live tile buffer's `Structure` occupant bit says only that a
+    /// building stands on a tile, not which one — since #177's TS/wire
+    /// follow-up, a structure's `TileKind` lives on its `BuildingInstance`,
+    /// not on the tile. TS needs this list to resolve `building_id` to a
+    /// template; call it alongside `tile_buffer()`. Status/health/trouble are
+    /// deliberately not carried here — TS derives building status locally
+    /// from the tile's `POWERED`/`WATERED` flags, as it already did before
+    /// this method existed.
+    pub fn buildings_json(&self) -> String {
+        let wire: Vec<WireBuilding> = self
+            .sim
+            .state
+            .buildings
+            .iter()
+            .map(|b| WireBuilding {
+                id: b.id,
+                kind: b.kind as u8,
+                origin_x: b.origin.0,
+                origin_y: b.origin.1,
+            })
+            .collect();
+        serde_json::to_string(&wire).unwrap_or_default()
+    }
+}
+
+/// One row of [`SimHost::buildings_json`]'s wire shape.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WireBuilding {
+    id: u32,
+    /// `TileKind as u8` — decode with `tileKindFromU8` in TS, matching every
+    /// other wire use of `TileKind`.
+    kind: u8,
+    origin_x: u32,
+    origin_y: u32,
 }

--- a/crates/tauri-plugin-city-sim/guest-js/index.ts
+++ b/crates/tauri-plugin-city-sim/guest-js/index.ts
@@ -38,11 +38,31 @@ export interface TickEvent {
   wildernessTrend:    number   // f32 — fast EMA − slow EMA; sign gives the arrow
   width:              number   // u32 — grid width in tiles
   height:             number   // u32 — grid height in tiles
-  /** One byte per tile, row-major. Values are `TileKind` u8 discriminants. */
+  /**
+   * Occupant/status bytes, four per tile, row-major, array-of-structs (not
+   * the SoA layout the WASM tile buffer uses — this is a separate, simpler
+   * encoding for the per-tick push). Per tile: `[underground, surface,
+   * overhead, status]` — see `city_sim_core::wire` for what each byte means.
+   */
   tiles:              number[]
+  /**
+   * The building list. A `Structure` occupant tile carries a `buildingId`
+   * but not a template kind — that lives here, on the matching entry's
+   * `kind` (a `TileKind` u8 discriminant, decode with `tileKindFromU8`).
+   */
+  buildings:          WireBuilding[]
   /** Whether an undo/redo step is currently available — drives button state. */
   canUndo:            boolean
   canRedo:            boolean
+}
+
+/** One entry in {@link TickEvent.buildings}. */
+export interface WireBuilding {
+  id:       number   // u32
+  /** `TileKind` u8 discriminant — decode with `tileKindFromU8`. */
+  kind:     number   // u8
+  originX:  number   // u32
+  originY:  number   // u32
 }
 
 /**

--- a/crates/tauri-plugin-city-sim/src/commands.rs
+++ b/crates/tauri-plugin-city-sim/src/commands.rs
@@ -55,9 +55,27 @@ pub struct TickEvent {
     /// what the same-named field means in `city_sim_protocol::tile_buffer`
     /// (see `city_sim_core::wire`).
     pub tiles: Vec<u8>,
+    /// The building list — `Structure` occupant tiles carry a `building_id`
+    /// but not a template kind (since #177's TS/wire follow-up, that lives
+    /// here, not on the tile). Mirrors `SimHost::buildings_json` on the WASM
+    /// path, sent as real values rather than a JSON string since Tauri IPC
+    /// serialises the whole `TickEvent` natively.
+    pub buildings: Vec<WireBuilding>,
     /// Whether an undo/redo step is currently available — drives button state.
     pub can_undo: bool,
     pub can_redo: bool,
+}
+
+/// One entry in [`TickEvent::buildings`].
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WireBuilding {
+    pub id: u32,
+    /// `TileKind as u8` — decode with `tileKindFromU8` in TS, matching every
+    /// other wire use of `TileKind`.
+    pub kind: u8,
+    pub origin_x: u32,
+    pub origin_y: u32,
 }
 
 // ── Internal command sent from invoke handlers to the sim thread ──────────────
@@ -128,6 +146,16 @@ fn build_tick_event(sim: &Simulation, history: &History) -> TickEvent {
         tiles.push(wire_overhead_byte(t));
         tiles.push(wire_status_byte(t));
     }
+    let buildings: Vec<WireBuilding> = s
+        .buildings
+        .iter()
+        .map(|b| WireBuilding {
+            id: b.id,
+            kind: b.kind as u8,
+            origin_x: b.origin.0,
+            origin_y: b.origin.1,
+        })
+        .collect();
     TickEvent {
         tick: s.tick,
         day: s.day,
@@ -146,6 +174,7 @@ fn build_tick_event(sim: &Simulation, history: &History) -> TickEvent {
         width: s.width,
         height: s.height,
         tiles,
+        buildings,
         can_undo: history.can_undo(),
         can_redo: history.can_redo(),
     }


### PR DESCRIPTION
## Summary
- **TS's `Tile` gains `terrain`/`underground`/`surface`/`overhead`/`density`**, decoded directly off the new wire bytes with no derivation — the TS analogue of `docs/tile-model.md`'s own step 1 ("add a derived accessor, no behaviour change"), except here the *new* fields are real data and the *old* ones (`kind`/`roadUnderlay`/`railUnderlay`/`powerOverlay`, renamed `underground` → `legacyUnderground` to free the name) are the shim being kept alive so the ~24 files reading them don't all have to move in this one PR.
- New `app/src/game/protocol/`:
  - **`occupants.ts`** — TS mirror of `occupants.rs`'s `Occupant`/`Stratum` bit model, `Terrain`/`ZoneDensity`, and the bitset helpers.
  - **`legacyProjection.ts`** — TS port of `display.rs`'s deleted `wire_kind`/`wire_flags`/`wire_underground` precedence ladder (strata → v4), plus `tileFromV4` for the opposite direction (decoding old saves). Both directions live here since this file — not any production code path — is the only thing left that ever needs to compute v4 spelling at all.
  - **`legacyTileBuffer.ts`** — TS mirror of the frozen `legacy_tile_buffer.rs`, used only by `persistence.ts`'s `buildLegacyEngineImport`.
- **A gap the plan hadn't sized:** with the `kind` byte gone from the wire, a `Structure` occupant only says a building stands on a tile, not which one — that lives solely on the `BuildingInstance` now. Neither host exposed the building list before, so this adds `SimHost::buildings_json` (WASM, a JSON `Vec<WireBuilding>`) and `TickEvent.buildings` (Tauri, native serde) alongside the tile bytes; both `wasmSimBridge.ts` and `tauriSimBridge.ts` now rebuild `state.buildings` straight from that list instead of scanning tiles for first-occurrence origins.
- **`tauriSimBridge.ts`'s `onTick`** was silently decoding the new 4-bytes/tile `TickEvent.tiles` as if it were still one `TileKind` byte per tile — fixed alongside the rest, though per-tile `building_id` still isn't on that wire at all (a pre-existing, now-documented gap), so a structure's specific kind can never resolve on the Tauri path; every other occupant decodes correctly.
- **`persistence.ts`'s `deserialize`** branches on whether a parsed tile already has `terrain`: absent means a genuine pre-migration save, decoded via `tileFromV4`; present means it was serialised after this migration and already carries real strata, decoded straight through.
- **`parity/engines.ts`'s `rustEngine().facts()`** now decodes the new wire layout directly (own buildings-list lookup, same as the bridges) and feeds `tileFacts.ts`'s `factsFromWire` the same v4-shaped quadruple it always took — that function's own redesign is Phase 7, unaffected here.

### A bug this PR found, not just fixed
Tried the naive `deserialize` version first — always decode via the old `underground` key — and it silently corrupted `copyState` on a freshly-created city, because a fresh tile's JSON round-trip already has the new numeric `underground` field. Caught by `copyState reproduces a fresh state exactly` going red, not by inspection; the `terrain`-presence branch above is the fix.

### Maintainer-facing changes
- `SimHost.buildings_json()` (WASM) and `TickEvent.buildings` (Tauri) are new wire surface — anything reading the raw tile/tick payload outside this repo would need updating (none exists).
- `crates/tauri-plugin-city-sim`'s `dist-js/` needs a rebuild (`bun run build` in that crate) to pick up the `TickEvent.buildings`/`WireBuilding` type change — done locally for this PR, gitignored as usual.

## Test plan
- [x] `cargo test --workspace` passes (new `WireBuilding` wire shape, `buildings_json`)
- [x] `bun run build:wasm`, `bun run lint` (`tsc --noEmit`) clean
- [x] `bun run test` — 351/351 passing
- [x] `bun run test:parity` (cross-engine parity harness) — 42/42 passing, the strongest signal here since it directly compares the new Rust-side decode against the TS oracle across every scripted scenario
- [x] Manually verified in a live browser: an existing pre-migration save (from IndexedDB) loaded and rendered correctly — buildings, power lines, roads, water, trees all intact — zero console errors; a tool placement round-tripped through `apply_tool` → wire decode → render cleanly
- [ ] Did not manually exercise the Tauri desktop path (no desktop shell in this environment) — covered by type-checking and the documented known gap above, not by a live run
