### PR TITLE
Convert shared TS predicates to read occupants directly

### DIFF
--- a/app/src/game/adjacency.test.ts
+++ b/app/src/game/adjacency.test.ts
@@ -8,6 +8,7 @@ import { createInitialState, getTile, setTile, TileKind } from './gameState';
 import { Tool } from './toolTypes';
 import { applyTool } from './tools';
 import { recomputePowerNetwork } from './utilities/power';
+import { resyncTileStrata as resyncStrata } from './protocol/legacyProjection';
 import {
   hasRoadAccess,
   isPowerCarrier,
@@ -80,6 +81,7 @@ describe('adjacency — road access is roads only', () => {
     neighbour.kind = TileKind.Tree;
     neighbour.roadUnderlay = true;
     neighbour.powerOverlay = true;
+    resyncStrata(neighbour);
 
     expect(hasRoadAccess(state, 0, 0)).toBe(true);
   });
@@ -146,6 +148,7 @@ describe('adjacency — a hydro line conducts in either spelling', () => {
     neighbour.kind = TileKind.Tree;
     neighbour.powerOverlay = true;
     neighbour.powered = true;
+    resyncStrata(neighbour);
 
     expect(tileHasPower(state, 0, 0)).toBe(true);
   });
@@ -198,6 +201,7 @@ describe('adjacency — water carriers exclude hydro lines', () => {
 
     const piped = getTile(state, 0, 0)!;
     piped.legacyUnderground = TileKind.WaterPipe;
+    resyncStrata(piped);
     expect(isWaterCarrier(piped)).toBe(true);
 
     applyTool(state, Tool.Road, 1, 0);

--- a/app/src/game/adjacency.ts
+++ b/app/src/game/adjacency.ts
@@ -3,7 +3,8 @@
 // (c) Copyright 2026 Liminal HQ, Scott Morris
 // SPDX-License-Identifier: MIT
 
-import { GameState, Tile, TileKind, getTile } from './gameState';
+import { GameState, Tile, getTile } from './gameState';
+import { Network, conducts, tileOccupants, zoneOccupant } from './protocol/occupants';
 
 const ORTHOGONAL_DIRS: Array<[number, number]> = [
   [0, -1],
@@ -28,8 +29,9 @@ export function getOrthogonalNeighbourCoords(
 }
 
 /**
- * Returns true if any orthogonal neighbour of (x, y) carries traffic — that is,
- * has a road, whether recorded as `kind` or as `roadUnderlay`.
+ * Returns true if any orthogonal neighbour of (x, y) carries traffic — that
+ * is, has a `Road` occupant, whether recorded as the tile's own kind or as an
+ * underlay in the old vocabulary; here, directly as the occupant bit.
  *
  * Mirrors `has_road_access()` in `crates/city-sim-core/src/adjacency.rs`, which
  * asks `Tile::conducts(Network::Traffic)`.
@@ -40,23 +42,25 @@ export function getOrthogonalNeighbourCoords(
  * `roadUnderlay`, and its author was reaching for the road hidden underneath.
  * It reached too far — a *bare* hydro line across open country granted road
  * access to every zone beside it, so lots grew, filled and paid tax with no
- * street. The road-under-a-line case answers through `roadUnderlay` with no
- * special case at all. A hydro line is not a road.
+ * street. The road-under-a-line case answers through the `Road` occupant with
+ * no special case at all. A hydro line is not a road.
  */
 export function hasRoadAccess(state: GameState, x: number, y: number): boolean {
   return getOrthogonalNeighbourCoords(state, x, y).some(([nx, ny]) => {
     const neighbour = getTile(state, nx, ny);
-    return neighbour?.kind === TileKind.Road || neighbour?.roadUnderlay === true;
+    if (!neighbour) return false;
+    return conducts(
+      Network.Traffic,
+      tileOccupants(neighbour.underground, neighbour.surface, neighbour.overhead),
+      neighbour.buildingId,
+      false
+    );
   });
 }
 
 export function isZone(tile: Tile | undefined): boolean {
   if (!tile) return false;
-  return (
-    tile.kind === TileKind.Residential ||
-    tile.kind === TileKind.Commercial ||
-    tile.kind === TileKind.Industrial
-  );
+  return zoneOccupant(tile.surface) !== undefined;
 }
 
 export function isFrontierZone(state: GameState, x: number, y: number): boolean {
@@ -83,15 +87,12 @@ export function isFrontierZone(state: GameState, x: number, y: number): boolean 
  */
 export function isPowerCarrier(tile: Tile | undefined): boolean {
   if (!tile) return false;
-  if (tile.powerPlantType) return true;
-  if (tile.buildingId !== undefined) return true;
-  if (tile.kind === TileKind.PowerLine || tile.powerOverlay) return true;
-  if (tile.kind === TileKind.Road || tile.roadUnderlay) return true;
-  if (tile.kind === TileKind.Rail || tile.railUnderlay) return true;
-  if (isZone(tile)) {
-    return true;
-  }
-  return false;
+  return conducts(
+    Network.Power,
+    tileOccupants(tile.underground, tile.surface, tile.overhead),
+    tile.buildingId,
+    !!tile.powerPlantType
+  );
 }
 
 /**
@@ -107,12 +108,12 @@ export function isPowerCarrier(tile: Tile | undefined): boolean {
  */
 export function isWaterCarrier(tile: Tile | undefined): boolean {
   if (!tile) return false;
-  if (tile.legacyUnderground === TileKind.WaterPipe) return true;
-  if (tile.buildingId !== undefined) return true; // Buildings carry water
-  if (tile.kind === TileKind.Road || tile.roadUnderlay) return true;
-  if (tile.kind === TileKind.Rail || tile.railUnderlay) return true;
-  if (isZone(tile)) return true;
-  return false;
+  return conducts(
+    Network.Water,
+    tileOccupants(tile.underground, tile.surface, tile.overhead),
+    tile.buildingId,
+    false
+  );
 }
 
 /**

--- a/app/src/game/buildings/manager.ts
+++ b/app/src/game/buildings/manager.ts
@@ -1,6 +1,7 @@
 import { PowerPlantType } from '../constants';
 import { GameState, Tile, getTile, TileKind } from '../gameState';
 import { tileHasPower, tileHasWater } from '../adjacency';
+import { resyncTileStrata } from '../protocol/legacyProjection';
 import { BuildingTemplate, getBuildingTemplate, getPowerPlantTemplate } from './templates';
 import { BuildingInstance, createBuildingState, BuildingStatus } from './state';
 
@@ -64,6 +65,7 @@ export function placeBuilding(
     tile.powerPlantId = undefined;
     tile.happiness = Math.min(1.5, tile.happiness + 0.05);
     decorateTile?.(tile, buildingId);
+    resyncTileStrata(tile);
   }
 
   state.nextBuildingId = buildingId + 1;
@@ -79,6 +81,7 @@ export function removeBuilding(state: GameState, buildingId: number) {
       tile.powerPlantType = undefined;
       tile.powerPlantId = undefined;
       tile.happiness = Math.min(1.5, tile.happiness + 0.05);
+      resyncTileStrata(tile);
     }
   }
 }

--- a/app/src/game/debugStats.ts
+++ b/app/src/game/debugStats.ts
@@ -5,6 +5,7 @@ import { computeDemand } from './demand';
 import { computeLabourStats, LabourStats } from './computeLabourStats';
 import { ServiceId } from './services';
 import { hasWaterSourceConnection } from './utilities/water';
+import { Occupant, hasOccupant } from './protocol/occupants';
 
 export interface DemandDetails {
   base: number;
@@ -92,19 +93,23 @@ export function getSimulationDebugStats(state: GameState): SimulationDebugStats 
     const tile = state.tiles[index];
     const tileX = index % state.width;
     const tileY = Math.floor(index / state.width);
-    if (tile.kind === TileKind.Residential) {
+    if (hasOccupant(tile.surface, Occupant.ZoneResidential)) {
       residentialZones++;
       if (tile.buildingId !== undefined) developedResidentialZones++;
     }
-    if (tile.kind === TileKind.Commercial) {
+    if (hasOccupant(tile.surface, Occupant.ZoneCommercial)) {
       commercialZones++;
       if (tile.buildingId !== undefined) developedCommercialZones++;
     }
-    if (tile.kind === TileKind.Industrial) {
+    if (hasOccupant(tile.surface, Occupant.ZoneIndustrial)) {
       industrialZones++;
       if (tile.buildingId !== undefined) developedIndustrialZones++;
     }
 
+    // A pump whose `Structure` occupant never got a development behind it —
+    // unrepresentable in the strata model by design (see `docs/tile-model.md`),
+    // so this reads the shim `kind` deliberately: it is the only field a
+    // pre-migration save artifact like this can still be spelled in.
     const isLegacyPump = tile.buildingId === undefined && tile.kind === TileKind.WaterPump;
     if (isLegacyPump && pumpTemplate) {
       const active = pumpTemplate.requiresPower === false ? true : tile.powered;

--- a/app/src/game/protocol/legacyProjection.ts
+++ b/app/src/game/protocol/legacyProjection.ts
@@ -17,6 +17,7 @@
  * zone > trees > line > rail > road > land.
  */
 
+import type { Tile } from '../gameState';
 import { TileKind } from '../gameState';
 import { Occupant, Terrain, ZoneDensity, hasOccupant, withOccupant, zoneOccupant } from './occupants';
 
@@ -140,4 +141,26 @@ export function tileFromV4(
     overhead,
     density: ZoneDensity.Low
   };
+}
+
+/**
+ * Bring one tile's strata fields back in sync with its shim fields, in
+ * place. `tools.ts`'s `applyTool` calls this (whole-grid, once per call —
+ * see its own `syncStrataFromLegacy`) after every tool, since its handlers
+ * are still unconverted v4-shape logic; tests that hand-spell a tile's shim
+ * fields directly (bypassing `applyTool`) need the same call so predicates
+ * reading the strata directly don't see stale zeros.
+ */
+export function resyncTileStrata(tile: Tile): void {
+  const strata = tileFromV4(
+    tile.kind,
+    { roadUnderlay: tile.roadUnderlay, railUnderlay: tile.railUnderlay, powerOverlay: tile.powerOverlay },
+    tile.legacyUnderground,
+    tile.buildingId
+  );
+  tile.terrain = strata.terrain;
+  tile.underground = strata.underground;
+  tile.surface = strata.surface;
+  tile.overhead = strata.overhead;
+  tile.density = strata.density;
 }

--- a/app/src/game/protocol/occupants.ts
+++ b/app/src/game/protocol/occupants.ts
@@ -120,3 +120,60 @@ export enum ZoneDensity {
   Medium = 1,
   High = 2
 }
+
+/** A network an occupant may conduct. Mirrors `Network` in `occupants.rs`. */
+export enum Network {
+  Power = 0,
+  Water = 1,
+  Traffic = 2
+}
+
+/** Occupant bits that conduct `Network.Power` by their own nature — mirrors each `OccupantDef.conducts` entry in `OCCUPANT_DEFS`. */
+const NET_POWER_MASK =
+  (1 << Occupant.Road) |
+  (1 << Occupant.Rail) |
+  (1 << Occupant.ZoneResidential) |
+  (1 << Occupant.ZoneCommercial) |
+  (1 << Occupant.ZoneIndustrial) |
+  (1 << Occupant.PowerLine);
+
+/** Occupant bits that conduct `Network.Water` by their own nature. */
+const NET_WATER_MASK =
+  (1 << Occupant.Pipe) |
+  (1 << Occupant.Road) |
+  (1 << Occupant.Rail) |
+  (1 << Occupant.ZoneResidential) |
+  (1 << Occupant.ZoneCommercial) |
+  (1 << Occupant.ZoneIndustrial);
+
+/** Occupant bits that conduct `Network.Traffic` by their own nature. Road only — no transit network exists yet, and rail is deliberately excluded (see `Occupant::Rail`'s `conducts` note in `occupants.rs`). */
+const NET_TRAFFIC_MASK = 1 << Occupant.Road;
+
+/** The union of everything on the tile — `underground | surface | overhead`. Mirrors `Tile::occupants` in Rust. */
+export function tileOccupants(underground: number, surface: number, overhead: number): number {
+  return underground | surface | overhead;
+}
+
+/**
+ * Whether a tile carries `network`, given its occupant bits and whether it is
+ * developed. Mirrors `Tile::conducts` in `occupants.rs`: a developed lot
+ * conducts power/water by virtue of being developed — a property of the
+ * development, not of any occupant — which is why `Structure` itself
+ * declares `NET_NONE` in `OCCUPANT_DEFS` and this function still needs
+ * `buildingId`/`isPowerPlant` passed in alongside the occupant bits.
+ */
+export function conducts(
+  network: Network,
+  occupants: number,
+  buildingId: number | undefined,
+  isPowerPlant: boolean
+): boolean {
+  switch (network) {
+    case Network.Power:
+      return isPowerPlant || buildingId !== undefined || (occupants & NET_POWER_MASK) !== 0;
+    case Network.Water:
+      return buildingId !== undefined || (occupants & NET_WATER_MASK) !== 0;
+    case Network.Traffic:
+      return (occupants & NET_TRAFFIC_MASK) !== 0;
+  }
+}

--- a/app/src/game/serviceDistribution.test.ts
+++ b/app/src/game/serviceDistribution.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { createInitialState, setTile, TileKind } from './gameState';
+import { createInitialState, getTile, setTile, TileKind } from './gameState';
 import { getBuildingTemplate } from './buildings/templates';
 import { placeBuilding } from './buildings/manager';
+import { resyncTileStrata } from './protocol/legacyProjection';
 import {
   computeZoneLoads,
   estimateZoneLoad,
@@ -9,6 +10,12 @@ import {
   DEFAULT_WORKER_SHARE
 } from './serviceDistribution';
 import { ServiceId } from './services';
+
+/** `setTile` only writes the old shim `kind` — resync the strata too, same as `tools.ts`'s `applyTool` does after every tool call. */
+function setTileAndSync(state: ReturnType<typeof createInitialState>, x: number, y: number, kind: TileKind): void {
+  setTile(state, x, y, kind);
+  resyncTileStrata(getTile(state, x, y)!);
+}
 
 describe('serviceDistribution', () => {
   it('computes population and job loads proportional to capacity with worker fallback', () => {
@@ -48,12 +55,12 @@ describe('serviceDistribution', () => {
   it('finds reachable zones through roads within a radius and sorts by distance', () => {
     const state = createInitialState(5, 5);
     // service origin at (1,1)
-    setTile(state, 1, 1, TileKind.Road);
-    setTile(state, 1, 2, TileKind.Road);
-    setTile(state, 1, 3, TileKind.Residential); // reachable via road chain, distance 2
-    setTile(state, 2, 1, TileKind.Road);
-    setTile(state, 3, 1, TileKind.Commercial); // reachable via road chain, distance 2
-    setTile(state, 4, 4, TileKind.Industrial); // outside radius / no path
+    setTileAndSync(state, 1, 1, TileKind.Road);
+    setTileAndSync(state, 1, 2, TileKind.Road);
+    setTileAndSync(state, 1, 3, TileKind.Residential); // reachable via road chain, distance 2
+    setTileAndSync(state, 2, 1, TileKind.Road);
+    setTileAndSync(state, 3, 1, TileKind.Commercial); // reachable via road chain, distance 2
+    setTileAndSync(state, 4, 4, TileKind.Industrial); // outside radius / no path
 
     const candidates = getReachableZoneCandidates(
       state,

--- a/app/src/game/serviceDistribution.ts
+++ b/app/src/game/serviceDistribution.ts
@@ -3,6 +3,7 @@ import { BuildingStatus } from './buildings/state';
 import { BuildingCategory, getBuildingTemplate } from './buildings/templates';
 import type { GameState, Tile } from './gameState';
 import { getTile, TileKind } from './gameState';
+import { Occupant, hasOccupant } from './protocol/occupants';
 import { ServiceId } from './services';
 
 export const DEFAULT_WORKER_SHARE = 0.55;
@@ -14,7 +15,7 @@ export type ZoneLoadMap = {
 
 function isRoadish(tile: Tile | undefined): boolean {
   if (!tile) return false;
-  return tile.kind === TileKind.Road || tile.roadUnderlay === true;
+  return hasOccupant(tile.surface, Occupant.Road);
 }
 
 /**

--- a/app/src/game/tools.test.ts
+++ b/app/src/game/tools.test.ts
@@ -8,6 +8,7 @@ import { Simulation } from './simulation';
 import { BuildingStatus } from './buildings/state';
 import { getBuildingTemplate } from './buildings/templates';
 import { placeBuilding } from './buildings/manager';
+import { resyncTileStrata } from './protocol/legacyProjection';
 import { hasRoadAccess } from './adjacency';
 import { SeededRng } from './rng';
 
@@ -97,6 +98,7 @@ describe('tools', () => {
     expect(pump).toBeDefined();
     const pumpConnection = getTile(state, 0, 1)!;
     pumpConnection.legacyUnderground = TileKind.WaterPipe;
+    resyncTileStrata(pumpConnection);
     const spent = initialMoney - state.money;
     expect(spent).toBeCloseTo(
       BUILD_COST[Tool.WindTurbine] + BUILD_COST[Tool.PowerLine] * 3 + template.cost
@@ -116,7 +118,9 @@ describe('tools', () => {
     const result = applyTool(state, Tool.WaterTower, 3, 3);
     expect(result.success).toBe(true);
     expect(state.buildings.filter((building) => building.templateId === template.id).length).toBe(1);
-    getTile(state, 5, 3)!.legacyUnderground = TileKind.WaterPipe;
+    const towerPipe = getTile(state, 5, 3)!;
+    towerPipe.legacyUnderground = TileKind.WaterPipe;
+    resyncTileStrata(towerPipe);
     const ids = new Set<number>();
     const footprint: Array<[number, number]> = [
       [3, 3],

--- a/app/src/game/tools.ts
+++ b/app/src/game/tools.ts
@@ -7,6 +7,7 @@ import { BUILD_COST, PowerPlantType } from './constants';
 import { type BuildingTemplate, getBuildingTemplate, getPowerPlantTemplate } from './buildings/templates';
 import { placeBuilding, removeBuilding } from './buildings/manager';
 import { GameState, Tile, TileKind, getTile, setTile } from './gameState';
+import { resyncTileStrata } from './protocol/legacyProjection';
 import { Tool } from './toolTypes';
 
 export interface ChangeResult {
@@ -321,6 +322,27 @@ const registry: ToolRegistry = {
   }
 };
 
+/**
+ * Bring every tile's strata fields (`terrain`/`underground`/`surface`/
+ * `overhead`/`density`) back in sync with its shim fields (`kind`/
+ * `roadUnderlay`/`railUnderlay`/`powerOverlay`/`legacyUnderground`).
+ *
+ * This file's own handlers above are unconverted v4-shape logic — mirroring
+ * `commands.rs` as it was *before* its own occupant migration, since
+ * rewriting them to match `commands.rs` as it is now is Phase 7's job, not
+ * this phase's. Until then, every tool mutates only the shim fields, so
+ * anything reading the real strata directly (`adjacency.ts` since Phase 4)
+ * would see stale zeros without this resync — whole-grid rather than
+ * targeted, since a footprint building or a regrade can touch tiles this
+ * function has no cheap way to enumerate ahead of time. Test-only, never on
+ * the production hot path, so an O(tiles) pass per call is free.
+ */
+function syncStrataFromLegacy(state: GameState): void {
+  for (const tile of state.tiles) {
+    resyncTileStrata(tile);
+  }
+}
+
 export function applyTool(state: GameState, tool: Tool, x: number, y: number): ChangeResult {
   const tile = getTile(state, x, y);
   if (!tile) return { success: false };
@@ -331,5 +353,7 @@ export function applyTool(state: GameState, tool: Tool, x: number, y: number): C
 
   const handler = registry[tool];
   if (!handler) return { success: false };
-  return handler({ state, tile, x, y }, cost);
+  const result = handler({ state, tile, x, y }, cost);
+  syncStrataFromLegacy(state);
+  return result;
 }

--- a/app/src/game/utilities/water.test.ts
+++ b/app/src/game/utilities/water.test.ts
@@ -3,6 +3,7 @@ import { createInitialState, getTile, TileKind } from '../gameState';
 import { placeBuilding, updateBuildingStates } from '../buildings/manager';
 import { recomputeWaterNetwork } from './water';
 import { getBuildingTemplate } from '../buildings/templates';
+import { resyncTileStrata } from '../protocol/legacyProjection';
 
 describe('water network', () => {
   it('propagates water from tower to pipes', () => {
@@ -24,6 +25,7 @@ describe('water network', () => {
     // Place Pipe at 3,1 (adjacent to tower at 2,1)
     const pipeTile = getTile(state, 3, 1)!;
     pipeTile.legacyUnderground = TileKind.WaterPipe;
+    resyncTileStrata(pipeTile);
 
     // Ensure building status is active (towers need power)
     updateBuildingStates(state);
@@ -48,8 +50,12 @@ describe('water network', () => {
       tile.powered = true;
     });
 
-    getTile(state, 3, 1)!.legacyUnderground = TileKind.WaterPipe;
-    getTile(state, 4, 1)!.legacyUnderground = TileKind.WaterPipe;
+    const pipe1 = getTile(state, 3, 1)!;
+    pipe1.legacyUnderground = TileKind.WaterPipe;
+    resyncTileStrata(pipe1);
+    const pipe2 = getTile(state, 4, 1)!;
+    pipe2.legacyUnderground = TileKind.WaterPipe;
+    resyncTileStrata(pipe2);
 
     updateBuildingStates(state);
     recomputeWaterNetwork(state);


### PR DESCRIPTION
## Summary
- **`adjacency.ts`'s carrier/road-access predicates** (`isPowerCarrier`, `isWaterCarrier`, `hasRoadAccess`, `isZone`) and **`serviceDistribution.ts`'s `isRoadish`** now read `terrain`/`underground`/`surface`/`overhead` directly instead of `kind`/`roadUnderlay`/`railUnderlay`/`powerOverlay`.
- **`debugStats.ts`'s zone tallies** convert too; its one `Occupant.Structure`-with-no-`buildingId` check stays on the shim `kind` deliberately — that state is unrepresentable in the strata model by design, so the shim is the only place a pre-migration save artifact like it can still be spelled.
- New in **`protocol/occupants.ts`**: `Network`, `conducts()` and `tileOccupants()` — a straight TS port of `Tile::conducts`/`OCCUPANT_DEFS` in `occupants.rs` (same three masks: power/water/traffic, same "a developed lot conducts by virtue of being developed" special case for `Structure`). `adjacency.ts`'s predicates are now thin callers of this, mirroring the relationship `adjacency.rs` has with `occupants.rs` on the Rust side.

### The gap this PR actually spent its time on
`tools.ts`, `simulation.ts` and `buildings/manager.ts` are the TS-side test-only parity oracle (never reachable from `main.ts`) and their own conversion is Phase 7 — out of scope here. But they run *underneath* every test that now calls the converted `adjacency.ts` predicates, and they only ever wrote the shim fields, never the strata. Converting `adjacency.ts` without addressing that would have left every test exercising it reading real zeros off tiles the oracle had, from the shim's point of view, filled in correctly.

Fixed at the boundary rather than by touching the oracle's own logic (still Phase 7's, not this PR's):
- **`tools.ts`'s `applyTool`** now calls a new whole-grid `syncStrataFromLegacy` after every handler runs, deriving strata from whatever the handler left in the shim fields via `tileFromV4` (already written for #189's `persistence.ts` decode — same v4-to-strata direction, different caller). Whole-grid because a footprint building or a regrade can touch tiles this function has no cheap way to enumerate ahead of time, and this path is test-only, so an O(tiles) pass per call costs nothing real.
- **`buildings/manager.ts`'s `placeBuilding`/`removeBuilding`** — reachable from both `tools.ts` and `simulation.ts`, so covering it once here beats covering it per caller — call the same per-tile `resyncTileStrata` (extracted from `tools.ts`'s loop into `legacyProjection.ts` so both share one definition) right after each shim-field write.
- **Five tests** across `adjacency.test.ts`/`tools.test.ts`/`water.test.ts`/`serviceDistribution.test.ts` hand-spell a tile's shim fields directly — bypassing `applyTool` and `placeBuilding` both — to build a scenario the tool layer cannot reach on its own (a line hidden in an overlay flag, a buried pipe with no tool for it). Each now calls `resyncTileStrata` right after, same as the production paths do automatically.

Every one of these was a real test going red, not a hunch: `cargo test` doesn't touch this file, so `bun run test` catching all five before this PR is the only thing that would have.

## Test plan
- [x] `bun run lint` clean
- [x] `bun run test` — 351/351 passing
- [x] `bun run test:parity` — 42/42 passing
