### PR TITLE
UI layer and mcpBridge read occupant bits instead of the legacy shim

### DIFF
--- a/app/src/game/mcpBridge.ts
+++ b/app/src/game/mcpBridge.ts
@@ -13,6 +13,7 @@ import { createInitialState } from './gameState';
 import { Tool } from './toolTypes';
 import { getCalendarPosition } from './time';
 import { nextStrokeId } from './protocol/commands';
+import { dominantOccupantLabel } from './protocol/tileLabel';
 
 // Bresenham's line — returns all integer (x,y) pairs from (x0,y0) to (x1,y1).
 function bresenhamLine(x0: number, y0: number, x1: number, y1: number): [number, number][] {
@@ -98,7 +99,7 @@ export function initMcpBridge(bridge: SimBridge, state: GameState): void {
     const t = s.tiles[y * s.width + x];
     if (!t) return null;
     return {
-      kind: t.kind as string,
+      kind: dominantOccupantLabel(s, t),
       powered: t.powered,
       watered: t.watered,
       abandoned: t.abandoned ?? false,
@@ -127,7 +128,7 @@ export function initMcpBridge(bridge: SimBridge, state: GameState): void {
           const s = bridge.getState();
           const kind = params.kind as string;
           const hits = s.tiles.flatMap((t, i) =>
-            (t.kind as string) === kind
+            dominantOccupantLabel(s, t) === kind
               ? [{ x: i % s.width, y: Math.floor(i / s.width) }]
               : [],
           );

--- a/app/src/game/protocol/tileLabel.ts
+++ b/app/src/game/protocol/tileLabel.ts
@@ -1,0 +1,30 @@
+// tileLabel.ts — dominantOccupantLabel: a tile's current display kind, computed live from strata.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import type { GameState, Tile } from '../gameState';
+import { getBuildingTemplate } from '../buildings/templates';
+import { legacyKind } from './legacyProjection';
+
+/**
+ * The tile's dominant occupant, as a display/query string — used by the HUD
+ * tile inspector, the minimap, and `mcpBridge.ts`'s `get_tile`/
+ * `get_tiles_where` handlers. Deliberately separate from `legacyKind`, even
+ * though today's derivation is identical: this one only needs to stay
+ * human-readable and current, `legacyKind` needs to stay byte-exact with old
+ * saves forever, and nothing here should have to care if those two
+ * requirements ever pull apart.
+ */
+export function dominantOccupantLabel(state: GameState, tile: Tile): string {
+  return legacyKind({
+    terrain: tile.terrain,
+    surface: tile.surface,
+    overhead: tile.overhead,
+    buildingId: tile.buildingId,
+    structureKindOf: (buildingId) => {
+      const instance = state.buildings.find((b) => b.id === buildingId);
+      return instance ? getBuildingTemplate(instance.templateId)?.tileKind : undefined;
+    }
+  });
+}

--- a/app/src/ui/bylawsModal.ts
+++ b/app/src/ui/bylawsModal.ts
@@ -1,6 +1,7 @@
 import { projectLightingPolicy } from '../game/bylawAnalytics';
 import { DEFAULT_BYLAWS, LIGHTING_POLICIES, type LightingBylaw } from '../game/bylaws';
-import { TileKind, type GameState } from '../game/gameState';
+import type { GameState } from '../game/gameState';
+import { Occupant, zoneOccupant } from '../game/protocol/occupants';
 import {
   NATURE_RESERVE_UNLOCK_SCORE,
   type WildernessPolicy
@@ -151,7 +152,7 @@ export function initBylawsModal(options: BylawsModalOptions) {
       const state = getState();
       const policy = state.policies.wilderness;
       const score = state.wilderness.score;
-      const industrialZones = state.tiles.filter((t) => t.kind === TileKind.Industrial).length;
+      const industrialZones = state.tiles.filter((t) => zoneOccupant(t.surface) === Occupant.ZoneIndustrial).length;
       const reserveUnlocked = policy.natureReserve || score >= NATURE_RESERVE_UNLOCK_SCORE;
       wildernessOptions.innerHTML = '';
 

--- a/app/src/ui/hud.ts
+++ b/app/src/ui/hud.ts
@@ -6,6 +6,7 @@
 import { BuildingStatus } from '../game/buildings/state';
 import { getBuildingTemplate } from '../game/buildings/templates';
 import { GameState, getTile } from '../game/gameState';
+import { dominantOccupantLabel } from '../game/protocol/tileLabel';
 import { Position } from '../rendering/renderer';
 import { Tool } from '../game/toolTypes';
 import { getToolDetails } from './toolInfo';
@@ -287,7 +288,7 @@ export function createHud(elements: HudElements) {
                   <div class="info-label">Tile</div>
                   <div class="info-name">${selected.x},${selected.y}</div>
                 </div>
-                <div class="status-line"><span>Type</span><strong>${hasTileSelection.kind}</strong></div>
+                <div class="status-line"><span>Type</span><strong>${dominantOccupantLabel(state, hasTileSelection)}</strong></div>
                 <div class="status-line"><span>Happy</span><strong>${hasTileSelection.happiness.toFixed(2)}</strong></div>
                 <div class="status-line"><span>Power</span><strong>${hasTileSelection.powered ? 'On' : 'Off'}</strong></div>
                 <div class="status-line"><span>Water</span><strong>${hasTileSelection.watered ? 'Wet' : 'Dry'}</strong></div>

--- a/app/src/ui/minimap.ts
+++ b/app/src/ui/minimap.ts
@@ -15,8 +15,11 @@ import {
 } from '../game/gameState';
 import { BuildingStatus } from '../game/buildings/state';
 import { isPowerCarrier, isZone } from '../game/adjacency';
+import { Occupant, Terrain, hasOccupant } from '../game/protocol/occupants';
+import { legacyKind, legacyFlags } from '../game/protocol/legacyProjection';
 import { ServiceId } from '../game/services';
 import { TILE_SIZE, palette as tilePalette } from '../rendering/sprites';
+import { createBuildingLookup, type BuildingLookup } from '../rendering/tileRenderUtils';
 
 export interface MinimapOptions {
   root: HTMLElement;
@@ -296,12 +299,17 @@ export function initMinimap(options: MinimapOptions): MinimapController {
     return lookup;
   }
 
-  function pickModeColor(tile: ReturnType<typeof getTile>, buildingStatuses: Map<number, BuildingStatus>) {
+  function pickModeColor(
+    tile: ReturnType<typeof getTile>,
+    buildingStatuses: Map<number, BuildingStatus>,
+    buildingLookup: BuildingLookup
+  ) {
     if (!tile) return '#000';
+    const templateKind = tile.buildingId !== undefined ? buildingLookup.get(tile.buildingId)?.template?.tileKind : undefined;
 
     if (settings.mode === 'power') {
       if (tile.powerPlantType) return '#81e8ff';
-      if (tile.kind === TileKind.PowerLine || tile.powerOverlay) {
+      if (hasOccupant(tile.overhead, Occupant.PowerLine)) {
         return tile.powered ? '#7bf0ff' : '#ff99c2';
       }
       const carrier = isPowerCarrier(tile);
@@ -311,9 +319,8 @@ export function initMinimap(options: MinimapOptions): MinimapController {
     }
 
     if (settings.mode === 'water') {
-      if (tile.kind === TileKind.Water) return '#1f68d6';
-      if (tile.kind === TileKind.WaterPipe) return '#4cc3ff';
-      if (tile.kind === TileKind.WaterPump || tile.kind === TileKind.WaterTower) {
+      if (tile.terrain === Terrain.Water) return '#1f68d6';
+      if (templateKind === TileKind.WaterPump || templateKind === TileKind.WaterTower) {
         return tile.powered ? '#7ad5ff' : '#ffcc70';
       }
       return tile.powered ? 'rgba(76, 195, 255, 0.25)' : 'rgba(16, 26, 42, 0.92)';
@@ -338,7 +345,7 @@ export function initMinimap(options: MinimapOptions): MinimapController {
       return 'rgba(255, 123, 123, 0.95)';
     }
     if (settings.mode === 'education') {
-      if (tile.kind === TileKind.ElementarySchool || tile.kind === TileKind.HighSchool) {
+      if (templateKind === TileKind.ElementarySchool || templateKind === TileKind.HighSchool) {
         return '#8f7bff';
       }
       if (isZone(tile)) {
@@ -351,7 +358,7 @@ export function initMinimap(options: MinimapOptions): MinimapController {
     }
 
     if (settings.mode === 'wilderness') {
-      if (tile.kind === TileKind.Water) return '#1f68d6';
+      if (tile.terrain === Terrain.Water) return '#1f68d6';
       const delta = (tile.wilderness ?? 0.5) - 0.5;
       if (delta > 0.02) return `rgba(94, 230, 160, ${Math.min(0.3 + delta * 1.4, 0.95).toFixed(2)})`;
       if (delta < -0.02) return `rgba(154, 160, 168, ${Math.min(0.3 + -delta * 1.4, 0.95).toFixed(2)})`;
@@ -359,24 +366,39 @@ export function initMinimap(options: MinimapOptions): MinimapController {
     }
 
     if (settings.mode === 'underground') {
-      if (tile.legacyUnderground === TileKind.WaterPipe) return '#4cc3ff';
-      if (tile.kind === TileKind.Water) return '#1f68d6';
+      if (hasOccupant(tile.underground, Occupant.Pipe)) return '#4cc3ff';
+      if (tile.terrain === Terrain.Water) return '#1f68d6';
       if (tile.watered) return 'rgba(76, 195, 255, 0.55)';
       // Fade others
       return 'rgba(16, 26, 42, 0.95)';
     }
 
-    // Base/default mode.
-    if (tile.powerOverlay) return colorToCss(palette[TileKind.PowerLine]);
-    if (tile.railUnderlay) return colorToCss(palette[TileKind.Rail]);
-    if (tile.roadUnderlay) return colorToCss(palette[TileKind.Road]);
-    return colorToCss(palette[tile.kind]);
+    // Base/default mode. `roadUnderlay`/`railUnderlay` are true only when
+    // that occupant did *not* win `kind` (e.g. a plain crossing's `kind` is
+    // always `Rail`, so `railUnderlay` is always false there and this falls
+    // through to the road colour) — order matters and is pinned by
+    // `e2e/visual.spec.ts`'s `d-minimap.png`, so this reuses `legacyKind`/
+    // `legacyFlags` rather than re-deriving that conjunct by hand.
+    const projectionInput = {
+      terrain: tile.terrain,
+      surface: tile.surface,
+      overhead: tile.overhead,
+      buildingId: tile.buildingId,
+      structureKindOf: (id: number) => buildingLookup.get(id)?.template?.tileKind
+    };
+    const derivedKind = legacyKind(projectionInput);
+    const flags = legacyFlags(projectionInput, derivedKind);
+    if (flags.powerOverlay) return colorToCss(palette[TileKind.PowerLine]);
+    if (flags.railUnderlay) return colorToCss(palette[TileKind.Rail]);
+    if (flags.roadUnderlay) return colorToCss(palette[TileKind.Road]);
+    return colorToCss(palette[derivedKind]);
   }
 
   function drawMap(state: GameState) {
     if (!layout) layoutCanvases();
     const frame = layout!;
     const buildingStatuses = createBuildingStatusLookup(state);
+    const { buildingLookup } = createBuildingLookup(state);
     baseCtx.clearRect(0, 0, frame.sizePx, frame.sizePx);
     const targetPixels = Math.max(60, frame.sizePx - 12);
     const step = Math.max(1, Math.ceil(Math.max(state.width, state.height) / targetPixels));
@@ -391,7 +413,7 @@ export function initMinimap(options: MinimapOptions): MinimapController {
         const tileX = Math.min(state.width - 1, sx * step);
         const tileY = Math.min(state.height - 1, sy * step);
         const tile = getTile(state, tileX, tileY);
-        baseCtx.fillStyle = pickModeColor(tile, buildingStatuses);
+        baseCtx.fillStyle = pickModeColor(tile, buildingStatuses, buildingLookup);
         baseCtx.fillRect(offsetX + sx * scale, offsetY + sy * scale, scale, scale);
       }
     }


### PR DESCRIPTION
## Summary

- **UI layer reads occupants, not the shim** — `minimap.ts`'s `pickModeColor` and `bylawsModal.ts`'s industrial-zone tally now read `terrain`/`surface`/`overhead` occupant bits and `zoneOccupant` directly instead of the deprecated `kind`/`roadUnderlay`/`railUnderlay`/`powerOverlay`/`legacyUnderground` shim fields. Building-kind branches (water pump/tower, schools) read `buildingLookup.get(tile.buildingId)?.template?.tileKind` instead of the per-tile shim.
- **New shared label helper** — `game/protocol/tileLabel.ts` exports `dominantOccupantLabel(state, tile)`, a live-strata wrapper around `legacyKind`. `hud.ts`'s tile-inspector "Type" row and both `mcpBridge.ts` handlers (`get_tile`, `get_tiles_where`) now use it, so they stop reading `tile.kind` while returning byte-identical strings — `kindAt()`'s e2e contract is untouched.

### A real bug caught along the way

Minimap's base-mode colour picker checked `railUnderlay`/`roadUnderlay` before falling back to `kind`, and those two flags carry a `&& kind !== X` conjunct that `powerOverlay` doesn't. A level crossing's `kind` is always `Rail` under the current precedence, so `railUnderlay` is always false there and the check was really relying on `roadUnderlay` to win. My first pass (`hasOccupant(surface, Rail)`, no conjunct) flipped the crossing colour back to rail-brown — `bun run test:visual` caught the 2-pixel diff in `d-minimap.png` before it landed. Fixed by calling `legacyKind`/`legacyFlags` directly for that one branch instead of hand-deriving the conjunct.

## Test plan

- [x] `bun run lint`
- [x] `bun run test` — 352 tests
- [x] `bun run test:parity` — 42 cross-engine parity tests
- [x] `bun run test:e2e` — all 15 tests, including the visual-regression spec with all four golden PNGs byte-unchanged from the Phase 5 PR
