### PR TITLE
Rewrite the TS test-only oracle (tools.ts, simulation.ts, stateHash.ts, parity) against occupant-based commands.rs

### DIFF
--- a/app/src/game/parity/engines.ts
+++ b/app/src/game/parity/engines.ts
@@ -17,7 +17,7 @@
  * {@link TileFacts} and {@link Headline}. Neither adapter is allowed to
  * normalise anything on its engine's behalf: every reading comes off the
  * engine's own public surface (`tile_buffer()` for Rust, `GameState` for TS)
- * and goes through the shared `factsFromWire`.
+ * and goes through the shared `factsFromTile`.
  */
 
 import { readFileSync } from 'node:fs';
@@ -35,10 +35,9 @@ import {
   decodeOverheadBits,
   STATUS
 } from '../protocol/tileBuffer';
-import { LEGACY_FLAGS } from '../protocol/legacyTileBuffer';
 import { Terrain } from '../protocol/occupants';
-import { legacyKind, legacyFlags, legacyUndergroundKind } from '../protocol/legacyProjection';
-import { factsFromWire, TileFacts } from './tileFacts';
+import { getBuildingTemplate } from '../buildings/templates';
+import { factsFromTile, TileFacts } from './tileFacts';
 
 interface WireBuilding {
   id: number;
@@ -121,7 +120,7 @@ export interface Engine {
 function naturalTerrain(state: GameState): Uint8Array {
   const out = new Uint8Array(state.tiles.length);
   state.tiles.forEach((tile, i) => {
-    out[i] = tileKindToU8(tile.kind);
+    out[i] = tileKindToU8(tile.terrain === Terrain.Water ? TileKind.Water : TileKind.Land);
   });
   return out;
 }
@@ -234,24 +233,21 @@ export function rustEngine(width: number, height: number, seed: number): Engine 
 
       const out: TileFacts[] = [];
       for (let i = 0; i < n; i++) {
-        const terrain = (buf[off.status + i] & STATUS.WATER_TERRAIN) !== 0 ? Terrain.Water : Terrain.Land;
-        const surface = decodeSurfaceBits(buf[off.surface + i]);
-        const overhead = decodeOverheadBits(buf[off.overhead + i]);
-        const underground = decodeUndergroundBits(buf[off.underground + i]);
+        const status = buf[off.status + i];
         const buildingIdRaw = view.getUint16(off.buildingId + i * 2, true);
-        const buildingId = buildingIdRaw === 0 ? undefined : buildingIdRaw;
-
-        const kind = legacyKind({ terrain, surface, overhead, buildingId, structureKindOf });
-        const flags = legacyFlags({ terrain, surface, overhead, buildingId, structureKindOf }, kind);
-        const flagBits =
-          ((buf[off.status + i] & STATUS.POWERED) !== 0 ? LEGACY_FLAGS.POWERED : 0) |
-          ((buf[off.status + i] & STATUS.WATERED) !== 0 ? LEGACY_FLAGS.WATERED : 0) |
-          ((buf[off.status + i] & STATUS.ABANDONED) !== 0 ? LEGACY_FLAGS.ABANDONED : 0) |
-          (flags.roadUnderlay ? LEGACY_FLAGS.ROAD_UNDERLAY : 0) |
-          (flags.railUnderlay ? LEGACY_FLAGS.RAIL_UNDERLAY : 0) |
-          (flags.powerOverlay ? LEGACY_FLAGS.POWER_OVERLAY : 0);
-
-        out.push(factsFromWire(kind, flagBits, buildingIdRaw, legacyUndergroundKind(underground)));
+        out.push(
+          factsFromTile({
+            terrain: (status & STATUS.WATER_TERRAIN) !== 0 ? Terrain.Water : Terrain.Land,
+            underground: decodeUndergroundBits(buf[off.underground + i]),
+            surface: decodeSurfaceBits(buf[off.surface + i]),
+            overhead: decodeOverheadBits(buf[off.overhead + i]),
+            buildingId: buildingIdRaw === 0 ? undefined : buildingIdRaw,
+            structureKindOf,
+            powered: (status & STATUS.POWERED) !== 0,
+            watered: (status & STATUS.WATERED) !== 0,
+            abandoned: (status & STATUS.ABANDONED) !== 0
+          })
+        );
       }
       return out;
     }
@@ -271,17 +267,9 @@ export function tsEngine(width: number, height: number, seed: number): Engine {
   const state = createInitialState(width, height, seed);
   const sim = new Simulation(state, { ticksPerSecond: 20 });
 
-  /** Repack a TS `Tile` into the v4 flags byte so both sides read it alike. */
-  const flagsOf = (x: number, y: number): number => {
-    const tile = getTile(state, x, y)!;
-    let bits = 0;
-    if (tile.powered) bits |= LEGACY_FLAGS.POWERED;
-    if (tile.watered) bits |= LEGACY_FLAGS.WATERED;
-    if (tile.abandoned) bits |= LEGACY_FLAGS.ABANDONED;
-    if (tile.roadUnderlay) bits |= LEGACY_FLAGS.ROAD_UNDERLAY;
-    if (tile.railUnderlay) bits |= LEGACY_FLAGS.RAIL_UNDERLAY;
-    if (tile.powerOverlay) bits |= LEGACY_FLAGS.POWER_OVERLAY;
-    return bits;
+  const structureKindOf = (buildingId: number): TileKind | undefined => {
+    const instance = state.buildings.find((b) => b.id === buildingId);
+    return instance ? getBuildingTemplate(instance.templateId)?.tileKind : undefined;
   };
 
   return {
@@ -313,12 +301,17 @@ export function tsEngine(width: number, height: number, seed: number): Engine {
         for (let x = 0; x < width; x++) {
           const tile = getTile(state, x, y)!;
           out.push(
-            factsFromWire(
-              tile.kind,
-              flagsOf(x, y),
-              tile.buildingId ?? 0,
-              tile.legacyUnderground === TileKind.WaterPipe ? TileKind.WaterPipe : undefined
-            )
+            factsFromTile({
+              terrain: tile.terrain,
+              underground: tile.underground,
+              surface: tile.surface,
+              overhead: tile.overhead,
+              buildingId: tile.buildingId,
+              structureKindOf,
+              powered: tile.powered,
+              watered: tile.watered,
+              abandoned: tile.abandoned ?? false
+            })
           );
         }
       }

--- a/app/src/game/parity/tileFacts.ts
+++ b/app/src/game/parity/tileFacts.ts
@@ -6,59 +6,40 @@
 /**
  * A tile stated as *what is on it*, not as *how it is spelled*.
  *
- * The cross-language parity harness cannot compare representations: Rust holds
- * per-stratum occupant sets and TypeScript holds a single-valued `kind` plus
- * underlay/overlay flags. It compares **observations** instead — the same
- * questions the renderer, the minimap and the placement guards ask — and both
- * sides answer them from their own representation through
- * {@link factsFromWire}.
+ * The cross-language parity harness cannot compare representations directly
+ * — the two engines' internal layouts can and do change shape independently
+ * — so it compares **observations** instead, the same questions the
+ * renderer, the minimap and the placement guards ask, and both sides answer
+ * them from their own strata through {@link factsFromTile}.
  *
- * Deliberately *not* compared: the raw wire `kind` byte. `display.rs` documents
- * three intended normalisations at that level (rail wins a level crossing, a
- * hydro line wins over bare ground, a bulldozed footprint stops being a ghost),
- * so a byte-for-byte comparison would fail on changes that are the point of
- * #177 rather than on drift. Those bytes are the visual-regression harness's
- * job. Every predicate here is spelling-agnostic and therefore invariant under
- * all three normalisations — if one of these disagrees, something real does.
+ * Deliberately *not* compared: a resolved `kind` spelling. `legacyKind`
+ * documents several intended precedence normalisations (rail wins a level
+ * crossing, a hydro line wins over bare ground, a bulldozed footprint stops
+ * being a ghost), so a byte-for-byte comparison of derived kinds would fail
+ * on changes that are the point of those normalisations rather than on
+ * drift. Reading occupant bits directly instead of going through a resolved
+ * `kind` sidesteps that entirely: every predicate here is spelling-agnostic
+ * and therefore invariant under all of them — if one of these disagrees,
+ * something real does. That byte-for-byte comparison is the visual-
+ * regression harness's job, not this one's.
  *
- * Also deliberately not compared: wilderness. It is excluded from the oracle by
- * design — `docs/features/wilderness-score.md`, decision 4.
+ * Also deliberately not compared: wilderness. It is excluded from the oracle
+ * by design — `docs/features/wilderness-score.md`, decision 4.
  */
 
 import { TileKind } from '../gameState';
-import { LEGACY_FLAGS as FLAGS } from '../protocol/legacyTileBuffer';
-
-/** Zone tags, in the order the wire kind byte spells them. */
-export const ZONE_KINDS: ReadonlySet<TileKind> = new Set([
-  TileKind.Residential,
-  TileKind.Commercial,
-  TileKind.Industrial
-]);
-
-/** Every kind that is a placed structure with a footprint behind it. */
-export const STRUCTURE_KINDS: ReadonlySet<TileKind> = new Set([
-  TileKind.HydroPlant,
-  TileKind.CoalPlant,
-  TileKind.WindTurbine,
-  TileKind.SolarFarm,
-  TileKind.WaterPump,
-  TileKind.WaterTower,
-  TileKind.ElementarySchool,
-  TileKind.HighSchool,
-  TileKind.Park,
-  TileKind.ParkLarge
-]);
+import { Occupant, Terrain, hasOccupant, zoneOccupant } from '../protocol/occupants';
 
 export interface TileFacts {
   /** The ground reads as water. */
   water: boolean;
   /** Tree canopy stands here. */
   trees: boolean;
-  /** A carriageway runs through, in either spelling. */
+  /** A carriageway runs through. */
   road: boolean;
-  /** A railway runs through, in either spelling. */
+  /** A railway runs through. */
   rail: boolean;
-  /** A hydro line spans the tile, in either spelling. */
+  /** A hydro line spans the tile. */
   line: boolean;
   /** The zone tag, or `null`. */
   zone: TileKind | null;
@@ -73,35 +54,58 @@ export interface TileFacts {
   abandoned: boolean;
 }
 
+/** One tile's strata, in the shape both engines' adapters decode their own state into. */
+export interface TileStrata {
+  terrain: Terrain;
+  underground: number;
+  surface: number;
+  overhead: number;
+  buildingId: number | undefined;
+  /** Resolves a `building_id` to its template's `TileKind` — `undefined` if not live. */
+  structureKindOf: (buildingId: number) => TileKind | undefined;
+  powered: boolean;
+  watered: boolean;
+  abandoned: boolean;
+}
+
+function zoneKindOf(zone: Occupant | undefined): TileKind | null {
+  switch (zone) {
+    case Occupant.ZoneResidential:
+      return TileKind.Residential;
+    case Occupant.ZoneCommercial:
+      return TileKind.Commercial;
+    case Occupant.ZoneIndustrial:
+      return TileKind.Industrial;
+    default:
+      return null;
+  }
+}
+
 /**
- * Read the facts out of one v4-shaped `(kind, flags, buildingId, underground)`
- * quadruple.
+ * Read the facts out of one tile's strata.
  *
- * Both engines feed this same function: the Rust side hands it bytes straight
- * off `SimHost::tile_buffer` (derived by `display.rs`), the TypeScript side
- * hands it the equivalent fields off its `Tile`, whose `kind` *is* the v4 wire
- * byte. Neither side gets a bespoke reading of its own state, so the mapping
- * cannot be where a disagreement is hidden.
+ * Both engines feed this same function: the Rust side hands it the occupant
+ * bits decoded straight off `SimHost::tile_buffer`, the TypeScript side
+ * hands it its own `Tile`'s `terrain`/`underground`/`surface`/`overhead`
+ * fields directly. Neither side gets a bespoke reading of its own state, so
+ * the mapping cannot be where a disagreement is hidden.
  */
-export function factsFromWire(
-  kind: TileKind,
-  flagBits: number,
-  buildingId: number,
-  underground: TileKind | undefined
-): TileFacts {
+export function factsFromTile(t: TileStrata): TileFacts {
+  const zone = zoneOccupant(t.surface);
+  const hasStructure = hasOccupant(t.surface, Occupant.Structure) && t.buildingId !== undefined;
   return {
-    water: kind === TileKind.Water,
-    trees: kind === TileKind.Tree,
-    road: kind === TileKind.Road || (flagBits & FLAGS.ROAD_UNDERLAY) !== 0,
-    rail: kind === TileKind.Rail || (flagBits & FLAGS.RAIL_UNDERLAY) !== 0,
-    line: kind === TileKind.PowerLine || (flagBits & FLAGS.POWER_OVERLAY) !== 0,
-    zone: ZONE_KINDS.has(kind) ? kind : null,
-    structure: STRUCTURE_KINDS.has(kind) ? kind : null,
-    pipe: underground === TileKind.WaterPipe,
-    developed: buildingId !== 0,
-    powered: (flagBits & FLAGS.POWERED) !== 0,
-    watered: (flagBits & FLAGS.WATERED) !== 0,
-    abandoned: (flagBits & FLAGS.ABANDONED) !== 0
+    water: t.terrain === Terrain.Water,
+    trees: hasOccupant(t.overhead, Occupant.Trees),
+    road: hasOccupant(t.surface, Occupant.Road),
+    rail: hasOccupant(t.surface, Occupant.Rail),
+    line: hasOccupant(t.overhead, Occupant.PowerLine),
+    zone: zoneKindOf(zone),
+    structure: hasStructure ? t.structureKindOf(t.buildingId!) ?? null : null,
+    pipe: hasOccupant(t.underground, Occupant.Pipe),
+    developed: t.buildingId !== undefined,
+    powered: t.powered,
+    watered: t.watered,
+    abandoned: t.abandoned
   };
 }
 

--- a/app/src/game/protocol/legacyProjection.ts
+++ b/app/src/game/protocol/legacyProjection.ts
@@ -145,11 +145,11 @@ export function tileFromV4(
 
 /**
  * Bring one tile's strata fields back in sync with its shim fields, in
- * place. `tools.ts`'s `applyTool` calls this (whole-grid, once per call —
- * see its own `syncStrataFromLegacy`) after every tool, since its handlers
- * are still unconverted v4-shape logic; tests that hand-spell a tile's shim
- * fields directly (bypassing `applyTool`) need the same call so predicates
- * reading the strata directly don't see stale zeros.
+ * place. `buildings/manager.ts`'s `placeBuilding`/`removeBuilding` call this
+ * after writing `kind`/`buildingId` directly, since those two functions are
+ * still shim-authoritative; tests that hand-spell a tile's shim fields
+ * directly (bypassing `applyTool`) need the same call so predicates reading
+ * the strata directly don't see stale zeros.
  */
 export function resyncTileStrata(tile: Tile): void {
   const strata = tileFromV4(
@@ -163,4 +163,36 @@ export function resyncTileStrata(tile: Tile): void {
   tile.surface = strata.surface;
   tile.overhead = strata.overhead;
   tile.density = strata.density;
+}
+
+/**
+ * The inverse of `resyncTileStrata`: bring one tile's shim fields
+ * (`kind`/`roadUnderlay`/`railUnderlay`/`powerOverlay`/`legacyUnderground`)
+ * back in sync with its strata, in place. `tools.ts`'s `applyTool` handlers
+ * are occupant-native (Phase 7 of the strata migration) and call this once
+ * per tool so that anything still reading the shim fields — chiefly
+ * `buildings/manager.ts`'s placement guard — doesn't see stale values.
+ *
+ * `structureKindOf` mirrors `legacyKind`'s own callback: resolve a
+ * `building_id` to its template's `TileKind`, or `undefined` if it isn't
+ * live.
+ */
+export function resyncLegacyFromStrata(
+  tile: Tile,
+  structureKindOf: (buildingId: number) => TileKind | undefined
+): void {
+  const input: LegacyProjectionInput = {
+    terrain: tile.terrain,
+    surface: tile.surface,
+    overhead: tile.overhead,
+    buildingId: tile.buildingId,
+    structureKindOf
+  };
+  const kind = legacyKind(input);
+  const flags = legacyFlags(input, kind);
+  tile.kind = kind;
+  tile.roadUnderlay = flags.roadUnderlay || undefined;
+  tile.railUnderlay = flags.railUnderlay || undefined;
+  tile.powerOverlay = flags.powerOverlay || undefined;
+  tile.legacyUnderground = legacyUndergroundKind(tile.underground);
 }

--- a/app/src/game/protocol/occupants.ts
+++ b/app/src/game/protocol/occupants.ts
@@ -96,6 +96,75 @@ export function iterSet(set: number): Occupant[] {
   return ALL_OCCUPANTS.filter((o) => hasOccupant(set, o));
 }
 
+interface TileStrata {
+  underground: number;
+  surface: number;
+  overhead: number;
+}
+
+/**
+ * Set or clear one occupant on the tile-shaped `strata`, in whichever
+ * stratum field the occupant belongs to. Mirrors `Tile::set_occupant` in
+ * Rust — the only write path into the strata, routed by the occupant's own
+ * declaration rather than a stratum the caller names.
+ */
+export function setTileOccupant(strata: TileStrata, occupant: Occupant, on: boolean): void {
+  switch (strataOf(occupant)) {
+    case Stratum.Underground:
+      strata.underground = withOccupant(strata.underground, occupant, on);
+      return;
+    case Stratum.Surface:
+      strata.surface = withOccupant(strata.surface, occupant, on);
+      return;
+    case Stratum.Overhead:
+      strata.overhead = withOccupant(strata.overhead, occupant, on);
+      return;
+  }
+}
+
+/** Clear a whole stratum. Mirrors `Tile::clear_stratum` in Rust. */
+export function clearTileStratum(strata: TileStrata, stratum: Stratum): void {
+  switch (stratum) {
+    case Stratum.Underground:
+      strata.underground = 0;
+      return;
+    case Stratum.Surface:
+      strata.surface = 0;
+      return;
+    case Stratum.Overhead:
+      strata.overhead = 0;
+      return;
+  }
+}
+
+/**
+ * Symmetric conflict masks, one per occupant — mirrors each `OccupantDef.conflicts`
+ * entry in `OCCUPANT_DEFS` (`occupants.rs`). The set of occupants that cannot
+ * share a tile with the key occupant.
+ */
+const CONFLICTS: Record<Occupant, number> = {
+  [Occupant.Pipe]: 0,
+  [Occupant.Subway]: 0,
+  [Occupant.Fibre]: 0,
+  [Occupant.Road]: SURFACE_MASK & ~((1 << Occupant.Road) | (1 << Occupant.Rail)),
+  [Occupant.Rail]: SURFACE_MASK & ~((1 << Occupant.Road) | (1 << Occupant.Rail)),
+  [Occupant.ZoneResidential]: SURFACE_MASK & ~(1 << Occupant.ZoneResidential),
+  [Occupant.ZoneCommercial]: SURFACE_MASK & ~(1 << Occupant.ZoneCommercial),
+  [Occupant.ZoneIndustrial]: SURFACE_MASK & ~(1 << Occupant.ZoneIndustrial),
+  [Occupant.Structure]: (SURFACE_MASK & ~(1 << Occupant.Structure)) | (1 << Occupant.PowerLine),
+  [Occupant.PowerLine]: (1 << Occupant.Trees) | (1 << Occupant.Structure),
+  [Occupant.Trees]: 1 << Occupant.PowerLine
+};
+
+/**
+ * Whether `a` and `b` cannot share a tile. Mirrors `pair_conflicts` in
+ * `occupants.rs`. Always `false` for an occupant against itself — a set
+ * holds at most one of each.
+ */
+export function pairConflicts(a: Occupant, b: Occupant): boolean {
+  return a !== b && (CONFLICTS[a] & (1 << b)) !== 0;
+}
+
 /**
  * The tile's land use, if it is zoned. Zones are mutually exclusive, and all
  * three are surface occupants. Mirrors `Tile::zone_occupant` in Rust.

--- a/app/src/game/regression.test.ts
+++ b/app/src/game/regression.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { createInitialState, TileKind } from './gameState';
+import { createInitialState } from './gameState';
 import { Simulation } from './simulation';
 import { applyTool } from './tools';
 import { Tool } from './toolTypes';
@@ -100,10 +100,10 @@ describe('regression: scenario 2 — power + residential growth', () => {
     expect(snap.utilities.powerProduced).toBeGreaterThan(0);
   });
   it('land tiles present', () => {
-    expect(snap.tileCounts[TileKind.Land] ?? 0).toBeGreaterThan(0);
+    expect(snap.tileCounts['terrain:land'] ?? 0).toBeGreaterThan(0);
   });
   it('residential tiles present', () => {
-    expect(snap.tileCounts[TileKind.Residential] ?? 0).toBeGreaterThan(0);
+    expect(snap.tileCounts['zone-residential'] ?? 0).toBeGreaterThan(0);
   });
 });
 
@@ -140,7 +140,7 @@ describe('regression: scenario 3 — water + zones', () => {
   it('buildings grew', () => expect(snap.buildingCount).toBeGreaterThan(0));
   it('population grew', () => expect(snap.population).toBeGreaterThan(20));
   it('residential tiles present', () => {
-    expect(snap.tileCounts[TileKind.Residential] ?? 0).toBeGreaterThan(0);
+    expect(snap.tileCounts['zone-residential'] ?? 0).toBeGreaterThan(0);
   });
 });
 
@@ -172,10 +172,15 @@ describe('regression: scenario 4 — power stress + abandonment', () => {
   it('tick count', () => expect(snap.tick).toBe(400));
   it('simulation remained alive (money >= 0)', () => expect(snap.money).toBeGreaterThanOrEqual(0));
   it('tile kinds are populated', () => {
-    const total = Object.values(snap.tileCounts).reduce((a, b) => a + b, 0);
+    // Every tile contributes to exactly one terrain bucket — unlike the
+    // occupant buckets, which a single tile can contribute to several of at
+    // once (a zoned lot crossed by a wire counts under both) — so summing
+    // just those two is the equivalent of the old "every tile accounted
+    // for" sanity check.
+    const total = (snap.tileCounts['terrain:land'] ?? 0) + (snap.tileCounts['terrain:water'] ?? 0);
     expect(total).toBe(16 * 16);
   });
   it('some road tiles present', () => {
-    expect(snap.tileCounts[TileKind.Road] ?? 0).toBeGreaterThan(0);
+    expect(snap.tileCounts['road'] ?? 0).toBeGreaterThan(0);
   });
 });

--- a/app/src/game/simulation.ts
+++ b/app/src/game/simulation.ts
@@ -8,6 +8,7 @@
 import type { GameState } from './gameState';
 import type { SimEvent } from './narrative/types';
 import { bumpTileRevision, getTile, TileKind } from './gameState';
+import { Occupant, hasOccupant, zoneOccupant } from './protocol/occupants';
 import { SeededRng } from './rng';
 import { BASE_INCOME, MAINTENANCE, POWER_PLANT_CONFIGS } from './constants';
 import { BuildingStatus } from './buildings/state';
@@ -125,11 +126,7 @@ export class Simulation {
     this.vacantZoneIndices.clear();
     this.state.tiles.forEach((tile, index) => {
       if (tile.buildingId !== undefined) return;
-      if (
-        tile.kind === TileKind.Residential ||
-        tile.kind === TileKind.Commercial ||
-        tile.kind === TileKind.Industrial
-      ) {
+      if (zoneOccupant(tile.surface) !== undefined) {
         this.vacantZoneIndices.add(index);
       }
     });
@@ -191,71 +188,49 @@ export class Simulation {
     let jobCapacity = 0;
     let commercialJobCapacity = 0;
     let industrialJobCapacity = 0;
-    const pumpTemplate = getBuildingTemplate(TileKind.WaterPump);
-    const parkTemplate = getBuildingTemplate(TileKind.Park);
 
-    for (let index = 0; index < this.state.tiles.length; index++) {
-      const tile = this.state.tiles[index];
-      const tileX = index % this.state.width;
-      const tileY = Math.floor(index / this.state.width);
-      if (tile.kind === TileKind.Residential) {
+    for (const tile of this.state.tiles) {
+      const zone = zoneOccupant(tile.surface);
+      if (zone === Occupant.ZoneResidential) {
         residentialZones++;
         if (tile.buildingId !== undefined) developedResidentialZones++;
       }
-      if (tile.kind === TileKind.Commercial) {
+      if (zone === Occupant.ZoneCommercial) {
         commercialZones++;
         if (tile.buildingId !== undefined) developedCommercialZones++;
       }
-      if (tile.kind === TileKind.Industrial) {
+      if (zone === Occupant.ZoneIndustrial) {
         industrialZones++;
         if (tile.buildingId !== undefined) developedIndustrialZones++;
       }
-      // Bill every feature the tile carries, not just whichever one owns its
-      // `kind`. Mirrors `compute_daily_budget` in
-      // `crates/city-sim-core/src/economy.rs` — see there for why the old
+      // Bill every occupant the tile carries, not just whichever one won its
+      // `kind` under the old flattened spelling. Mirrors `compute_daily_budget`
+      // in `crates/city-sim-core/src/economy.rs` — see there for why the old
       // per-kind form made a road get *cheaper* when you strung a line over it.
-      // Water pipes are only ever recorded in `underground`, handled below.
       const bill = (kind: TileKind, present: boolean, add: (u: number) => void) => {
         if (!present) return;
         const upkeep = MAINTENANCE[kind] ?? 0;
         maintenance += upkeep;
         add(upkeep);
       };
-      bill(TileKind.Road, tile.kind === TileKind.Road || !!tile.roadUnderlay,
-        (u) => { maintenanceRoads += u; });
-      bill(TileKind.Rail, tile.kind === TileKind.Rail || !!tile.railUnderlay,
-        (u) => { maintenanceRail += u; });
-      bill(TileKind.PowerLine, tile.kind === TileKind.PowerLine || !!tile.powerOverlay,
-        (u) => { maintenancePowerLines += u; });
+      bill(TileKind.Road, hasOccupant(tile.surface, Occupant.Road), (u) => { maintenanceRoads += u; });
+      bill(TileKind.Rail, hasOccupant(tile.surface, Occupant.Rail), (u) => { maintenanceRail += u; });
+      bill(TileKind.PowerLine, hasOccupant(tile.overhead, Occupant.PowerLine), (u) => { maintenancePowerLines += u; });
 
-      if (tile.legacyUnderground) {
-        const uUpkeep = MAINTENANCE[tile.legacyUnderground];
+      if (hasOccupant(tile.underground, Occupant.Pipe)) {
+        const uUpkeep = MAINTENANCE[TileKind.WaterPipe];
         if (uUpkeep) {
           maintenance += uUpkeep;
-          if (tile.legacyUnderground === TileKind.WaterPipe) maintenancePipes += uUpkeep;
+          maintenancePipes += uUpkeep;
         }
       }
-
-      if (tile.buildingId === undefined && tile.kind === TileKind.WaterPump && pumpTemplate) {
-        const active = pumpTemplate.requiresPower === false ? true : tile.powered;
-        const connected = hasWaterSourceConnection(this.state, { x: tileX, y: tileY }, { width: 1, height: 1 });
-        if (pumpTemplate.maintenance) {
-          buildingMaintenance += pumpTemplate.maintenance;
-          buildingMaintenanceCivic += pumpTemplate.maintenance;
-          civicMaintenanceByType[pumpTemplate.id] =
-            (civicMaintenanceByType[pumpTemplate.id] ?? 0) + pumpTemplate.maintenance;
-        }
-        if (this.waterEnabled && active && connected && pumpTemplate.waterOutput)
-          buildingWaterOutput += pumpTemplate.waterOutput;
-      }
-      if (tile.buildingId === undefined && tile.kind === TileKind.Park && parkTemplate) {
-        if (parkTemplate.maintenance) {
-          buildingMaintenance += parkTemplate.maintenance;
-          buildingMaintenanceCivic += parkTemplate.maintenance;
-          civicMaintenanceByType[parkTemplate.id] =
-            (civicMaintenanceByType[parkTemplate.id] ?? 0) + parkTemplate.maintenance;
-        }
-      }
+      // A `WaterPump`/`Park` tile with no `buildingId` cannot exist under the
+      // strata model — `legacyKind`'s `Structure` tier only spells a kind
+      // that way once `structureKindOf` resolves a live building — so the
+      // "billed by kind, not by BuildingInstance" civic branch this loop used
+      // to carry for those two is unreachable and has no strata equivalent.
+      // Every civic building's maintenance comes from the `state.buildings`
+      // loop below.
     }
 
     for (const building of this.state.buildings) {
@@ -574,11 +549,8 @@ export class Simulation {
         this.vacantZoneIndices.delete(idx);
         continue;
       }
-      if (
-        tile.kind !== TileKind.Residential &&
-        tile.kind !== TileKind.Commercial &&
-        tile.kind !== TileKind.Industrial
-      ) {
+      const zone = zoneOccupant(tile.surface);
+      if (zone === undefined) {
         this.zoneGrowthTimers.delete(idx);
         this.vacantZoneIndices.delete(idx);
         continue;
@@ -604,9 +576,9 @@ export class Simulation {
       }
       this.zoneGrowthTimers.delete(idx);
 
-      if (tile.kind === TileKind.Residential) residentialCandidates.push({ idx, x, y, hasPower, hasWater });
-      if (tile.kind === TileKind.Commercial) commercialCandidates.push({ idx, x, y, hasPower, hasWater });
-      if (tile.kind === TileKind.Industrial) industrialCandidates.push({ idx, x, y, hasPower, hasWater });
+      if (zone === Occupant.ZoneResidential) residentialCandidates.push({ idx, x, y, hasPower, hasWater });
+      if (zone === Occupant.ZoneCommercial) commercialCandidates.push({ idx, x, y, hasPower, hasWater });
+      if (zone === Occupant.ZoneIndustrial) industrialCandidates.push({ idx, x, y, hasPower, hasWater });
     }
 
     const grewResidential = this.applyZoneGrowthForType(

--- a/app/src/game/stateHash.ts
+++ b/app/src/game/stateHash.ts
@@ -14,6 +14,22 @@
  */
 
 import type { GameState } from './gameState';
+import { Occupant, Terrain, iterSet, tileOccupants } from './protocol/occupants';
+
+/** Mirrors `Occupant`'s variants — the bucket key each contributes to `tileCounts`. */
+const OCCUPANT_LABEL: Record<Occupant, string> = {
+  [Occupant.Pipe]: 'pipe',
+  [Occupant.Subway]: 'subway',
+  [Occupant.Fibre]: 'fibre',
+  [Occupant.Road]: 'road',
+  [Occupant.Rail]: 'rail',
+  [Occupant.ZoneResidential]: 'zone-residential',
+  [Occupant.ZoneCommercial]: 'zone-commercial',
+  [Occupant.ZoneIndustrial]: 'zone-industrial',
+  [Occupant.Structure]: 'structure',
+  [Occupant.PowerLine]: 'power-line',
+  [Occupant.Trees]: 'trees'
+};
 
 export interface StateSnapshot {
   tick: number;
@@ -37,13 +53,28 @@ export interface StateSnapshot {
   buildingCount: number;
 }
 
-/** Extract a deterministic snapshot from GameState for hashing. */
+/**
+ * Extract a deterministic snapshot from GameState for hashing.
+ *
+ * `tileCounts` buckets by occupant (one tile can contribute to several — a
+ * zoned lot crossed by a wire counts under both `zone-residential` and
+ * `power-line`) plus terrain, rather than by the single flattened `kind` a
+ * tile used to have. Bucketing by occupant is strictly more precise: it
+ * stops conflating two tiles that carry the same set of features but used
+ * to derive different — or accidentally the same — `kind` spellings.
+ */
 export function extractSnapshot(state: GameState): StateSnapshot {
   const tileCounts: Record<string, number> = {};
   let abandonedCount = 0;
 
   for (const tile of state.tiles) {
-    tileCounts[tile.kind] = (tileCounts[tile.kind] ?? 0) + 1;
+    const terrainKey = tile.terrain === Terrain.Water ? 'terrain:water' : 'terrain:land';
+    tileCounts[terrainKey] = (tileCounts[terrainKey] ?? 0) + 1;
+    const occupants = tileOccupants(tile.underground, tile.surface, tile.overhead);
+    for (const occupant of iterSet(occupants)) {
+      const key = OCCUPANT_LABEL[occupant];
+      tileCounts[key] = (tileCounts[key] ?? 0) + 1;
+    }
     if (tile.abandoned) abandonedCount++;
   }
 

--- a/app/src/game/tools.test.ts
+++ b/app/src/game/tools.test.ts
@@ -334,13 +334,16 @@ describe('simulation', () => {
     applyTool(state, Tool.Rail, 3, 2);
     applyTool(state, Tool.Rail, 3, 3);
     applyTool(state, Tool.Rail, 3, 4);
-    // draw a road across it, creating a rail underlay
+    // draw a road across it, creating a road underlay — `Rail` outranks
+    // `Road` in `legacyKind`'s precedence regardless of build order, so a
+    // road-last crossing is still spelled `Rail` (see `e2e/visual.spec.ts`'s
+    // "delta 1").
     applyTool(state, Tool.Road, 2, 3);
     applyTool(state, Tool.Road, 3, 3);
     applyTool(state, Tool.Road, 4, 3);
     const crossing = getTile(state, 3, 3)!;
-    expect(crossing.kind).toBe(TileKind.Road);
-    expect(crossing.railUnderlay).toBe(true);
+    expect(crossing.kind).toBe(TileKind.Rail);
+    expect(crossing.roadUnderlay).toBe(true);
 
     applyTool(state, Tool.Bulldoze, 3, 3);
 

--- a/app/src/game/tools.ts
+++ b/app/src/game/tools.ts
@@ -1,13 +1,32 @@
 // tools.ts — applyTool: cost, placement rules, and per-tool handlers.
 //
+// Mirrors `apply_tool` in `crates/city-sim-core/src/commands.rs` — occupant-
+// native, like the Rust it is a test oracle for, since Phase 7 of the strata
+// migration. `applyTool` itself is not reachable from production: the
+// browser/desktop clients send `SimCommand`s to the real Rust engine over
+// the WASM/Tauri bridge (see `CLAUDE.md`'s "SimBridge" section) and this
+// file's only caller is the test suite.
+//
 // (c) Copyright 2026 Liminal HQ, Scott Morris
 // SPDX-License-Identifier: MIT
 
 import { BUILD_COST, PowerPlantType } from './constants';
 import { type BuildingTemplate, getBuildingTemplate, getPowerPlantTemplate } from './buildings/templates';
 import { placeBuilding, removeBuilding } from './buildings/manager';
-import { GameState, Tile, TileKind, getTile, setTile } from './gameState';
-import { resyncTileStrata } from './protocol/legacyProjection';
+import { GameState, Tile, TileKind, bumpTileRevision, getTile } from './gameState';
+import { resyncLegacyFromStrata } from './protocol/legacyProjection';
+import {
+  Occupant,
+  Stratum,
+  Terrain,
+  ZONE_MASK,
+  clearTileStratum,
+  hasOccupant,
+  iterSet,
+  pairConflicts,
+  setTileOccupant,
+  tileOccupants
+} from './protocol/occupants';
 import { Tool } from './toolTypes';
 
 export interface ChangeResult {
@@ -32,39 +51,73 @@ export function getToolCost(tool: Tool): number {
   return BUILD_COST[tool] ?? 0;
 }
 
+function structureKindOf(state: GameState, buildingId: number): TileKind | undefined {
+  const instance = state.buildings.find((b) => b.id === buildingId);
+  return instance ? getBuildingTemplate(instance.templateId)?.tileKind : undefined;
+}
+
+/** Bring `tile`'s shim fields back in sync after an occupant-native mutation. */
+function syncLegacy(state: GameState, tile: Tile): void {
+  resyncLegacyFromStrata(tile, (buildingId) => structureKindOf(state, buildingId));
+}
+
 /**
- * Refuse a footprint that would be stamped over a live hydro line.
+ * The first occupant standing on `tile` that refuses `incoming`, in bit
+ * order. Mirrors `refused_by` in `crates/city-sim-core/src/commands.rs`.
  *
- * Mirrors the `Occupant::PowerLine` half of `place_footprint_building`'s
- * overlap check in `crates/city-sim-core/src/commands.rs`. `placeBuilding`
- * already refuses the `kind === PowerLine` spelling, but a line strung across a
- * *zone* wears `powerOverlay` instead — the zone keeps `kind` — and so does
- * every line that has since been regraded. Three clicks (zone, line, park)
- * therefore stamped a structure straight over live conductors that went on
- * drawing, conducting and billing under it, unreachable by the bulldozer except
- * through the building on top.
- *
- * It lives here rather than in `placeBuilding` because that function is also
- * the zone-growth path, and a lot under a line must still develop.
+ * `OCCUPANT_DEFS`'s conflict table says which pairs cannot share a tile; it
+ * does not say what happens when the player asks for one anyway. Only
+ * refusal needs a guard, so each caller names the conflicts it resolves by
+ * *displacement* in `displaces` and everything left over is refused.
  */
-function refuseHydroSpan(
-  state: GameState,
-  template: BuildingTemplate,
-  x: number,
-  y: number
-): ChangeResult | undefined {
-  const { width, height } = template.footprint;
-  for (let dy = 0; dy < height; dy++) {
-    for (let dx = 0; dx < width; dx++) {
-      if (getTile(state, x + dx, y + dy)?.powerOverlay) {
-        return { success: false, message: 'Cannot build here — clear roads and powerlines first.' };
-      }
-    }
-  }
+function refusedBy(tile: Tile, incoming: Occupant, displaces: number): Occupant | undefined {
+  const standing = tileOccupants(tile.underground, tile.surface, tile.overhead) & ~displaces;
+  return iterSet(standing).find((o) => pairConflicts(o, incoming));
+}
+
+/**
+ * Why a regrade must refuse this tile, if it must. Mirrors `regrade_refusal`.
+ * A live building is the one thing a regrade cannot wipe on the player's
+ * behalf — doing so would leave the `BuildingInstance` running with no tile
+ * under it.
+ */
+function regradeRefusal(tile: Tile | undefined): string | undefined {
+  if (tile?.buildingId !== undefined) return 'A building occupies this tile. Bulldoze first.';
   return undefined;
 }
 
-function placeTemplatedBuilding(
+/**
+ * Rewrite the ground at (x, y): set the terrain, and clear the surface
+ * stratum and the tree canopy — leaving the hydro span and anything buried
+ * standing. Mirrors `regrade_at`.
+ */
+function regradeAt(state: GameState, x: number, y: number, terrain: Terrain): void {
+  const tile = getTile(state, x, y);
+  if (!tile) return;
+  tile.terrain = terrain;
+  clearTileStratum(tile, Stratum.Surface);
+  setTileOccupant(tile, Occupant.Trees, false);
+  bumpTileRevision(state);
+}
+
+/** Remove any building whose footprint covers (x, y). Mirrors `clear_building_at`. */
+function clearBuildingAt(state: GameState, x: number, y: number): void {
+  const tile = getTile(state, x, y);
+  if (tile?.buildingId !== undefined) {
+    removeBuilding(state, tile.buildingId);
+  }
+}
+
+/**
+ * Place a multi-tile civic/power building at (x, y). Mirrors
+ * `place_footprint_building`. The overlap check refuses a developed tile,
+ * and anything the structure conflicts with that it does not simply
+ * displace — the zone tags are displaced (a park stamped over a residential
+ * lot is ordinary play), so what is left of `Occupant::Structure`'s
+ * conflict set is road, rail and the hydro line, all caught by one
+ * `refusedBy` call.
+ */
+function placeFootprintBuilding(
   state: GameState,
   template: BuildingTemplate | undefined,
   x: number,
@@ -72,8 +125,19 @@ function placeTemplatedBuilding(
   cost: number
 ): ChangeResult {
   if (!template) return { success: false, message: 'Unknown building type' };
-  const refusal = refuseHydroSpan(state, template, x, y);
-  if (refusal) return refusal;
+  const { width, height } = template.footprint;
+  for (let dy = 0; dy < height; dy++) {
+    for (let dx = 0; dx < width; dx++) {
+      const tile = getTile(state, x + dx, y + dy);
+      if (!tile) return { success: false, message: 'Invalid tile location' };
+      if (tile.buildingId !== undefined) {
+        return { success: false, message: 'Cannot overlap another building. Bulldoze first.' };
+      }
+      if (refusedBy(tile, Occupant.Structure, ZONE_MASK) !== undefined) {
+        return { success: false, message: 'Cannot build here — clear roads and powerlines first.' };
+      }
+    }
+  }
   const result = placeBuilding(state, template, x, y, (tile, buildingId) => {
     if (template.power) {
       tile.powerPlantType = template.power.type;
@@ -85,263 +149,193 @@ function placeTemplatedBuilding(
   return result;
 }
 
-function placePowerPlant(
-  state: GameState,
-  x: number,
-  y: number,
-  type: PowerPlantType,
-  cost: number
-): ChangeResult {
-  const template = getPowerPlantTemplate(type);
-  return placeTemplatedBuilding(state, template, x, y, cost);
-}
-
-function clearBuildingAt(state: GameState, x: number, y: number) {
-  const tile = getTile(state, x, y);
-  if (tile?.buildingId !== undefined) {
-    removeBuilding(state, tile.buildingId);
-  }
-}
-
-/**
- * Why a regrade must refuse this tile, if it must.
- *
- * Mirrors `regrade_refusal` in `crates/city-sim-core/src/commands.rs`. A live
- * building is the one thing a regrade cannot wipe on the player's behalf: doing
- * so would leave the `BuildingInstance` running with no tile under it, so a
- * ten-credit misclick could take a 25,000-credit plant off the map while it
- * kept producing and billing.
- */
-function regradeRefusal(tile: Tile | undefined): string | undefined {
-  if (tile?.buildingId !== undefined) return 'A building occupies this tile. Bulldoze first.';
-  return undefined;
-}
-
-/**
- * Rewrite the ground at (x, y), taking the surface stratum and the tree canopy
- * with it and leaving the strata above and below standing.
- *
- * Mirrors `regrade_at` in `crates/city-sim-core/src/commands.rs`. `setTile`
- * clears everything indiscriminately, including the overhead hydro line and —
- * were it ever asked to — the buried pipe; the engine keeps both, because a
- * line spans the tile whatever the ground does under it (over water it is the
- * pylon span `docs/tile-model.md` names) and a pipe is at depth. Restoring them
- * afterwards is how this file says `clear_stratum(Surface)` without a stratum
- * of its own to clear.
- */
-function regradeAt(state: GameState, x: number, y: number, spelling: TileKind) {
-  const before = getTile(state, x, y);
-  if (!before) return;
-  const hadLine = before.kind === TileKind.PowerLine || before.powerOverlay === true;
-  const underground = before.legacyUnderground;
-  setTile(state, x, y, spelling);
-  const tile = getTile(state, x, y);
-  if (!tile) return;
-  tile.legacyUnderground = underground;
-  if (hadLine) tile.powerOverlay = true;
-}
-
 /**
  * The three zone brushes, which differ only in the tag they lay down.
- *
- * Mirrors the `Tool::Residential | Tool::Commercial | Tool::Industrial` arm of
- * `apply_tool`. Road, rail and a building are refused; the tree canopy, the
- * water and any previous zone tag are displaced by the regrade; and a hydro
- * line is *not* in the way — a zone and a line share a tile happily in either
- * build order, because they are in different strata.
+ * Mirrors the `Tool::Residential | Tool::Commercial | Tool::Industrial` arm
+ * of `apply_tool`. Re-zoning is a replacement, so the zone tags are
+ * displaced rather than refused — what is left of a zone's conflict set is
+ * road, rail and structure. A developed lot is refused separately:
+ * `refusedBy` cannot see it, since a developed zone lot's occupant is its
+ * zone tag, not `Structure` (see `occupants.ts`'s own note on this).
  */
-function zone({ state, x, y }: ToolContext, cost: number, tag: TileKind): ChangeResult {
+function zone({ state, x, y }: ToolContext, cost: number, zoneOccupant: Occupant): ChangeResult {
   const tile = getTile(state, x, y);
-  if (tile && (tile.kind === TileKind.Road || tile.kind === TileKind.Rail || tile.roadUnderlay || tile.railUnderlay)) {
-    return { success: false, message: 'Cannot zone over roads or rail. Bulldoze first.' };
+  if (!tile) return { success: false };
+  const blocker = refusedBy(tile, zoneOccupant, ZONE_MASK);
+  if (blocker !== undefined) {
+    return {
+      success: false,
+      message:
+        blocker === Occupant.Structure
+          ? 'Cannot zone over a building. Bulldoze first.'
+          : 'Cannot zone over roads or rail. Bulldoze first.'
+    };
   }
-  if (tile?.buildingId !== undefined) {
+  if (tile.buildingId !== undefined) {
     return { success: false, message: 'Cannot zone over a building. Bulldoze first.' };
   }
   state.money -= cost;
-  regradeAt(state, x, y, tag);
+  regradeAt(state, x, y, Terrain.Land);
+  const updated = getTile(state, x, y)!;
+  setTileOccupant(updated, zoneOccupant, true);
+  syncLegacy(state, updated);
   return { success: true };
 }
 
 const registry: ToolRegistry = {
   [Tool.Inspect]: (_ctx, _cost) => ({ success: true }),
+
   // The three terrain brushes regrade the ground through one gate — see
-  // `regradeRefusal` and `regradeAt`. They used to be a bare `setTile`, which
-  // made them the only tools that could take a live building off the map
-  // without removing it, and which erased the hydro span overhead.
+  // `regradeRefusal` and `regradeAt`. The water brush is `TerraformLower` at
+  // a different price, regraded through the same gate.
   [Tool.TerraformRaise]: ({ state, x, y }, cost) => {
     const refusal = regradeRefusal(getTile(state, x, y));
     if (refusal) return { success: false, message: refusal };
     state.money -= cost;
-    regradeAt(state, x, y, TileKind.Land);
+    regradeAt(state, x, y, Terrain.Land);
+    syncLegacy(state, getTile(state, x, y)!);
     return { success: true };
   },
   [Tool.TerraformLower]: ({ state, x, y }, cost) => {
     const refusal = regradeRefusal(getTile(state, x, y));
     if (refusal) return { success: false, message: refusal };
     state.money -= cost;
-    regradeAt(state, x, y, TileKind.Water);
+    regradeAt(state, x, y, Terrain.Water);
+    syncLegacy(state, getTile(state, x, y)!);
     return { success: true };
   },
   [Tool.Water]: ({ state, x, y }, cost) => {
     const refusal = regradeRefusal(getTile(state, x, y));
     if (refusal) return { success: false, message: refusal };
     state.money -= cost;
-    regradeAt(state, x, y, TileKind.Water);
+    regradeAt(state, x, y, Terrain.Water);
+    syncLegacy(state, getTile(state, x, y)!);
     return { success: true };
   },
   [Tool.Tree]: ({ state, x, y }, cost) => {
     // Planting clears the ground it plants on and leaves the hydro span
-    // standing — `known_defect_trees_are_planted_through_a_live_hydro_line`
-    // in `commands.rs`. The one refusal is against stranding a live building.
+    // standing — a tree planted over a live line still produces
+    // `{Trees, PowerLine}` (`known_defect_trees_are_planted_through_a_live_hydro_line`
+    // in `commands.rs`). The one refusal is against stranding a live building.
     const tile = getTile(state, x, y);
     if (tile?.buildingId !== undefined) {
       return { success: false, message: 'A building occupies this tile. Bulldoze first.' };
     }
     state.money -= cost;
-    regradeAt(state, x, y, TileKind.Tree);
+    regradeAt(state, x, y, Terrain.Land);
+    const updated = getTile(state, x, y)!;
+    setTileOccupant(updated, Occupant.Trees, true);
+    syncLegacy(state, updated);
     return { success: true };
   },
   [Tool.Road]: ({ state, x, y }, cost) => {
     const tile = getTile(state, x, y);
     if (tile?.buildingId !== undefined) return { success: false, message: 'Bulldoze the building first.' };
+    const hadRail = tile !== undefined && hasOccupant(tile.surface, Occupant.Rail);
+    clearBuildingAt(state, x, y);
     state.money -= cost;
-    const hadRail = tile?.kind === TileKind.Rail || tile?.railUnderlay;
-    // A hydro line survives a road laid across it, exactly as a rail does, and
-    // the tile is recorded the one canonical way — kind `PowerLine` with the
-    // road beneath, identical to building them in the other order. Mirrors
-    // `Tool::Road` in `crates/city-sim-core/src/commands.rs`.
-    const hadLine = tile?.kind === TileKind.PowerLine || tile?.powerOverlay;
-    setTile(state, x, y, hadLine ? TileKind.PowerLine : TileKind.Road);
-    const updated = getTile(state, x, y);
-    if (updated && hadRail) updated.railUnderlay = true; // remember rail for render/crossing
-    if (updated && hadLine) {
-      updated.roadUnderlay = true;
-      updated.powerOverlay = true;
-    }
+    // A hydro line survives a road laid across it, exactly as a rail does —
+    // the overhead stratum is not the surface, so there is nothing left to
+    // arbitrate. `regradeAt` is what takes the zone tag, the canopy and the
+    // water under the carriageway.
+    regradeAt(state, x, y, Terrain.Land);
+    const updated = getTile(state, x, y)!;
+    setTileOccupant(updated, Occupant.Road, true);
+    setTileOccupant(updated, Occupant.Rail, hadRail);
+    syncLegacy(state, updated);
     return { success: true };
   },
   [Tool.Rail]: ({ state, x, y }, cost) => {
     const tile = getTile(state, x, y);
     if (tile?.buildingId !== undefined) return { success: false, message: 'Bulldoze the building first.' };
+    const hadRoad = tile !== undefined && hasOccupant(tile.surface, Occupant.Road);
+    clearBuildingAt(state, x, y);
     state.money -= cost;
-    const hadRoad = tile?.kind === TileKind.Road || tile?.roadUnderlay;
-    const hadLine = tile?.kind === TileKind.PowerLine || tile?.powerOverlay;
-    setTile(state, x, y, hadLine ? TileKind.PowerLine : TileKind.Rail);
-    const updated = getTile(state, x, y);
-    if (updated && hadRoad) updated.roadUnderlay = true; // rail over road
-    if (updated && hadLine) {
-      updated.railUnderlay = true;
-      updated.powerOverlay = true;
-    }
+    // Mirrors `Tool::Road` above.
+    regradeAt(state, x, y, Terrain.Land);
+    const updated = getTile(state, x, y)!;
+    setTileOccupant(updated, Occupant.Rail, true);
+    setTileOccupant(updated, Occupant.Road, hadRoad);
+    syncLegacy(state, updated);
     return { success: true };
   },
   [Tool.PowerLine]: ({ state, x, y }, cost) => {
     const tile = getTile(state, x, y);
     if (tile?.buildingId !== undefined) return { success: false, message: 'Bulldoze the building first.' };
+    clearBuildingAt(state, x, y);
     state.money -= cost;
-    // Powerlines pass through zones as an overlay — zone tiles keep their kind.
-    if (tile?.kind === TileKind.Residential || tile?.kind === TileKind.Commercial || tile?.kind === TileKind.Industrial) {
-      tile.powerOverlay = true;
-      return { success: true };
-    }
-    const hadRoad = tile?.kind === TileKind.Road || tile?.roadUnderlay;
-    const hadRail = tile?.kind === TileKind.Rail || tile?.railUnderlay;
-    setTile(state, x, y, TileKind.PowerLine);
-    const updated = getTile(state, x, y);
-    if (updated && hadRoad) updated.roadUnderlay = true;
-    if (updated && hadRail) updated.railUnderlay = true;
-    if (updated) updated.powerOverlay = true;
+    const updated = getTile(state, x, y)!;
+    // The surface is untouched: a line strung across a zone, a road or a
+    // rail leaves all of them standing — there is no `kind` slot left to
+    // arbitrate. The canopy does not survive: utilities trim trees away from
+    // conductors, which is also what `Occupant::PowerLine`'s conflict set
+    // says.
+    updated.terrain = Terrain.Land;
+    setTileOccupant(updated, Occupant.PowerLine, true);
+    setTileOccupant(updated, Occupant.Trees, false);
+    bumpTileRevision(state);
+    syncLegacy(state, updated);
     return { success: true };
   },
   [Tool.HydroPlant]: ({ state, x, y }, cost) =>
-    placePowerPlant(state, x, y, PowerPlantType.Hydro, cost),
+    placeFootprintBuilding(state, getPowerPlantTemplate(PowerPlantType.Hydro), x, y, cost),
   [Tool.CoalPlant]: ({ state, x, y }, cost) =>
-    placePowerPlant(state, x, y, PowerPlantType.Coal, cost),
+    placeFootprintBuilding(state, getPowerPlantTemplate(PowerPlantType.Coal), x, y, cost),
   [Tool.WindTurbine]: ({ state, x, y }, cost) =>
-    placePowerPlant(state, x, y, PowerPlantType.Wind, cost),
+    placeFootprintBuilding(state, getPowerPlantTemplate(PowerPlantType.Wind), x, y, cost),
   [Tool.SolarFarm]: ({ state, x, y }, cost) =>
-    placePowerPlant(state, x, y, PowerPlantType.Solar, cost),
+    placeFootprintBuilding(state, getPowerPlantTemplate(PowerPlantType.Solar), x, y, cost),
   [Tool.WaterPump]: ({ state, x, y }, cost) =>
-    placeTemplatedBuilding(state, getBuildingTemplate(TileKind.WaterPump), x, y, cost),
+    placeFootprintBuilding(state, getBuildingTemplate(TileKind.WaterPump), x, y, cost),
   [Tool.WaterTower]: ({ state, x, y }, cost) =>
-    placeTemplatedBuilding(state, getBuildingTemplate(TileKind.WaterTower), x, y, cost),
+    placeFootprintBuilding(state, getBuildingTemplate(TileKind.WaterTower), x, y, cost),
   [Tool.WaterPipe]: ({ state, x, y }, cost) => {
     state.money -= cost;
     const tile = getTile(state, x, y);
     if (tile) {
-      tile.legacyUnderground = TileKind.WaterPipe;
+      // Underground doesn't affect the zone-growth cache, so — mirroring
+      // `Tool::WaterPipe` in `commands.rs` — this deliberately does not bump
+      // `tileRevision`.
+      setTileOccupant(tile, Occupant.Pipe, true);
+      syncLegacy(state, tile);
     }
     return { success: true };
   },
   [Tool.ElementarySchool]: ({ state, x, y }, cost) =>
-    placeTemplatedBuilding(state, getBuildingTemplate(TileKind.ElementarySchool), x, y, cost),
+    placeFootprintBuilding(state, getBuildingTemplate(TileKind.ElementarySchool), x, y, cost),
   [Tool.HighSchool]: ({ state, x, y }, cost) =>
-    placeTemplatedBuilding(state, getBuildingTemplate(TileKind.HighSchool), x, y, cost),
-  [Tool.Residential]: (ctx, cost) => zone(ctx, cost, TileKind.Residential),
-  [Tool.Commercial]: (ctx, cost) => zone(ctx, cost, TileKind.Commercial),
-  [Tool.Industrial]: (ctx, cost) => zone(ctx, cost, TileKind.Industrial),
+    placeFootprintBuilding(state, getBuildingTemplate(TileKind.HighSchool), x, y, cost),
+  [Tool.Residential]: (ctx, cost) => zone(ctx, cost, Occupant.ZoneResidential),
+  [Tool.Commercial]: (ctx, cost) => zone(ctx, cost, Occupant.ZoneCommercial),
+  [Tool.Industrial]: (ctx, cost) => zone(ctx, cost, Occupant.ZoneIndustrial),
   [Tool.Park]: ({ state, x, y }, cost) =>
-    placeTemplatedBuilding(state, getBuildingTemplate(TileKind.Park), x, y, cost),
+    placeFootprintBuilding(state, getBuildingTemplate(TileKind.Park), x, y, cost),
   [Tool.ParkLarge]: ({ state, x, y }, cost) =>
-    placeTemplatedBuilding(state, getBuildingTemplate(TileKind.ParkLarge), x, y, cost),
+    placeFootprintBuilding(state, getBuildingTemplate(TileKind.ParkLarge), x, y, cost),
   [Tool.Bulldoze]: ({ state, x, y }, cost) => {
+    // Mirrors `bulldoze` in `commands.rs`: a live building goes first: then
+    // the buried pipe, reached from either view — the engine has no notion
+    // of which minimap mode is open; then what stands on the ground —
+    // surface and overhead together — leaving the ground itself exactly as
+    // it was (terrain is deliberately absent from this list, see #177 step 4).
     const tile = getTile(state, x, y);
     if (!tile) return { success: false };
-
-    if (state.settings.minimap.mode === 'underground') {
-      if (tile.legacyUnderground) {
-        state.money -= cost;
-        tile.legacyUnderground = undefined;
-        return { success: true };
-      }
-      return { success: true }; // Nothing to bulldoze underground
-    }
-
     state.money -= cost;
     if (tile.buildingId !== undefined) {
       removeBuilding(state, tile.buildingId);
-    } else if (tile.legacyUnderground !== undefined) {
-      // The engine reaches the buried pipe *before* the surface — `bulldoze`
-      // in `commands.rs` tests `building_id`, then `underground`, then the
-      // surface, and it has no notion of which minimap view is open. So a
-      // click on a road with a pipe under it takes the pipe and leaves the
-      // road. Mirrored here rather than corrected: `commands.rs` is canonical.
-      tile.legacyUnderground = undefined;
+    } else if (tile.underground !== 0) {
+      clearTileStratum(tile, Stratum.Underground);
+      syncLegacy(state, tile);
     } else {
-      // The bulldozer clears what stands on the ground — surface and overhead
-      // together — and leaves the ground itself exactly as it was (#177 step
-      // 4). It used to write `Land` unconditionally, so one credit filled in a
-      // lake that cost twelve to dig: the cheapest tool on the palette was
-      // also the most powerful terraformer.
-      setTile(state, x, y, tile.kind === TileKind.Water ? TileKind.Water : TileKind.Land);
-      // `abandoned` describes a lot that no longer exists.
-      getTile(state, x, y)!.abandoned = false;
+      clearTileStratum(tile, Stratum.Surface);
+      clearTileStratum(tile, Stratum.Overhead);
+      tile.abandoned = false;
+      bumpTileRevision(state);
+      syncLegacy(state, tile);
     }
     return { success: true };
   }
 };
-
-/**
- * Bring every tile's strata fields (`terrain`/`underground`/`surface`/
- * `overhead`/`density`) back in sync with its shim fields (`kind`/
- * `roadUnderlay`/`railUnderlay`/`powerOverlay`/`legacyUnderground`).
- *
- * This file's own handlers above are unconverted v4-shape logic — mirroring
- * `commands.rs` as it was *before* its own occupant migration, since
- * rewriting them to match `commands.rs` as it is now is Phase 7's job, not
- * this phase's. Until then, every tool mutates only the shim fields, so
- * anything reading the real strata directly (`adjacency.ts` since Phase 4)
- * would see stale zeros without this resync — whole-grid rather than
- * targeted, since a footprint building or a regrade can touch tiles this
- * function has no cheap way to enumerate ahead of time. Test-only, never on
- * the production hot path, so an O(tiles) pass per call is free.
- */
-function syncStrataFromLegacy(state: GameState): void {
-  for (const tile of state.tiles) {
-    resyncTileStrata(tile);
-  }
-}
 
 export function applyTool(state: GameState, tool: Tool, x: number, y: number): ChangeResult {
   const tile = getTile(state, x, y);
@@ -353,7 +347,5 @@ export function applyTool(state: GameState, tool: Tool, x: number, y: number): C
 
   const handler = registry[tool];
   if (!handler) return { success: false };
-  const result = handler({ state, tile, x, y }, cost);
-  syncStrataFromLegacy(state);
-  return result;
+  return handler({ state, tile, x, y }, cost);
 }


### PR DESCRIPTION
## Summary

- **`tools.ts` is occupant-native** — `applyTool`'s handlers no longer hand-roll `kind`+flags precedence; they mirror `commands.rs`'s current `apply_tool` directly (`refusedBy`/`regradeAt` port `refused_by`/`regrade_at`, new `setTileOccupant`/`clearTileStratum`/`pairConflicts` helpers in `occupants.ts` do the mutation). `refuseHydroSpan` is gone — `refusedBy(tile, Structure, ZONE_MASK)` catches a hydro line the same unified way `refused_by` does.
- **Two real oracle-drift bugs fixed** — the old `regradeAt` bumped tile happiness by +0.05 on every terrain/infrastructure tool (via `setTile`), which `commands.rs`'s `regrade_at` doesn't do; and `Tool::Bulldoze` only reached a buried pipe when `state.settings.minimap.mode === 'underground'`, a UI concept `commands.rs`'s `bulldoze` has no notion of. Both now match Rust exactly.
- **Shim fields stay live** — new `resyncLegacyFromStrata` (the inverse of `resyncTileStrata`) derives `kind`/`roadUnderlay`/`railUnderlay`/`powerOverlay`/`legacyUnderground` from the strata after each tool, so `buildings/manager.ts`'s still-shim-reading placement guard keeps working unchanged. The old whole-grid `syncStrataFromLegacy` pass is gone; each handler syncs only what it touched.
- **`simulation.ts`** reads occupant bits for zone tallies, growth candidates and maintenance billing; deletes a dead civic-billing branch that's structurally unreachable under the current `legacyKind` derivation.
- **`stateHash.ts`** buckets `tileCounts` by occupant instead of by the old flattened `kind` — more precise, since one tile can now land in several buckets. `regression.test.ts` updated to match.
- **`parity/tileFacts.ts`** is now `factsFromTile(strata)` instead of `factsFromWire(kind, flags, buildingId, underground)` — reads occupant bits directly rather than through a resolved v4 kind first, letting `parity/engines.ts`'s Rust-side adapter drop a `legacyKind`/`legacyFlags` round-trip it only existed to feed the old signature.
- One stale test assertion fixed in `tools.test.ts` (a road-last crossing's `kind` was asserted as the old v4 precedence winner; the current precedence — already pinned by `e2e/visual.spec.ts`'s "delta 1" — is different).

None of `tools.ts`/`simulation.ts`/`stateHash.ts`/`parity/*` are reachable from production; the browser/desktop clients talk to the real Rust engine over the WASM/Tauri bridge. Everything here is oracle fidelity, not user-facing behavior.

## Test plan

- [x] `bun run lint`
- [x] `bun run test` — 352 tests (one stale assertion updated, no other changes needed)
- [x] `bun run test:parity` — 42 cross-engine parity tests
- [x] `bun run test:e2e` — all 15 tests, visual-regression golden PNGs byte-unchanged
