### PR TITLE
Delete the kind/roadUnderlay/railUnderlay/powerOverlay/legacyUnderground shim from Tile

### DIFF
--- a/app/src/game/adjacency.test.ts
+++ b/app/src/game/adjacency.test.ts
@@ -8,7 +8,7 @@ import { createInitialState, getTile, setTile, TileKind } from './gameState';
 import { Tool } from './toolTypes';
 import { applyTool } from './tools';
 import { recomputePowerNetwork } from './utilities/power';
-import { resyncTileStrata as resyncStrata } from './protocol/legacyProjection';
+import { Occupant, Terrain, hasOccupant, setTileOccupant } from './protocol/occupants';
 import {
   hasRoadAccess,
   isPowerCarrier,
@@ -40,8 +40,8 @@ describe('adjacency — road access is roads only', () => {
     applyTool(state, Tool.PowerLine, 1, 0);
 
     const line = getTile(state, 1, 0)!;
-    expect(line.kind).toBe(TileKind.PowerLine);
-    expect(line.roadUnderlay).toBeUndefined(); // no road under this line
+    expect(hasOccupant(line.overhead, Occupant.PowerLine)).toBe(true);
+    expect(hasOccupant(line.surface, Occupant.Road)).toBe(false); // no road under this line
 
     expect(hasRoadAccess(state, 0, 0)).toBe(false);
   });
@@ -57,8 +57,9 @@ describe('adjacency — road access is roads only', () => {
     applyTool(lineFirst, Tool.Residential, 0, 0);
     applyTool(lineFirst, Tool.PowerLine, 1, 0);
     applyTool(lineFirst, Tool.Road, 1, 0);
-    expect(getTile(lineFirst, 1, 0)?.kind).toBe(TileKind.PowerLine);
-    expect(getTile(lineFirst, 1, 0)?.roadUnderlay).toBe(true);
+    const lineFirstTile = getTile(lineFirst, 1, 0)!;
+    expect(hasOccupant(lineFirstTile.overhead, Occupant.PowerLine)).toBe(true);
+    expect(hasOccupant(lineFirstTile.surface, Occupant.Road)).toBe(true);
     expect(hasRoadAccess(lineFirst, 0, 0)).toBe(true);
 
     const roadFirst = createInitialState(4, 3);
@@ -70,18 +71,18 @@ describe('adjacency — road access is roads only', () => {
   });
 
   /**
-   * A road hidden under a hydro *overlay* — the spelling the engine sends over
-   * the wire when a tree or a flood rewrites `kind` and leaves the overlay
-   * standing. No `kind`-only test could see this tile.
+   * A road standing underneath tree canopy and a hydro line all at once — not
+   * reachable through any tool sequence (`Tool.Road`'s `regradeAt` always
+   * clears the canopy), but a real combination the wire can carry, so
+   * `hasRoadAccess` must still see the road through it.
    */
-  it('grants road access through a road underlay beneath a power overlay', () => {
+  it('grants road access through a road buried under trees and a hydro line', () => {
     const state = createInitialState(3, 3);
     applyTool(state, Tool.Residential, 0, 0);
     const neighbour = getTile(state, 1, 0)!;
-    neighbour.kind = TileKind.Tree;
-    neighbour.roadUnderlay = true;
-    neighbour.powerOverlay = true;
-    resyncStrata(neighbour);
+    setTileOccupant(neighbour, Occupant.Road, true);
+    setTileOccupant(neighbour, Occupant.Trees, true);
+    setTileOccupant(neighbour, Occupant.PowerLine, true);
 
     expect(hasRoadAccess(state, 0, 0)).toBe(true);
   });
@@ -125,15 +126,16 @@ describe('adjacency — a hydro line conducts in either spelling', () => {
     state.money = 50000;
     applyTool(state, Tool.PowerLine, 1, 1);
     const tile = getTile(state, 1, 1)!;
-    expect(tile.powerOverlay).toBe(true);
+    expect(hasOccupant(tile.overhead, Occupant.PowerLine)).toBe(true);
 
-    // A tree planted over the line: the engine rewrites `kind` and the overlay
-    // survives, so this is exactly what the display mirror receives.
-    tile.kind = TileKind.Tree;
+    // A tree planted over the line: the canopy joins the overhead stratum and
+    // the line survives — `known_defect_trees_are_planted_through_a_live_hydro_line`.
+    setTileOccupant(tile, Occupant.Trees, true);
     expect(isPowerCarrier(tile)).toBe(true);
 
     // Flooding it is the same story.
-    tile.kind = TileKind.Water;
+    setTileOccupant(tile, Occupant.Trees, false);
+    tile.terrain = Terrain.Water;
     expect(isPowerCarrier(tile)).toBe(true);
   });
 
@@ -145,10 +147,9 @@ describe('adjacency — a hydro line conducts in either spelling', () => {
     const state = createInitialState(3, 3);
     applyTool(state, Tool.Residential, 0, 0);
     const neighbour = getTile(state, 1, 0)!;
-    neighbour.kind = TileKind.Tree;
-    neighbour.powerOverlay = true;
+    setTileOccupant(neighbour, Occupant.Trees, true);
+    setTileOccupant(neighbour, Occupant.PowerLine, true);
     neighbour.powered = true;
-    resyncStrata(neighbour);
 
     expect(tileHasPower(state, 0, 0)).toBe(true);
   });
@@ -166,8 +167,8 @@ describe('adjacency — a hydro line conducts in either spelling', () => {
       applyTool(state, Tool.PowerLine, x, 0);
     }
     const buried = getTile(state, 3, 0)!;
-    buried.kind = TileKind.Tree; // overlay stands, kind is overwritten
-    expect(buried.powerOverlay).toBe(true);
+    setTileOccupant(buried, Occupant.Trees, true); // canopy joins the line, doesn't replace it
+    expect(hasOccupant(buried.overhead, Occupant.PowerLine)).toBe(true);
 
     recomputePowerNetwork(state);
     expect(getTile(state, 5, 0)?.powered).toBe(true);
@@ -190,7 +191,7 @@ describe('adjacency — water carriers exclude hydro lines', () => {
     expect(isPowerCarrier(tile)).toBe(true);
     expect(isWaterCarrier(tile)).toBe(false);
 
-    tile.kind = TileKind.Tree; // overlay-only spelling
+    setTileOccupant(tile, Occupant.Trees, true); // canopy joins the line, doesn't replace it
     expect(isPowerCarrier(tile)).toBe(true);
     expect(isWaterCarrier(tile)).toBe(false);
   });
@@ -200,8 +201,7 @@ describe('adjacency — water carriers exclude hydro lines', () => {
     state.money = 50000;
 
     const piped = getTile(state, 0, 0)!;
-    piped.legacyUnderground = TileKind.WaterPipe;
-    resyncStrata(piped);
+    setTileOccupant(piped, Occupant.Pipe, true);
     expect(isWaterCarrier(piped)).toBe(true);
 
     applyTool(state, Tool.Road, 1, 0);
@@ -214,9 +214,9 @@ describe('adjacency — water carriers exclude hydro lines', () => {
     expect(isWaterCarrier(getTile(state, 3, 0))).toBe(true);
 
     // A road that later had a line strung over it keeps carrying water, because
-    // the road survives as an underlay.
+    // the road survives on the surface — the line lives overhead.
     applyTool(state, Tool.PowerLine, 1, 0);
-    expect(getTile(state, 1, 0)?.roadUnderlay).toBe(true);
+    expect(hasOccupant(getTile(state, 1, 0)!.surface, Occupant.Road)).toBe(true);
     expect(isWaterCarrier(getTile(state, 1, 0))).toBe(true);
 
     // Bare land carries nothing.

--- a/app/src/game/buildings.test.ts
+++ b/app/src/game/buildings.test.ts
@@ -71,9 +71,17 @@ describe('buildings state machine', () => {
 
   it('rebuilds legacy civic tiles into building instances on load', () => {
     const state = createInitialState(4, 4);
-    const tile = getTile(state, 1, 1)!;
-    tile.kind = TileKind.WaterPump;
-    const restored = deserialize(serialize(state));
+    // Simulate a pre-migration save: `deserialize` branches on `terrain` being
+    // absent to decode a v4-shaped tile, so a live `Tile` (which has no `kind`
+    // field any more) can't stand in for one — spell the raw JSON directly.
+    const json = JSON.parse(serialize(state));
+    const idx = 1 * state.width + 1;
+    delete json.tiles[idx].terrain;
+    delete json.tiles[idx].underground;
+    delete json.tiles[idx].surface;
+    delete json.tiles[idx].overhead;
+    json.tiles[idx].kind = TileKind.WaterPump;
+    const restored = deserialize(JSON.stringify(json));
     const pumpTile = getTile(restored, 1, 1)!;
     expect(pumpTile.buildingId).toBeDefined();
     const building = restored.buildings.find((b) => b.id === pumpTile.buildingId);

--- a/app/src/game/buildings/manager.ts
+++ b/app/src/game/buildings/manager.ts
@@ -1,7 +1,25 @@
 import { PowerPlantType } from '../constants';
-import { GameState, Tile, getTile, TileKind } from '../gameState';
+import { GameState, Tile, TileKind, bumpTileRevision, getTile } from '../gameState';
 import { tileHasPower, tileHasWater } from '../adjacency';
-import { resyncTileStrata } from '../protocol/legacyProjection';
+import {
+  Occupant,
+  Stratum,
+  Terrain,
+  ZONE_MASK,
+  clearTileStratum,
+  hasOccupant,
+  iterSet,
+  pairConflicts,
+  setTileOccupant,
+  tileOccupants
+} from '../protocol/occupants';
+
+/** The zone tag a lot must carry to develop into `kind`. Mirrors `zone_template_kind`'s inverse in `occupants.rs`. */
+const ZONE_OCCUPANT_FOR_KIND: Partial<Record<TileKind, Occupant>> = {
+  [TileKind.Residential]: Occupant.ZoneResidential,
+  [TileKind.Commercial]: Occupant.ZoneCommercial,
+  [TileKind.Industrial]: Occupant.ZoneIndustrial
+};
 import { BuildingTemplate, getBuildingTemplate, getPowerPlantTemplate } from './templates';
 import { BuildingInstance, createBuildingState, BuildingStatus } from './state';
 
@@ -11,6 +29,28 @@ export interface BuildingPlacementResult {
   instance?: BuildingInstance;
 }
 
+/**
+ * The first occupant standing on `tile` that refuses `incoming`, in bit
+ * order. Mirrors `refused_by` in `crates/city-sim-core/src/commands.rs` —
+ * same helper `tools.ts` ports for its own placement guards.
+ */
+function refusedBy(tile: Tile, incoming: Occupant, displaces: number): Occupant | undefined {
+  const standing = tileOccupants(tile.underground, tile.surface, tile.overhead) & ~displaces;
+  return iterSet(standing).find((o) => pairConflicts(o, incoming));
+}
+
+/**
+ * Place a multi-tile civic/power building's footprint. Mirrors
+ * `place_footprint_building` in `commands.rs`: regrades every covered tile
+ * to `Terrain::Land` with an empty surface, then stamps `Occupant::Structure`
+ * and the shared `buildingId` — the zone tags are displaced (a park stamped
+ * over a residential lot is ordinary play), so what's left of `Structure`'s
+ * conflict set is road, rail and a hydro line, all caught by one
+ * `refusedBy` call.
+ *
+ * Not for zone growth: a developed zone lot's occupant is its zone tag, not
+ * `Structure` (`occupants.ts`'s own note on this) — see `placeZoneBuilding`.
+ */
 export function placeBuilding(
   state: GameState,
   template: BuildingTemplate,
@@ -30,19 +70,10 @@ export function placeBuilding(
       if (!tile) {
         return { success: false, message: 'Invalid tile location' };
       }
-      if (tile.buildingId !== undefined || tile.powerPlantType) {
+      if (tile.buildingId !== undefined) {
         return { success: false, message: 'Cannot overlap another building. Bulldoze first.' };
       }
-      // A hydro line recorded in `powerOverlay` rather than `kind` is refused
-      // one level up, in `refuseHydroSpan` in `tools.ts` — not here. This
-      // function is also the zone-growth path (`spawnZoneBuildings` in
-      // `simulation.ts` calls it to develop a lot), and a lot under a line
-      // develops perfectly happily; the engine's guard is in
-      // `place_footprint_building`, which only the structure tools reach.
-      if (
-        tile.kind === TileKind.Road || tile.kind === TileKind.Rail ||
-        tile.kind === TileKind.PowerLine || tile.roadUnderlay || tile.railUnderlay
-      ) {
+      if (refusedBy(tile, Occupant.Structure, ZONE_MASK) !== undefined) {
         return { success: false, message: 'Cannot build here — clear roads and powerlines first.' };
       }
       tiles.push(tile);
@@ -59,14 +90,56 @@ export function placeBuilding(
   state.buildings.push(instance);
 
   for (const tile of tiles) {
-    tile.kind = template.tileKind;
+    tile.terrain = Terrain.Land;
+    clearTileStratum(tile, Stratum.Surface);
+    setTileOccupant(tile, Occupant.Trees, false);
+    setTileOccupant(tile, Occupant.Structure, true);
     tile.buildingId = buildingId;
     tile.abandoned = false;
     tile.powerPlantId = undefined;
     tile.happiness = Math.min(1.5, tile.happiness + 0.05);
     decorateTile?.(tile, buildingId);
-    resyncTileStrata(tile);
   }
+  bumpTileRevision(state);
+
+  state.nextBuildingId = buildingId + 1;
+  return { success: true, instance };
+}
+
+/**
+ * Develop an already-zoned lot into a building. Mirrors `place_zone_building`
+ * in `crates/city-sim-core/src/zones.rs` — the zone-growth counterpart to
+ * `placeBuilding`, and deliberately much smaller: unlike a footprint
+ * building, developing a lot touches no occupant bit at all. The zone tag
+ * a player painted stays exactly as it was; only `buildingId` changes, which
+ * is why a developed lot's occupant is still its zone tag and not
+ * `Structure`.
+ */
+export function placeZoneBuilding(state: GameState, kind: TileKind, x: number, y: number): BuildingPlacementResult {
+  const tile = getTile(state, x, y);
+  if (!tile) return { success: false, message: 'Invalid tile location' };
+  if (tile.buildingId !== undefined) {
+    return { success: false, message: 'Cannot overlap another building. Bulldoze first.' };
+  }
+  const zoneOccupant = ZONE_OCCUPANT_FOR_KIND[kind];
+  if (zoneOccupant === undefined || !hasOccupant(tile.surface, zoneOccupant)) {
+    return { success: false, message: 'Tile is not zoned for this building type' };
+  }
+  const template = getBuildingTemplate(kind);
+  if (!template) return { success: false, message: 'Unknown building type' };
+
+  const buildingId = state.nextBuildingId ?? 1;
+  const instance: BuildingInstance = {
+    id: buildingId,
+    templateId: template.id,
+    origin: { x, y },
+    state: createBuildingState()
+  };
+  state.buildings.push(instance);
+
+  tile.buildingId = buildingId;
+  tile.abandoned = false;
+  bumpTileRevision(state);
 
   state.nextBuildingId = buildingId + 1;
   return { success: true, instance };
@@ -76,14 +149,19 @@ export function removeBuilding(state: GameState, buildingId: number) {
   state.buildings = (state.buildings || []).filter((b) => b.id !== buildingId);
   for (const tile of state.tiles) {
     if (tile.buildingId === buildingId) {
-      tile.kind = TileKind.Land;
+      // The `Structure` tag goes with the development — it is unrepresentable
+      // without a `buildingId` behind it (`occupants.ts`'s own note). A
+      // developed zone lot has no `Structure` bit to clear in the first
+      // place, so this is a no-op for it: the zone tag survives untouched
+      // and the lot regrows, mirroring `remove_building` in `commands.rs`.
+      setTileOccupant(tile, Occupant.Structure, false);
       tile.buildingId = undefined;
       tile.powerPlantType = undefined;
       tile.powerPlantId = undefined;
       tile.happiness = Math.min(1.5, tile.happiness + 0.05);
-      resyncTileStrata(tile);
     }
   }
+  bumpTileRevision(state);
 }
 
 export function updateBuildingStates(state: GameState, options: { waterEnabled?: boolean } = {}) {

--- a/app/src/game/debugStats.ts
+++ b/app/src/game/debugStats.ts
@@ -87,12 +87,8 @@ export function getSimulationDebugStats(state: GameState): SimulationDebugStats 
   const elementaryCoverage = state.education?.elementaryCoverage ?? 0;
   const highCoverage = state.education?.highCoverage ?? 0;
 
-  const pumpTemplate = getBuildingTemplate(TileKind.WaterPump);
-
   for (let index = 0; index < state.tiles.length; index++) {
     const tile = state.tiles[index];
-    const tileX = index % state.width;
-    const tileY = Math.floor(index / state.width);
     if (hasOccupant(tile.surface, Occupant.ZoneResidential)) {
       residentialZones++;
       if (tile.buildingId !== undefined) developedResidentialZones++;
@@ -104,22 +100,6 @@ export function getSimulationDebugStats(state: GameState): SimulationDebugStats 
     if (hasOccupant(tile.surface, Occupant.ZoneIndustrial)) {
       industrialZones++;
       if (tile.buildingId !== undefined) developedIndustrialZones++;
-    }
-
-    // A pump whose `Structure` occupant never got a development behind it —
-    // unrepresentable in the strata model by design (see `docs/tile-model.md`),
-    // so this reads the shim `kind` deliberately: it is the only field a
-    // pre-migration save artifact like this can still be spelled in.
-    const isLegacyPump = tile.buildingId === undefined && tile.kind === TileKind.WaterPump;
-    if (isLegacyPump && pumpTemplate) {
-      const active = pumpTemplate.requiresPower === false ? true : tile.powered;
-      if (
-        active &&
-        pumpTemplate.waterOutput &&
-        hasWaterSourceConnection(state, { x: tileX, y: tileY }, { width: 1, height: 1 })
-      ) {
-        buildingWaterOutput += pumpTemplate.waterOutput;
-      }
     }
   }
 

--- a/app/src/game/gameState.ts
+++ b/app/src/game/gameState.ts
@@ -8,7 +8,7 @@ import { BylawState, DEFAULT_BYLAWS } from './bylaws';
 import { createDefaultPolicies, type Policies } from './protocol/commands';
 import { defaultHotkeys, type HotkeyBindings } from '../ui/hotkeys';
 import { createDefaultSfxOverrides, type SfxOverrides } from './sfxOverrides';
-import { Terrain, ZoneDensity } from './protocol/occupants';
+import { Occupant, Terrain, ZoneDensity, withOccupant } from './protocol/occupants';
 import type { BudgetHistory } from './economy';
 import type { EducationStats } from './education';
 import type { BuildingInstance } from './buildings/state';
@@ -40,26 +40,11 @@ export enum TileKind {
 }
 
 export interface Tile {
-  kind: TileKind;
   elevation: number;
   happiness: number;
   powered: boolean;
   watered: boolean;
   abandoned?: boolean;
-  /**
-   * @deprecated shim field, renamed from `underground` (now the strata
-   * field below) to avoid a name collision. Populated from `underground`/
-   * `Occupant.Pipe` by `wasmSimBridge.ts`/`tauriSimBridge.ts` during the
-   * strangler window — removed once every consumer reads the strata fields
-   * directly.
-   */
-  legacyUnderground?: TileKind;
-  /** @deprecated shim field — see `legacyUnderground`'s note. */
-  roadUnderlay?: boolean;
-  /** @deprecated shim field — see `legacyUnderground`'s note. */
-  railUnderlay?: boolean;
-  /** @deprecated shim field — see `legacyUnderground`'s note. */
-  powerOverlay?: boolean;
   powerPlantType?: PowerPlantType;
   powerPlantId?: number;
   buildingId?: number;
@@ -345,7 +330,6 @@ export function createInitialState(width = 64, height = 64, seed?: number): Game
       const isWater = (x - width / 2) ** 2 + (y - height / 2) ** 2 < 180 && (x + y) % 5 === 0;
       const water = edge || isWater;
       tiles.push({
-        kind: water ? TileKind.Water : TileKind.Land,
         elevation: 0,
         happiness: 1,
         powered: false,
@@ -431,21 +415,35 @@ export function getTile(state: GameState, x: number, y: number): Tile | undefine
 }
 
 /**
- * Set a tile's v4-shaped `kind`. Does not touch the real strata fields —
- * `gameState.ts` cannot import `protocol/legacyProjection.ts`'s
- * `resyncTileStrata` without a circular import that breaks at runtime
- * (`legacyProjection.ts` has module-scope constants keyed by `TileKind`,
- * evaluated at import time, before `gameState.ts`'s own `TileKind` export
- * would exist). Every caller — `tools.ts`'s `applyTool`, and any test that
- * calls `setTile` directly — must call `resyncTileStrata` itself afterward.
+ * Test-only convenience: stamp a tile to a single-valued `TileKind`,
+ * translated to the strata it implies. Not used by `tools.ts` — its
+ * `applyTool` handlers are occupant-native and mutate `terrain`/
+ * `underground`/`surface`/`overhead` directly — this exists so tests can
+ * still set up a tile in one call the way `TileKind` names it.
+ *
+ * Replaces the whole surface and overhead stratum (a bare `TileKind` can
+ * only ever mean one thing at a time) but leaves `underground` standing —
+ * mirrors `tileFromV4`'s treatment of a v4 tile's buried pipe, which this
+ * function cannot call directly: `protocol/legacyProjection.ts` imports
+ * `TileKind` from this module at its own top level, so importing back from
+ * it here would form a cycle whose evaluation order left `TileKind`
+ * `undefined` the one time this was tried (see git history). Duplicated
+ * instead of shared; the mapping is small and `Occupant`'s bit positions
+ * are pinned "never reorder".
  */
 export function setTile(state: GameState, x: number, y: number, kind: TileKind) {
   const tile = getTile(state, x, y);
   if (!tile) return;
-  tile.kind = kind;
-  tile.roadUnderlay = undefined;
-  tile.railUnderlay = undefined;
-  tile.powerOverlay = undefined;
+  tile.terrain = kind === TileKind.Water ? Terrain.Water : Terrain.Land;
+  tile.surface = 0;
+  tile.overhead = 0;
+  tile.surface = withOccupant(tile.surface, Occupant.Road, kind === TileKind.Road);
+  tile.surface = withOccupant(tile.surface, Occupant.Rail, kind === TileKind.Rail);
+  tile.surface = withOccupant(tile.surface, Occupant.ZoneResidential, kind === TileKind.Residential);
+  tile.surface = withOccupant(tile.surface, Occupant.ZoneCommercial, kind === TileKind.Commercial);
+  tile.surface = withOccupant(tile.surface, Occupant.ZoneIndustrial, kind === TileKind.Industrial);
+  tile.overhead = withOccupant(tile.overhead, Occupant.PowerLine, kind === TileKind.PowerLine);
+  tile.overhead = withOccupant(tile.overhead, Occupant.Trees, kind === TileKind.Tree);
   tile.happiness = Math.min(1.5, tile.happiness + 0.05);
   const isPowerPlant = kind === TileKind.HydroPlant || kind === TileKind.CoalPlant
     || kind === TileKind.WindTurbine || kind === TileKind.SolarFarm;

--- a/app/src/game/persistence.ts
+++ b/app/src/game/persistence.ts
@@ -27,7 +27,7 @@ import type { LegacyEngineImport } from '../workers/wasmSim.worker';
 import { encodeHappiness } from './protocol/tileBuffer';
 import { LEGACY_BYTES_PER_TILE, LEGACY_FLAGS, legacyTileBufferOffsets } from './protocol/legacyTileBuffer';
 import { tileKindToU8 } from './protocol/tileKind';
-import { tileFromV4 } from './protocol/legacyProjection';
+import { legacyFlags, legacyKind, legacyUndergroundKind, tileFromV4 } from './protocol/legacyProjection';
 
 export function serialize(state: GameState): string {
   return JSON.stringify(state);
@@ -426,23 +426,36 @@ export function buildLegacyEngineImport(state: GameState): LegacyEngineImport {
   const n = state.width * state.height;
   const o = legacyTileBufferOffsets(n);
   const tiles = new Uint8Array(n * LEGACY_BYTES_PER_TILE);
+  const structureKindOf = (buildingId: number): TileKind | undefined => {
+    const instance = state.buildings.find((b) => b.id === buildingId);
+    return instance ? getBuildingTemplate(instance.templateId)?.tileKind : undefined;
+  };
   for (let i = 0; i < n; i++) {
     const tile = state.tiles[i];
-    tiles[o.kind + i] = tileKindToU8(tile.kind);
+    const input = {
+      terrain: tile.terrain,
+      surface: tile.surface,
+      overhead: tile.overhead,
+      buildingId: tile.buildingId,
+      structureKindOf
+    };
+    const kind = legacyKind(input);
+    const flags = legacyFlags(input, kind);
+    tiles[o.kind + i] = tileKindToU8(kind);
     tiles[o.flags + i] =
       (tile.powered ? LEGACY_FLAGS.POWERED : 0) |
       (tile.watered ? LEGACY_FLAGS.WATERED : 0) |
       (tile.abandoned ? LEGACY_FLAGS.ABANDONED : 0) |
-      (tile.roadUnderlay ? LEGACY_FLAGS.ROAD_UNDERLAY : 0) |
-      (tile.railUnderlay ? LEGACY_FLAGS.RAIL_UNDERLAY : 0) |
-      (tile.powerOverlay ? LEGACY_FLAGS.POWER_OVERLAY : 0);
+      (flags.roadUnderlay ? LEGACY_FLAGS.ROAD_UNDERLAY : 0) |
+      (flags.railUnderlay ? LEGACY_FLAGS.RAIL_UNDERLAY : 0) |
+      (flags.powerOverlay ? LEGACY_FLAGS.POWER_OVERLAY : 0);
     tiles[o.happiness + i] = encodeHappiness(tile.happiness);
     tiles[o.elevation + i] = tile.elevation & 0xff;
     const buildingId = tile.buildingId ?? 0;
     tiles[o.buildingId + i * 2] = buildingId & 0xff;
     tiles[o.buildingId + i * 2 + 1] = (buildingId >> 8) & 0xff;
-    tiles[o.undergroundKind + i] =
-      tile.legacyUnderground === undefined ? 0xff : tileKindToU8(tile.legacyUnderground);
+    const legacyUnderground = legacyUndergroundKind(tile.underground);
+    tiles[o.undergroundKind + i] = legacyUnderground === undefined ? 0xff : tileKindToU8(legacyUnderground);
     tiles[o.wilderness + i] = 128; // recomputed by the sim within one interval
   }
   return {

--- a/app/src/game/protocol/legacyProjection.ts
+++ b/app/src/game/protocol/legacyProjection.ts
@@ -5,19 +5,23 @@
 // SPDX-License-Identifier: MIT
 
 /**
- * Temporary strangler-window scaffolding: `wasmSimBridge.ts`/`tauriSimBridge.ts`
- * call this to populate `Tile`'s deprecated `kind`/`roadUnderlay`/`railUnderlay`/
- * `powerOverlay`/`legacyUnderground` shim fields from the real strata, so
- * consumers not yet converted to `terrain`/`underground`/`surface`/`overhead`
- * keep working. Deleted, along with the shim fields themselves, once every
- * consumer reads the strata directly.
+ * The v4 wire format's flattened `kind`+flags spelling, derived on demand
+ * from the real strata. `Tile` itself carries no shim fields any more (the
+ * strangler window they existed for closed once every consumer converted to
+ * reading `terrain`/`underground`/`surface`/`overhead` directly) — this
+ * module survives as the two permanent things a v4 spelling is still needed
+ * for: importing old `.citysim` JSON saves (`tileFromV4`, via
+ * `persistence.ts`'s `deserialize`), and exporting the current strata back
+ * into that format for the frozen legacy importer (`legacyKind`/
+ * `legacyFlags`, via `persistence.ts`'s `buildLegacyEngineImport`) — plus
+ * `dominantOccupantLabel` (`protocol/tileLabel.ts`) and the one minimap
+ * mode that still cares about v4-style precedence for display.
  *
  * Mirrors `city_sim_core::display::{wire_kind, wire_flags, wire_underground}`
  * exactly (as they were before deletion) — precedence: terrain > structure >
  * zone > trees > line > rail > road > land.
  */
 
-import type { Tile } from '../gameState';
 import { TileKind } from '../gameState';
 import { Occupant, Terrain, ZoneDensity, hasOccupant, withOccupant, zoneOccupant } from './occupants';
 
@@ -141,58 +145,4 @@ export function tileFromV4(
     overhead,
     density: ZoneDensity.Low
   };
-}
-
-/**
- * Bring one tile's strata fields back in sync with its shim fields, in
- * place. `buildings/manager.ts`'s `placeBuilding`/`removeBuilding` call this
- * after writing `kind`/`buildingId` directly, since those two functions are
- * still shim-authoritative; tests that hand-spell a tile's shim fields
- * directly (bypassing `applyTool`) need the same call so predicates reading
- * the strata directly don't see stale zeros.
- */
-export function resyncTileStrata(tile: Tile): void {
-  const strata = tileFromV4(
-    tile.kind,
-    { roadUnderlay: tile.roadUnderlay, railUnderlay: tile.railUnderlay, powerOverlay: tile.powerOverlay },
-    tile.legacyUnderground,
-    tile.buildingId
-  );
-  tile.terrain = strata.terrain;
-  tile.underground = strata.underground;
-  tile.surface = strata.surface;
-  tile.overhead = strata.overhead;
-  tile.density = strata.density;
-}
-
-/**
- * The inverse of `resyncTileStrata`: bring one tile's shim fields
- * (`kind`/`roadUnderlay`/`railUnderlay`/`powerOverlay`/`legacyUnderground`)
- * back in sync with its strata, in place. `tools.ts`'s `applyTool` handlers
- * are occupant-native (Phase 7 of the strata migration) and call this once
- * per tool so that anything still reading the shim fields — chiefly
- * `buildings/manager.ts`'s placement guard — doesn't see stale values.
- *
- * `structureKindOf` mirrors `legacyKind`'s own callback: resolve a
- * `building_id` to its template's `TileKind`, or `undefined` if it isn't
- * live.
- */
-export function resyncLegacyFromStrata(
-  tile: Tile,
-  structureKindOf: (buildingId: number) => TileKind | undefined
-): void {
-  const input: LegacyProjectionInput = {
-    terrain: tile.terrain,
-    surface: tile.surface,
-    overhead: tile.overhead,
-    buildingId: tile.buildingId,
-    structureKindOf
-  };
-  const kind = legacyKind(input);
-  const flags = legacyFlags(input, kind);
-  tile.kind = kind;
-  tile.roadUnderlay = flags.roadUnderlay || undefined;
-  tile.railUnderlay = flags.railUnderlay || undefined;
-  tile.powerOverlay = flags.powerOverlay || undefined;
-  tile.legacyUnderground = legacyUndergroundKind(tile.underground);
 }

--- a/app/src/game/saveContainer.test.ts
+++ b/app/src/game/saveContainer.test.ts
@@ -22,6 +22,8 @@ import { Tool } from './toolTypes';
 import { deleteSave, getSave, listSaveMetas, putSave, setIdbFactory } from './saveStore';
 import { LEGACY_BYTES_PER_TILE, LEGACY_FLAGS, legacyTileBufferOffsets } from './protocol/legacyTileBuffer';
 import { tileKindToU8 } from './protocol/tileKind';
+import { Occupant, setTileOccupant } from './protocol/occupants';
+import { legacyKind } from './protocol/legacyProjection';
 
 function makeContainer(name?: string): SaveContainer {
   const state = createInitialState(8, 8, 5);
@@ -76,15 +78,31 @@ describe('buildLegacyEngineImport', () => {
   it('re-encodes tiles into the wire SoA layout with packed flags', () => {
     const state = createInitialState(8, 8, 3);
     applyTool(state, Tool.Road, 3, 3);
-    state.tiles[10].powered = true;
-    state.tiles[10].watered = true;
-    state.tiles[10].roadUnderlay = true;
+    // (4,4) — the only other land tile `createInitialState`'s border carves
+    // out of an 8×8 map — for the flags-packing tile, so it doesn't collide
+    // with the road tile above.
+    const flagsIdx = 4 * 8 + 4;
+    state.tiles[flagsIdx].powered = true;
+    state.tiles[flagsIdx].watered = true;
+    // A road that isn't `kind` — pairing it with rail pushes `legacyKind` to
+    // resolve `Rail` instead (it outranks `Road`), so the road only survives
+    // as the `ROAD_UNDERLAY` flag this test is packing, with nothing else set.
+    setTileOccupant(state.tiles[flagsIdx], Occupant.Road, true);
+    setTileOccupant(state.tiles[flagsIdx], Occupant.Rail, true);
     const imp = buildLegacyEngineImport(state);
     const n = 64;
     const o = legacyTileBufferOffsets(n);
+    const roadTile = state.tiles[3 * 8 + 3];
+    const roadTileKind = legacyKind({
+      terrain: roadTile.terrain,
+      surface: roadTile.surface,
+      overhead: roadTile.overhead,
+      buildingId: roadTile.buildingId,
+      structureKindOf: () => undefined
+    });
     expect(imp.tiles).toHaveLength(n * LEGACY_BYTES_PER_TILE);
-    expect(imp.tiles[o.kind + 3 * 8 + 3]).toBe(tileKindToU8(state.tiles[3 * 8 + 3].kind));
-    expect(imp.tiles[o.flags + 10]).toBe(LEGACY_FLAGS.POWERED | LEGACY_FLAGS.WATERED | LEGACY_FLAGS.ROAD_UNDERLAY);
+    expect(imp.tiles[o.kind + 3 * 8 + 3]).toBe(tileKindToU8(roadTileKind));
+    expect(imp.tiles[o.flags + flagsIdx]).toBe(LEGACY_FLAGS.POWERED | LEGACY_FLAGS.WATERED | LEGACY_FLAGS.ROAD_UNDERLAY);
     expect(imp.rngState).toEqual(state.rngState);
     expect(imp.seed).toBe(3);
     expect(imp.policies).toEqual(state.policies);
@@ -93,7 +111,6 @@ describe('buildLegacyEngineImport', () => {
   it('writes building ids little-endian and 0xFF for no underground', () => {
     const state = createInitialState(8, 8, 3);
     state.tiles[5].buildingId = 0x1234;
-    state.tiles[6].legacyUnderground = state.tiles[6].kind; // any kind round-trips
     const imp = buildLegacyEngineImport(state);
     const o = legacyTileBufferOffsets(64);
     expect(imp.tiles[o.buildingId + 5 * 2]).toBe(0x34);

--- a/app/src/game/serviceDistribution.test.ts
+++ b/app/src/game/serviceDistribution.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { createInitialState, getTile, setTile, TileKind } from './gameState';
-import { getBuildingTemplate } from './buildings/templates';
-import { placeBuilding } from './buildings/manager';
-import { resyncTileStrata } from './protocol/legacyProjection';
+import { createInitialState, setTile, TileKind } from './gameState';
+import { placeZoneBuilding } from './buildings/manager';
 import {
   computeZoneLoads,
   estimateZoneLoad,
@@ -11,26 +9,20 @@ import {
 } from './serviceDistribution';
 import { ServiceId } from './services';
 
-/** `setTile` only writes the old shim `kind` — resync the strata too, same as `tools.ts`'s `applyTool` does after every tool call. */
-function setTileAndSync(state: ReturnType<typeof createInitialState>, x: number, y: number, kind: TileKind): void {
-  setTile(state, x, y, kind);
-  resyncTileStrata(getTile(state, x, y)!);
-}
-
 describe('serviceDistribution', () => {
   it('computes population and job loads proportional to capacity with worker fallback', () => {
     const state = createInitialState(6, 6);
     state.population = 28;
     state.jobs = 40;
 
-    const resTemplate = getBuildingTemplate(TileKind.Residential)!;
-    const comTemplate = getBuildingTemplate(TileKind.Commercial)!;
-    const indTemplate = getBuildingTemplate(TileKind.Industrial)!;
-
-    placeBuilding(state, resTemplate, 0, 0);
-    placeBuilding(state, resTemplate, 1, 0);
-    placeBuilding(state, comTemplate, 3, 0);
-    placeBuilding(state, indTemplate, 4, 0);
+    setTile(state, 0, 0, TileKind.Residential);
+    setTile(state, 1, 0, TileKind.Residential);
+    setTile(state, 3, 0, TileKind.Commercial);
+    setTile(state, 4, 0, TileKind.Industrial);
+    placeZoneBuilding(state, TileKind.Residential, 0, 0);
+    placeZoneBuilding(state, TileKind.Residential, 1, 0);
+    placeZoneBuilding(state, TileKind.Commercial, 3, 0);
+    placeZoneBuilding(state, TileKind.Industrial, 4, 0);
 
     const loads = computeZoneLoads(state);
 
@@ -55,12 +47,12 @@ describe('serviceDistribution', () => {
   it('finds reachable zones through roads within a radius and sorts by distance', () => {
     const state = createInitialState(5, 5);
     // service origin at (1,1)
-    setTileAndSync(state, 1, 1, TileKind.Road);
-    setTileAndSync(state, 1, 2, TileKind.Road);
-    setTileAndSync(state, 1, 3, TileKind.Residential); // reachable via road chain, distance 2
-    setTileAndSync(state, 2, 1, TileKind.Road);
-    setTileAndSync(state, 3, 1, TileKind.Commercial); // reachable via road chain, distance 2
-    setTileAndSync(state, 4, 4, TileKind.Industrial); // outside radius / no path
+    setTile(state, 1, 1, TileKind.Road);
+    setTile(state, 1, 2, TileKind.Road);
+    setTile(state, 1, 3, TileKind.Residential); // reachable via road chain, distance 2
+    setTile(state, 2, 1, TileKind.Road);
+    setTile(state, 3, 1, TileKind.Commercial); // reachable via road chain, distance 2
+    setTile(state, 4, 4, TileKind.Industrial); // outside radius / no path
 
     const candidates = getReachableZoneCandidates(
       state,

--- a/app/src/game/simulation.ts
+++ b/app/src/game/simulation.ts
@@ -13,7 +13,7 @@ import { SeededRng } from './rng';
 import { BASE_INCOME, MAINTENANCE, POWER_PLANT_CONFIGS } from './constants';
 import { BuildingStatus } from './buildings/state';
 import { BuildingCategory, getBuildingTemplate } from './buildings/templates';
-import { listPowerPlants, placeBuilding, updateBuildingStates } from './buildings/manager';
+import { listPowerPlants, placeZoneBuilding, updateBuildingStates } from './buildings/manager';
 import { recomputePowerNetwork } from './utilities/power';
 import { hasWaterSourceConnection, recomputeWaterNetwork } from './utilities/water';
 import {
@@ -649,9 +649,7 @@ export class Simulation {
       if (needsWater && waterBalance < 0) utilityFactor *= clamp(1 + waterBalance / 30, 0.05, 1);
       const adjustedPGrow = clamp(pGrow * utilityFactor, 0, 1);
       if (adjustedPGrow <= 0 || this.rng.nextF32() > adjustedPGrow) continue;
-      const template = getBuildingTemplate(kind);
-      if (!template) continue;
-      const result = placeBuilding(this.state, template, x, y);
+      const result = placeZoneBuilding(this.state, kind, x, y);
       if (result.success) {
         grown++;
         this.vacantZoneIndices.delete(idx);

--- a/app/src/game/tauriSimBridge.ts
+++ b/app/src/game/tauriSimBridge.ts
@@ -23,12 +23,12 @@
  *     per tile (see `TickEvent.tiles` in `guest-js/index.ts`), but not
  *     happiness, elevation, wilderness or per-tile `building_id` — those
  *     still need the Rust sim to serialise them (P3+).
- *   • Because per-tile `building_id` is absent, a `Structure` occupant's
- *     specific `TileKind` can never resolve here (`legacyKind`'s structure
- *     branch needs it) — every structure tile decodes via the same
- *     kind-precedence fallback a bare zone/road/rail/line tile would.
- *     `event.buildings` (id/kind/origin, no footprint) isn't enough on its
- *     own to fix this; it would need `building_id` on the wire too.
+ *   • Because per-tile `building_id` is absent, `tile.buildingId` is never
+ *     set on this path — anything keyed off it (a developed zone lot's
+ *     `isDevelopedZone` check, the HUD tile inspector) silently sees an
+ *     undeveloped tile. `event.buildings` (id/kind/origin, no footprint)
+ *     isn't enough on its own to fix this; it would need `building_id` on
+ *     the wire too.
  */
 
 import type { GameState, Tile } from './gameState';
@@ -36,9 +36,8 @@ import { TileKind } from './gameState';
 import type { SimBridge } from './simBridge';
 import type { SimCommand, CommandResult } from './protocol/commands';
 import type { FromSim } from './protocol/events';
-import { tileKindFromU8, tileKindToU8 } from './protocol/tileKind';
+import { tileKindToU8 } from './protocol/tileKind';
 import { Terrain, ZoneDensity } from './protocol/occupants';
-import { legacyKind, legacyFlags, legacyUndergroundKind } from './protocol/legacyProjection';
 import { STATUS } from './protocol/tileBuffer';
 import { createTileServiceState } from './services';
 import { Tool } from './toolTypes';
@@ -210,7 +209,7 @@ export class TauriSimBridge implements SimBridge {
   private async seedEngine(state: GameState): Promise<void> {
     const terrain = new Uint8Array(state.tiles.length);
     for (let i = 0; i < terrain.length; i++) {
-      terrain[i] = tileKindToU8(state.tiles[i].kind);
+      terrain[i] = tileKindToU8(state.tiles[i].terrain === Terrain.Water ? TileKind.Water : TileKind.Land);
     }
     await pluginSetNaturalTerrain(terrain);
     await pluginSetPolicies(state.policies);
@@ -264,16 +263,6 @@ export class TauriSimBridge implements SimBridge {
       s.tiles = Array.from({ length: n }, () => makeBlankTile());
     }
 
-    // `event.buildings` is the only source for a Structure occupant's
-    // specific TileKind — the tile bytes only say a building stands there
-    // (#177's TS/wire follow-up), same as the WASM path.
-    const structureKindById = new Map<number, TileKind>();
-    for (const b of event.buildings) {
-      const kind = tileKindFromU8(b.kind);
-      if (kind !== undefined) structureKindById.set(b.id, kind);
-    }
-    const structureKindOf = (id: number) => structureKindById.get(id);
-
     for (let i = 0; i < n; i++) {
       const tile = s.tiles[i];
       const base = i * 4;
@@ -286,23 +275,6 @@ export class TauriSimBridge implements SimBridge {
       tile.watered = (status & STATUS.WATERED) !== 0;
       tile.abandoned = (status & STATUS.ABANDONED) !== 0;
       tile.density = ((status & STATUS.DENSITY_MASK) >> STATUS.DENSITY_SHIFT) as ZoneDensity;
-
-      // Shim fields — deleted, along with this whole block, once every
-      // consumer reads terrain/underground/surface/overhead directly.
-      const projectionInput = {
-        terrain: tile.terrain,
-        surface: tile.surface,
-        overhead: tile.overhead,
-        buildingId: tile.buildingId,
-        structureKindOf
-      };
-      const kind = legacyKind(projectionInput);
-      tile.kind = kind;
-      const flags = legacyFlags(projectionInput, kind);
-      tile.roadUnderlay = flags.roadUnderlay;
-      tile.railUnderlay = flags.railUnderlay;
-      tile.powerOverlay = flags.powerOverlay;
-      tile.legacyUnderground = legacyUndergroundKind(tile.underground);
     }
 
     // Forward TickStats to the UI handler
@@ -324,7 +296,6 @@ export class TauriSimBridge implements SimBridge {
 /** A bare land tile, for growing the mirror array when dimensions change — immediately overwritten by the decode loop. */
 function makeBlankTile(): Tile {
   return {
-    kind: TileKind.Land,
     elevation: 0,
     happiness: 1,
     powered: false,

--- a/app/src/game/tools.test.ts
+++ b/app/src/game/tools.test.ts
@@ -7,8 +7,8 @@ import { Tool } from './toolTypes';
 import { Simulation } from './simulation';
 import { BuildingStatus } from './buildings/state';
 import { getBuildingTemplate } from './buildings/templates';
-import { placeBuilding } from './buildings/manager';
-import { resyncTileStrata } from './protocol/legacyProjection';
+import { placeZoneBuilding } from './buildings/manager';
+import { Occupant, Terrain, hasOccupant, setTileOccupant, zoneOccupant } from './protocol/occupants';
 import { hasRoadAccess } from './adjacency';
 import { SeededRng } from './rng';
 
@@ -30,7 +30,7 @@ describe('tools', () => {
     const before = state.money;
     const result = applyTool(state, Tool.Road, 0, 0);
     expect(result.success).toBe(true);
-    expect(getTile(state, 0, 0)?.kind).toBe(TileKind.Road);
+    expect(hasOccupant(getTile(state, 0, 0)!.surface, Occupant.Road)).toBe(true);
     expect(state.money).toBe(before - BUILD_COST[Tool.Road]);
   });
 
@@ -39,9 +39,9 @@ describe('tools', () => {
     state.money = 100;
     setTile(state, 1, 1, TileKind.Water);
     applyTool(state, Tool.TerraformRaise, 1, 1);
-    expect(getTile(state, 1, 1)?.kind).toBe(TileKind.Land);
+    expect(getTile(state, 1, 1)?.terrain).toBe(Terrain.Land);
     applyTool(state, Tool.TerraformLower, 1, 1);
-    expect(getTile(state, 1, 1)?.kind).toBe(TileKind.Water);
+    expect(getTile(state, 1, 1)?.terrain).toBe(Terrain.Water);
   });
 
   it('places power plants as 2x2 footprints with a shared id and single cost', () => {
@@ -97,8 +97,7 @@ describe('tools', () => {
     const pump = state.buildings.find((b) => b.templateId === template.id);
     expect(pump).toBeDefined();
     const pumpConnection = getTile(state, 0, 1)!;
-    pumpConnection.legacyUnderground = TileKind.WaterPipe;
-    resyncTileStrata(pumpConnection);
+    setTileOccupant(pumpConnection, Occupant.Pipe, true);
     const spent = initialMoney - state.money;
     expect(spent).toBeCloseTo(
       BUILD_COST[Tool.WindTurbine] + BUILD_COST[Tool.PowerLine] * 3 + template.cost
@@ -119,8 +118,7 @@ describe('tools', () => {
     expect(result.success).toBe(true);
     expect(state.buildings.filter((building) => building.templateId === template.id).length).toBe(1);
     const towerPipe = getTile(state, 5, 3)!;
-    towerPipe.legacyUnderground = TileKind.WaterPipe;
-    resyncTileStrata(towerPipe);
+    setTileOccupant(towerPipe, Occupant.Pipe, true);
     const ids = new Set<number>();
     const footprint: Array<[number, number]> = [
       [3, 3],
@@ -130,7 +128,7 @@ describe('tools', () => {
     ];
     footprint.forEach(([x, y]) => {
       const tile = getTile(state, x, y)!;
-      expect(tile.kind).toBe(TileKind.WaterTower);
+      expect(hasOccupant(tile.surface, Occupant.Structure)).toBe(true);
       ids.add(tile.buildingId ?? -1);
     });
     expect(ids.size).toBe(1);
@@ -148,16 +146,15 @@ describe('tools', () => {
     const before = state.money;
     const result = applyTool(state, Tool.Commercial, 2, 2);
     expect(result.success).toBe(false);
-    expect(getTile(state, 2, 2)?.kind).toBe(TileKind.Road);
+    expect(hasOccupant(getTile(state, 2, 2)!.surface, Occupant.Road)).toBe(true);
     expect(state.money).toBe(before); // no charge on failure
   });
 
   it('rejects placing transport tools over existing buildings', () => {
     const state = createInitialState(6, 6);
-    const template = getBuildingTemplate(TileKind.Residential)!;
-    // seed a zone building manually
+    // seed a developed zone lot manually
     setTile(state, 3, 3, TileKind.Residential);
-    placeBuilding(state, template, 3, 3);
+    placeZoneBuilding(state, TileKind.Residential, 3, 3);
     expect(state.buildings.length).toBe(1);
     const buildingId = state.buildings[0].id;
     const moneyBefore = state.money;
@@ -165,7 +162,7 @@ describe('tools', () => {
     expect(result.success).toBe(false); // building protection — must bulldoze first
     expect(state.buildings.find((b) => b.id === buildingId)).toBeDefined();
     expect(getTile(state, 3, 3)?.buildingId).toBeDefined();
-    expect(getTile(state, 3, 3)?.kind).toBe(TileKind.Residential); // tile unchanged
+    expect(zoneOccupant(getTile(state, 3, 3)!.surface)).toBe(Occupant.ZoneResidential); // tile unchanged
     expect(state.money).toBe(moneyBefore); // no charge on failure
   });
 
@@ -185,7 +182,9 @@ describe('tools', () => {
     ];
     clearedTiles.forEach(([x, y]) => {
       const tile = getTile(state, x, y)!;
-      expect(tile.kind).toBe(TileKind.Land);
+      expect(tile.terrain).toBe(Terrain.Land);
+      expect(tile.surface).toBe(0);
+      expect(tile.overhead).toBe(0);
       expect(tile.buildingId).toBeUndefined();
       expect(tile.powerPlantType).toBeUndefined();
     });
@@ -285,7 +284,7 @@ describe('simulation', () => {
     }
     // drop a power line on the middle tile to simulate an over-road line
     applyTool(state, Tool.PowerLine, 4, 3);
-    expect(getTile(state, 4, 3)?.kind).toBe(TileKind.PowerLine);
+    expect(hasOccupant(getTile(state, 4, 3)!.overhead, Occupant.PowerLine)).toBe(true);
     expect(hasRoadAccess(state, 5, 3)).toBe(true);
   });
 
@@ -334,24 +333,21 @@ describe('simulation', () => {
     applyTool(state, Tool.Rail, 3, 2);
     applyTool(state, Tool.Rail, 3, 3);
     applyTool(state, Tool.Rail, 3, 4);
-    // draw a road across it, creating a road underlay — `Rail` outranks
-    // `Road` in `legacyKind`'s precedence regardless of build order, so a
-    // road-last crossing is still spelled `Rail` (see `e2e/visual.spec.ts`'s
-    // "delta 1").
+    // draw a road across it — both occupy the same surface stratum
+    // regardless of build order, so there is no "underlay" spelling to pin,
+    // only the two bits.
     applyTool(state, Tool.Road, 2, 3);
     applyTool(state, Tool.Road, 3, 3);
     applyTool(state, Tool.Road, 4, 3);
     const crossing = getTile(state, 3, 3)!;
-    expect(crossing.kind).toBe(TileKind.Rail);
-    expect(crossing.roadUnderlay).toBe(true);
+    expect(hasOccupant(crossing.surface, Occupant.Rail)).toBe(true);
+    expect(hasOccupant(crossing.surface, Occupant.Road)).toBe(true);
 
     applyTool(state, Tool.Bulldoze, 3, 3);
 
     const cleared = getTile(state, 3, 3)!;
-    expect(cleared.kind).toBe(TileKind.Land);
-    expect(cleared.railUnderlay).toBeUndefined();
-    expect(cleared.roadUnderlay).toBeUndefined();
-    expect(cleared.powerOverlay).toBeUndefined();
+    expect(cleared.surface).toBe(0);
+    expect(cleared.overhead).toBe(0);
   });
 
   it('grows frontier zones even without roads, but roads still trigger growth', () => {

--- a/app/src/game/tools.ts
+++ b/app/src/game/tools.ts
@@ -14,7 +14,6 @@ import { BUILD_COST, PowerPlantType } from './constants';
 import { type BuildingTemplate, getBuildingTemplate, getPowerPlantTemplate } from './buildings/templates';
 import { placeBuilding, removeBuilding } from './buildings/manager';
 import { GameState, Tile, TileKind, bumpTileRevision, getTile } from './gameState';
-import { resyncLegacyFromStrata } from './protocol/legacyProjection';
 import {
   Occupant,
   Stratum,
@@ -49,16 +48,6 @@ export function getToolCost(tool: Tool): number {
   const templateCost = getBuildingTemplate(tool)?.cost;
   if (templateCost !== undefined) return templateCost;
   return BUILD_COST[tool] ?? 0;
-}
-
-function structureKindOf(state: GameState, buildingId: number): TileKind | undefined {
-  const instance = state.buildings.find((b) => b.id === buildingId);
-  return instance ? getBuildingTemplate(instance.templateId)?.tileKind : undefined;
-}
-
-/** Bring `tile`'s shim fields back in sync after an occupant-native mutation. */
-function syncLegacy(state: GameState, tile: Tile): void {
-  resyncLegacyFromStrata(tile, (buildingId) => structureKindOf(state, buildingId));
 }
 
 /**
@@ -178,7 +167,6 @@ function zone({ state, x, y }: ToolContext, cost: number, zoneOccupant: Occupant
   regradeAt(state, x, y, Terrain.Land);
   const updated = getTile(state, x, y)!;
   setTileOccupant(updated, zoneOccupant, true);
-  syncLegacy(state, updated);
   return { success: true };
 }
 
@@ -193,7 +181,6 @@ const registry: ToolRegistry = {
     if (refusal) return { success: false, message: refusal };
     state.money -= cost;
     regradeAt(state, x, y, Terrain.Land);
-    syncLegacy(state, getTile(state, x, y)!);
     return { success: true };
   },
   [Tool.TerraformLower]: ({ state, x, y }, cost) => {
@@ -201,7 +188,6 @@ const registry: ToolRegistry = {
     if (refusal) return { success: false, message: refusal };
     state.money -= cost;
     regradeAt(state, x, y, Terrain.Water);
-    syncLegacy(state, getTile(state, x, y)!);
     return { success: true };
   },
   [Tool.Water]: ({ state, x, y }, cost) => {
@@ -209,7 +195,6 @@ const registry: ToolRegistry = {
     if (refusal) return { success: false, message: refusal };
     state.money -= cost;
     regradeAt(state, x, y, Terrain.Water);
-    syncLegacy(state, getTile(state, x, y)!);
     return { success: true };
   },
   [Tool.Tree]: ({ state, x, y }, cost) => {
@@ -225,7 +210,6 @@ const registry: ToolRegistry = {
     regradeAt(state, x, y, Terrain.Land);
     const updated = getTile(state, x, y)!;
     setTileOccupant(updated, Occupant.Trees, true);
-    syncLegacy(state, updated);
     return { success: true };
   },
   [Tool.Road]: ({ state, x, y }, cost) => {
@@ -242,7 +226,6 @@ const registry: ToolRegistry = {
     const updated = getTile(state, x, y)!;
     setTileOccupant(updated, Occupant.Road, true);
     setTileOccupant(updated, Occupant.Rail, hadRail);
-    syncLegacy(state, updated);
     return { success: true };
   },
   [Tool.Rail]: ({ state, x, y }, cost) => {
@@ -256,7 +239,6 @@ const registry: ToolRegistry = {
     const updated = getTile(state, x, y)!;
     setTileOccupant(updated, Occupant.Rail, true);
     setTileOccupant(updated, Occupant.Road, hadRoad);
-    syncLegacy(state, updated);
     return { success: true };
   },
   [Tool.PowerLine]: ({ state, x, y }, cost) => {
@@ -274,7 +256,6 @@ const registry: ToolRegistry = {
     setTileOccupant(updated, Occupant.PowerLine, true);
     setTileOccupant(updated, Occupant.Trees, false);
     bumpTileRevision(state);
-    syncLegacy(state, updated);
     return { success: true };
   },
   [Tool.HydroPlant]: ({ state, x, y }, cost) =>
@@ -297,7 +278,6 @@ const registry: ToolRegistry = {
       // `Tool::WaterPipe` in `commands.rs` — this deliberately does not bump
       // `tileRevision`.
       setTileOccupant(tile, Occupant.Pipe, true);
-      syncLegacy(state, tile);
     }
     return { success: true };
   },
@@ -325,13 +305,11 @@ const registry: ToolRegistry = {
       removeBuilding(state, tile.buildingId);
     } else if (tile.underground !== 0) {
       clearTileStratum(tile, Stratum.Underground);
-      syncLegacy(state, tile);
     } else {
       clearTileStratum(tile, Stratum.Surface);
       clearTileStratum(tile, Stratum.Overhead);
       tile.abandoned = false;
       bumpTileRevision(state);
-      syncLegacy(state, tile);
     }
     return { success: true };
   }

--- a/app/src/game/utilities/water.test.ts
+++ b/app/src/game/utilities/water.test.ts
@@ -3,7 +3,7 @@ import { createInitialState, getTile, TileKind } from '../gameState';
 import { placeBuilding, updateBuildingStates } from '../buildings/manager';
 import { recomputeWaterNetwork } from './water';
 import { getBuildingTemplate } from '../buildings/templates';
-import { resyncTileStrata } from '../protocol/legacyProjection';
+import { Occupant, setTileOccupant } from '../protocol/occupants';
 
 describe('water network', () => {
   it('propagates water from tower to pipes', () => {
@@ -24,8 +24,7 @@ describe('water network', () => {
 
     // Place Pipe at 3,1 (adjacent to tower at 2,1)
     const pipeTile = getTile(state, 3, 1)!;
-    pipeTile.legacyUnderground = TileKind.WaterPipe;
-    resyncTileStrata(pipeTile);
+    setTileOccupant(pipeTile, Occupant.Pipe, true);
 
     // Ensure building status is active (towers need power)
     updateBuildingStates(state);
@@ -51,11 +50,9 @@ describe('water network', () => {
     });
 
     const pipe1 = getTile(state, 3, 1)!;
-    pipe1.legacyUnderground = TileKind.WaterPipe;
-    resyncTileStrata(pipe1);
+    setTileOccupant(pipe1, Occupant.Pipe, true);
     const pipe2 = getTile(state, 4, 1)!;
-    pipe2.legacyUnderground = TileKind.WaterPipe;
-    resyncTileStrata(pipe2);
+    setTileOccupant(pipe2, Occupant.Pipe, true);
 
     updateBuildingStates(state);
     recomputeWaterNetwork(state);

--- a/app/src/game/wasmSimBridge.ts
+++ b/app/src/game/wasmSimBridge.ts
@@ -32,7 +32,6 @@ import {
 } from './protocol/tileBuffer';
 import { tileKindFromU8, tileKindToU8 } from './protocol/tileKind';
 import { Occupant, Terrain, ZoneDensity, hasOccupant } from './protocol/occupants';
-import { legacyKind, legacyFlags, legacyUndergroundKind } from './protocol/legacyProjection';
 import { Tool } from './toolTypes';
 
 // Mapping from TS string-valued Tool enum → Rust #[repr(u8)] discriminant.
@@ -582,14 +581,8 @@ export class WasmSimBridge implements SimBridge {
     // The live wire no longer carries a resolved kind byte per tile (#177's
     // TS/wire follow-up) — a `Structure` occupant says only that a building
     // stands here, not which one. `buildings_json` is the only source for
-    // that now; parse it once and look up by id below.
+    // that now.
     const wireBuildings: WireBuilding[] = buildingsJson ? JSON.parse(buildingsJson) : [];
-    const structureKindById = new Map<number, TileKind>();
-    for (const b of wireBuildings) {
-      const kind = tileKindFromU8(b.kind);
-      if (kind !== undefined) structureKindById.set(b.id, kind);
-    }
-    const structureKindOf = (id: number) => structureKindById.get(id);
 
     for (let i = 0; i < n; i++) {
       const tile = this.state.tiles[i];
@@ -609,25 +602,6 @@ export class WasmSimBridge implements SimBridge {
       tile.buildingId = bid === 0 ? undefined : bid;
       // Normalised 0–1 (0.5 = neutral) for the overlay heatmap.
       tile.wilderness = bytes[o.wilderness + i] / 255;
-
-      // Shim fields — deleted, along with this whole block, once every
-      // consumer reads terrain/underground/surface/overhead directly.
-      const kind = legacyKind({
-        terrain: tile.terrain,
-        surface: tile.surface,
-        overhead: tile.overhead,
-        buildingId: tile.buildingId,
-        structureKindOf
-      });
-      tile.kind = kind;
-      const flags = legacyFlags(
-        { terrain: tile.terrain, surface: tile.surface, overhead: tile.overhead, buildingId: tile.buildingId, structureKindOf },
-        kind
-      );
-      tile.roadUnderlay = flags.roadUnderlay;
-      tile.railUnderlay = flags.railUnderlay;
-      tile.powerOverlay = flags.powerOverlay;
-      tile.legacyUnderground = legacyUndergroundKind(tile.underground);
     }
 
     // Rebuild state.buildings directly from the parsed list — Rust is
@@ -636,16 +610,12 @@ export class WasmSimBridge implements SimBridge {
     // carries id, kind and origin.
     // Mirror of the engine's water opt-in gate (`GameState::has_water_system`):
     // until a pump, tower, or pipe exists, buildings don't require water.
-    let hasWaterSystem = false;
-    for (let i = 0; i < n; i++) {
-      const tile = this.state.tiles[i];
-      if (
-        tile.kind === TileKind.WaterPump ||
-        tile.kind === TileKind.WaterTower ||
-        hasOccupant(tile.underground, Occupant.Pipe)
-      ) {
-        hasWaterSystem = true;
-      }
+    let hasWaterSystem = wireBuildings.some((b) => {
+      const kind = tileKindFromU8(b.kind);
+      return kind === TileKind.WaterPump || kind === TileKind.WaterTower;
+    });
+    for (let i = 0; i < n && !hasWaterSystem; i++) {
+      if (hasOccupant(this.state.tiles[i].underground, Occupant.Pipe)) hasWaterSystem = true;
     }
     this.state.buildings = wireBuildings.map((b) => {
       const kind = tileKindFromU8(b.kind) ?? TileKind.Land;
@@ -680,7 +650,7 @@ export class WasmSimBridge implements SimBridge {
 function terrainBytes(state: GameState): Uint8Array {
   const bytes = new Uint8Array(state.tiles.length);
   for (let i = 0; i < bytes.length; i++) {
-    bytes[i] = tileKindToU8(state.tiles[i].kind);
+    bytes[i] = tileKindToU8(state.tiles[i].terrain === Terrain.Water ? TileKind.Water : TileKind.Land);
   }
   return bytes;
 }

--- a/app/src/rendering/hydroCoverage.test.ts
+++ b/app/src/rendering/hydroCoverage.test.ts
@@ -23,19 +23,11 @@
 
 import { describe, it, expect } from 'vitest';
 import type { Texture } from 'pixi.js';
-import { createInitialState, getTile, setTile as rawSetTile, TileKind, type GameState } from '../game/gameState';
-import { resyncTileStrata } from '../game/protocol/legacyProjection';
+import { createInitialState, getTile, setTile, TileKind, type GameState } from '../game/gameState';
+import { Occupant, hasOccupant, setTileOccupant } from '../game/protocol/occupants';
 import { resolveTileSprite, type BuildingLookup } from './tileRenderUtils';
 import { CARRIAGEWAY_CLASSES, isSquareCrossing } from './tileAtlas';
 import type { TileTextures, RoadVariant, CarriagewayClass, HydroVariant } from './tileAtlas';
-
-/** `setTile` only ever wrote the v4 shim fields — resync the real strata
- *  every case in this matrix is built from, same as `tools.ts`'s `applyTool`
- *  does after every tool call. */
-function setTile(state: GameState, x: number, y: number, kind: TileKind): void {
-  rawSetTile(state, x, y, kind);
-  resyncTileStrata(getTile(state, x, y)!);
-}
 
 const VARIANTS: RoadVariant[] = [
   'ns', 'ew',
@@ -151,18 +143,17 @@ function buildCase(hydro: HydroCase, sub: Substrate, rec: Recording = 'line-last
   const railEdges = sub.rail ?? [];
 
   if (rec === 'carriageway-last' && sub.cls) {
-    // The carriageway owns the kind; the line survives only as a flag.
+    // The carriageway owns the kind; the line survives only as an occupant
+    // bit alongside it.
     setTile(state, CX, CY, sub.rail ? TileKind.Rail : TileKind.Road);
     const laid = getTile(state, CX, CY)!;
-    if (sub.rail && sub.road) laid.roadUnderlay = true;
-    laid.powerOverlay = true;
-    resyncTileStrata(laid);
+    if (sub.rail && sub.road) setTileOccupant(laid, Occupant.Road, true);
+    setTileOccupant(laid, Occupant.PowerLine, true);
   } else {
     setTile(state, CX, CY, TileKind.PowerLine);
     const centre = getTile(state, CX, CY)!;
-    if (sub.road) centre.roadUnderlay = true;
-    if (sub.rail) centre.railUnderlay = true;
-    resyncTileStrata(centre);
+    if (sub.road) setTileOccupant(centre, Occupant.Road, true);
+    if (sub.rail) setTileOccupant(centre, Occupant.Rail, true);
   }
 
   for (const edge of ['n', 'e', 's', 'w'] as const) {
@@ -178,9 +169,8 @@ function buildCase(hydro: HydroCase, sub: Substrate, rec: Recording = 'line-last
     // `pickPowerUnderlayTexture` reads a level crossing.
     setTile(state, x, y, wire ? TileKind.PowerLine : rail ? TileKind.Rail : TileKind.Road);
     const tile = getTile(state, x, y)!;
-    if (road && tile.kind !== TileKind.Road) tile.roadUnderlay = true;
-    if (rail && tile.kind !== TileKind.Rail) tile.railUnderlay = true;
-    resyncTileStrata(tile);
+    if (road && !hasOccupant(tile.surface, Occupant.Road)) setTileOccupant(tile, Occupant.Road, true);
+    if (rail && !hasOccupant(tile.surface, Occupant.Rail)) setTileOccupant(tile, Occupant.Rail, true);
   }
   return state;
 }

--- a/app/src/rendering/renderer.ts
+++ b/app/src/rendering/renderer.ts
@@ -208,7 +208,7 @@ export class MapRenderer {
           // overlay on top, and count it as sprited so the debug label
           // doesn't also stamp a "P" over it.
           this.hideSprite(idx);
-          const color = getTileColour(tile, this.palette);
+          const color = getTileColour(tile, this.palette, buildingLookup);
           this.mapLayer
             .rect(this.camera.x + x * size, this.camera.y + y * size, size, size)
             .fill({ color, alpha: 0.95 * surfaceAlpha });
@@ -222,7 +222,7 @@ export class MapRenderer {
         } else {
           this.hideSprite(idx);
           this.hideOverlaySprite(idx);
-          const color = getTileColour(tile, this.palette);
+          const color = getTileColour(tile, this.palette, buildingLookup);
           this.mapLayer
             .rect(
               this.camera.x + x * size,
@@ -507,7 +507,12 @@ export class MapRenderer {
     const tile = getTile(state, selected.x, selected.y);
     if (!tile || tile.buildingId === undefined) return null;
     const lookup = buildingLookup.get(tile.buildingId);
-    const template = lookup?.template ?? getBuildingTemplate(tile.kind);
+    // Fall back to `state.buildings` directly — `buildingLookup` is built
+    // from the same array (`createBuildingLookup`), so a miss here can only
+    // mean the lookup is stale relative to a `buildingId` this tile already
+    // has.
+    const templateId = state.buildings.find((b) => b.id === tile.buildingId)?.templateId;
+    const template = lookup?.template ?? (templateId !== undefined ? getBuildingTemplate(templateId) : undefined);
     if (!template?.service) return null;
     if (
       template.service.id !== ServiceId.EducationElementary &&

--- a/app/src/rendering/tileRenderUtils.test.ts
+++ b/app/src/rendering/tileRenderUtils.test.ts
@@ -5,23 +5,12 @@
 
 import { describe, it, expect } from 'vitest';
 import type { Texture } from 'pixi.js';
-import { createInitialState, getTile, setTile as rawSetTile, TileKind } from '../game/gameState';
+import { createInitialState, getTile, setTile, TileKind } from '../game/gameState';
 import { PowerPlantType } from '../game/constants';
-import { resyncTileStrata } from '../game/protocol/legacyProjection';
-import { getTileColour, resolveTileSprite, type BuildingLookup } from './tileRenderUtils';
+import { createBuildingState } from '../game/buildings/state';
+import { Occupant, Terrain, setTileOccupant } from '../game/protocol/occupants';
+import { createBuildingLookup, getTileColour, resolveTileSprite, type BuildingLookup } from './tileRenderUtils';
 import type { TileTextures } from './tileAtlas';
-
-/**
- * Every test in this file hand-spells a specific wire scenario, the same way
- * the old wire format could (a line built before its road, a zone that only
- * recorded a hydro overlay, ...). `setTile` only ever wrote the v4 shim
- * fields — resync the real strata it drives sprite selection from, same as
- * `tools.ts`'s `applyTool` does after every tool call.
- */
-function setTile(state: ReturnType<typeof createInitialState>, x: number, y: number, kind: TileKind): void {
-  rawSetTile(state, x, y, kind);
-  resyncTileStrata(getTile(state, x, y)!);
-}
 
 /** Sentinel "textures" — resolveTileSprite only passes them through, so plain
  *  tagged objects are enough to assert which sprite was picked. */
@@ -116,8 +105,7 @@ describe('rail-road level crossings', () => {
     for (const x of [1, 2, 3]) setTile(state, x, 2, TileKind.Road);
     for (const y of [1, 2, 3]) setTile(state, 2, y, TileKind.Rail);
     const crossingTile = getTile(state, 2, 2)!;
-    crossingTile.roadUnderlay = true;
-    resyncTileStrata(crossingTile);
+    setTileOccupant(crossingTile, Occupant.Road, true);
     expect(spriteName(state, 2, 2, textures)).toBe('crossing-ns');
   });
 
@@ -130,8 +118,7 @@ describe('rail-road level crossings', () => {
     setTile(state, 2, 2, TileKind.Road);
     setTile(state, 2, 3, TileKind.Road);
     const crossingTile = getTile(state, 2, 2)!;
-    crossingTile.railUnderlay = true;
-    resyncTileStrata(crossingTile);
+    setTileOccupant(crossingTile, Occupant.Rail, true);
     expect(spriteName(state, 2, 2, textures)).toBe('crossing-ew');
   });
 
@@ -220,8 +207,7 @@ describe('hydro crossing road, rail and zones (issue #169)', () => {
     setTile(state, 2, 5, TileKind.PowerLine);
     setTile(state, 2, 4, TileKind.PowerLine);
     const tile = getTile(state, 2, 4)!;
-    tile.roadUnderlay = true;
-    resyncTileStrata(tile);
+    setTileOccupant(tile, Occupant.Road, true);
 
     expect(spriteName(state, 2, 4, textures)).toBe('road-ew');
     expect(overlayName(state, 2, 4, textures)).toBe('xing-ns');
@@ -236,8 +222,7 @@ describe('hydro crossing road, rail and zones (issue #169)', () => {
     setTile(state, 3, 4, TileKind.PowerLine);
     setTile(state, 2, 4, TileKind.PowerLine);
     const tile = getTile(state, 2, 4)!;
-    tile.railUnderlay = true;
-    resyncTileStrata(tile);
+    setTileOccupant(tile, Occupant.Rail, true);
 
     expect(spriteName(state, 2, 4, textures)).toBe('rail-ns');
     expect(overlayName(state, 2, 4, textures)).toBe('xing-ew');
@@ -254,8 +239,7 @@ describe('hydro crossing road, rail and zones (issue #169)', () => {
     const textures = makeTextures();
     setTile(state, 2, 4, TileKind.Residential);
     const tile = getTile(state, 2, 4)!;
-    tile.powerOverlay = true;
-    resyncTileStrata(tile);
+    setTileOccupant(tile, Occupant.PowerLine, true);
     setTile(state, 2, 3, TileKind.PowerLine);
     setTile(state, 2, 5, TileKind.PowerLine);
 
@@ -274,8 +258,7 @@ describe('hydro crossing road, rail and zones (issue #169)', () => {
     setTile(state, 2, 4, TileKind.Residential);
     const tile = getTile(state, 2, 4)!;
     tile.buildingId = 1;
-    tile.powerOverlay = true;
-    resyncTileStrata(tile);
+    setTileOccupant(tile, Occupant.PowerLine, true);
     setTile(state, 2, 3, TileKind.PowerLine);
     setTile(state, 2, 5, TileKind.PowerLine);
 
@@ -304,8 +287,7 @@ describe('hydro crossing poles', () => {
     for (const x of [1, 2, 3]) setTile(state, x, 4, TileKind.Road);
     for (const y of [3, 4, 5]) setTile(state, 2, y, TileKind.PowerLine);
     const tile = getTile(state, 2, 4)!;
-    tile.roadUnderlay = true;
-    resyncTileStrata(tile);
+    setTileOccupant(tile, Occupant.Road, true);
     expect(overlayName(state, 2, 4, textures)).toBe('xing-ns');
   });
 
@@ -319,8 +301,7 @@ describe('hydro crossing poles', () => {
     for (const x of [1, 2, 3]) setTile(state, x, 4, TileKind.PowerLine);
     for (const t of [[1, 4], [2, 4], [3, 4]]) {
       const tile = getTile(state, t[0], t[1])!;
-      tile.roadUnderlay = true;
-      resyncTileStrata(tile);
+      setTileOccupant(tile, Occupant.Road, true);
     }
     expect(overlayName(state, 2, 4, textures)).toBe('kerb-ew-ew');
   });
@@ -334,8 +315,7 @@ describe('hydro crossing poles', () => {
     setTile(state, 2, 3, TileKind.PowerLine);
     setTile(state, 2, 4, TileKind.PowerLine);
     const tile = getTile(state, 2, 4)!;
-    tile.roadUnderlay = true;
-    resyncTileStrata(tile);
+    setTileOccupant(tile, Occupant.Road, true);
     expect(overlayName(state, 2, 4, textures)).toBe('kerb-ew-end-n');
   });
 
@@ -347,8 +327,7 @@ describe('hydro crossing poles', () => {
     for (const t of [[2, 3], [2, 5], [1, 4], [3, 4], [2, 4]]) setTile(state, t[0], t[1], TileKind.PowerLine);
     for (const t of [[2, 3], [2, 5], [1, 4], [3, 4], [2, 4]]) {
       const tile = getTile(state, t[0], t[1])!;
-      tile.roadUnderlay = true;
-      resyncTileStrata(tile);
+      setTileOccupant(tile, Occupant.Road, true);
     }
     expect(overlayName(state, 2, 4, textures)).toBe('kerb-x-cross');
   });
@@ -381,8 +360,7 @@ describe('crossing selection by axis', () => {
     setTile(state, 2, 5, TileKind.Road);          // makes it a T
     for (const y of [3, 4, 5]) setTile(state, 2, y, TileKind.PowerLine);
     const tile = getTile(state, 2, 4)!;
-    tile.roadUnderlay = true;
-    resyncTileStrata(tile);
+    setTileOccupant(tile, Occupant.Road, true);
     expect(overlayName(state, 2, 4, textures)).toBe('xing-ns');
   });
 });
@@ -391,34 +369,44 @@ describe('getTileColour agrees with the sprite/connectivity derivation on what c
   it('tints a tile with powerPlantType set, differently powered vs unpowered', () => {
     const state = createInitialState(3, 3);
     const tile = getTile(state, 1, 1)!;
-    tile.kind = TileKind.Land; // pin the palette key regardless of createInitialState's terrain pattern
+    tile.terrain = Terrain.Land; // pin the palette key regardless of createInitialState's terrain pattern
     tile.powerPlantType = PowerPlantType.Coal;
     const palette = { [TileKind.Land]: 0x804020 } as Record<TileKind, number>;
 
     tile.powered = false;
-    const unpowered = getTileColour(tile, palette);
+    const unpowered = getTileColour(tile, palette, emptyLookup);
     tile.powered = true;
-    const powered = getTileColour(tile, palette);
+    const powered = getTileColour(tile, palette, emptyLookup);
 
     expect(unpowered).not.toBe(palette[TileKind.Land]);
     expect(powered).not.toBe(palette[TileKind.Land]);
     expect(unpowered).not.toBe(powered);
   });
 
-  it('does not treat a bare kind match as power infrastructure without powerPlantType', () => {
+  it('does not treat a live structure as power infrastructure without powerPlantType', () => {
     // Regression: `getTileColour` and the wire-connectivity predicate used to
-    // fall back to a `tile.kind`-based plant-type lookup, diverging from
+    // fall back to a derived-kind plant-type lookup, diverging from
     // `resolveBaseTileSprite`'s buildingLookup-only derivation for the same
-    // question. `setTile` here sets `kind` to a plant kind but — matching a
-    // real placed plant only ever getting `powerPlantType` through
-    // `placeBuilding`'s `decorateTile` callback — leaves `powerPlantType`
-    // unset, so this tile must read as plain ground, not a plant.
+    // question. This tile carries a `Structure` occupant and a `buildingId`
+    // resolving to `TileKind.CoalPlant` via the lookup — matching a real
+    // placed plant only ever getting `powerPlantType` through
+    // `placeBuilding`'s `decorateTile` callback — but `powerPlantType` itself
+    // is left unset, so this tile must read as plain ground, not a plant.
     const state = createInitialState(3, 3);
-    setTile(state, 1, 1, TileKind.CoalPlant);
     const tile = getTile(state, 1, 1)!;
+    tile.terrain = Terrain.Land;
+    tile.buildingId = 1;
+    setTileOccupant(tile, Occupant.Structure, true);
+    state.buildings.push({
+      id: 1,
+      templateId: PowerPlantType.Coal,
+      origin: { x: 1, y: 1 },
+      state: createBuildingState()
+    });
     expect(tile.powerPlantType).toBeUndefined();
+    const { buildingLookup } = createBuildingLookup(state);
     const palette = { [TileKind.CoalPlant]: 0x804020 } as Record<TileKind, number>;
 
-    expect(getTileColour(tile, palette)).toBe(palette[TileKind.CoalPlant]);
+    expect(getTileColour(tile, palette, buildingLookup)).toBe(palette[TileKind.CoalPlant]);
   });
 });

--- a/app/src/rendering/tileRenderUtils.ts
+++ b/app/src/rendering/tileRenderUtils.ts
@@ -9,6 +9,7 @@ import { POWER_PLANT_CONFIGS, PowerPlantType } from '../game/constants';
 import { getBuildingTemplate } from '../game/buildings/templates';
 import { getTile, TileKind, type GameState } from '../game/gameState';
 import { Occupant, Terrain, hasOccupant, zoneOccupant } from '../game/protocol/occupants';
+import { legacyKind } from '../game/protocol/legacyProjection';
 import type { CarriagewayClass, HydroVariant, RoadVariant, TileTextures } from './tileAtlas';
 
 export type BuildingLookupEntry = {
@@ -67,6 +68,22 @@ export function createBuildingLookup(state: GameState) {
  *  line, so a plant/school/park with a buildingId never carries one). */
 function isDevelopedZone(tile: NonNullable<ReturnType<typeof getTile>>): boolean {
   return zoneOccupant(tile.surface) !== undefined && tile.buildingId !== undefined;
+}
+
+/**
+ * The tile's derived `TileKind` — the terminal fallback for `tileTextures`/
+ * `palette` lookups once every dedicated branch above has passed. Computed
+ * on demand via `legacyKind` rather than stored: there is no shim field
+ * left to read it off.
+ */
+function fallbackKind(tile: NonNullable<ReturnType<typeof getTile>>, buildingLookup: BuildingLookup): TileKind {
+  return legacyKind({
+    terrain: tile.terrain,
+    surface: tile.surface,
+    overhead: tile.overhead,
+    buildingId: tile.buildingId,
+    structureKindOf: (id) => buildingLookup.get(id)?.template?.tileKind
+  });
 }
 
 /** True when hydro is strung over this tile and must be drawn as a separate
@@ -386,19 +403,23 @@ function resolveBaseTileSprite(
       if (roadTexture) return { texture: roadTexture, widthTiles: 1, heightTiles: 1 };
     }
   }
-  const baseTexture = tileTextures.tiles[tile.kind];
+  const baseTexture = tileTextures.tiles[fallbackKind(tile, buildingLookup)];
   if (baseTexture) return { texture: baseTexture, widthTiles: 1, heightTiles: 1 };
   return undefined;
 }
 
-export function getTileColour(tile: ReturnType<typeof getTile>, palette: Record<TileKind, number>) {
+export function getTileColour(
+  tile: ReturnType<typeof getTile>,
+  palette: Record<TileKind, number>,
+  buildingLookup: BuildingLookup
+) {
   if (!tile) return 0x000000;
-  const base = palette[tile.kind];
+  const base = palette[fallbackKind(tile, buildingLookup)];
   // `tile.powerPlantType` alone, matching `resolveBaseTileSprite`'s plant-type
   // derivation below — `placeBuilding`'s `decorateTile` callback sets it on
   // every tile of a plant's footprint, not just the origin, so there is no
-  // live plant tile this can miss. A `tile.kind`-based fallback here used to
-  // let this function call a tile "power infrastructure" that
+  // live plant tile this can miss. A `kind`-based fallback here used to let
+  // this function call a tile "power infrastructure" that
   // `resolveBaseTileSprite` didn't recognise as a plant, tinting a tile
   // whose own sprite never resolved as one.
   const isPowerTile = hasOccupant(tile.overhead, Occupant.PowerLine) || !!tile.powerPlantType;


### PR DESCRIPTION
## Summary

- **The shim is gone.** `kind`, `legacyUnderground`, `roadUnderlay`, `railUnderlay` and `powerOverlay` are deleted from `Tile` in `gameState.ts`. `tsc --noEmit` (whole-program) walked every remaining consumer to a fix — this PR is that fix, applied file by file until the compiler had nothing left to say.
- **A real architectural gap surfaced and got fixed**: `buildings/manager.ts`'s single `placeBuilding` was doing two different jobs — civic/power footprint placement *and* zone-lot development — that Rust deliberately keeps separate (`place_footprint_building` vs. `place_zone_building` in `zones.rs`). New `placeZoneBuilding` splits zone growth out: it only ever sets `buildingId`, never touches an occupant bit, since a developed zone lot's occupant is its zone tag, not `Structure`. `simulation.ts`'s zone-growth path and two tests that manually seeded a "developed lot" now use it.
- **Bridges drop their shim-derivation blocks** (`wasmSimBridge.ts`, `tauriSimBridge.ts`) — they existed purely to populate fields nothing reads any more.
- **Rendering fallbacks compute on demand**: `tileRenderUtils.ts`'s terminal `tileTextures.tiles[...]`/`palette[...]` lookups (once every dedicated branch has passed) now derive the kind via a new `fallbackKind` helper wrapping `legacyKind`, rather than reading a stored field.
- **`legacyProjection.ts` sheds `resyncTileStrata`/`resyncLegacyFromStrata`** — both existed only to keep two representations in sync with each other; there's one left. `legacyKind`/`legacyFlags`/`tileFromV4` survive: old `.citysim` saves still import through `tileFromV4`, and the frozen legacy engine importer still needs a v4-shaped export (`persistence.ts`'s `buildLegacyEngineImport`, now deriving it live instead of reading it off the tile).
- **Two dead-code branches removed** (`debugStats.ts`, matching one already removed from `simulation.ts` last PR): a `buildingId === undefined && kind === WaterPump` civic-billing case that's structurally unreachable under `legacyKind`'s current derivation — no test exercised it.

### An interesting side effect while fixing tests

Several test scenarios (`tools.test.ts`, `saveContainer.test.ts`) happened to place their assertions on tiles that `createInitialState`'s terrain pattern makes water on a small map — invisible before because nothing checked terrain first, but `legacyKind` does (`terrain === Water` short-circuits everything else). Rebuilt those scenarios on land tiles.

## Test plan

- [x] `bun run lint` — `tsc --noEmit`, whole-program, clean
- [x] `bun run test` — 352 tests
- [x] `bun run test:parity` — 42 cross-engine parity tests
- [x] `bun run test:e2e` — all 15 tests, visual-regression golden PNGs byte-unchanged from the previous PR
