### PR TITLE
Reconnect deficit alerts, command results, and the no-water icon

### DIFF
--- a/app/src/game/protocol/deficitNarrative.test.ts
+++ b/app/src/game/protocol/deficitNarrative.test.ts
@@ -1,0 +1,27 @@
+// deficitNarrative.test.ts — AlertKind → narrative SimEvent derivation.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+import { deriveNarrativeEventFromAlert } from './deficitNarrative';
+import type { SimAlert } from './events';
+
+describe('deriveNarrativeEventFromAlert', () => {
+  it.each([
+    ['PowerDeficit', 'power_deficit_start', 'alert'],
+    ['PowerRestored', 'power_deficit_end', 'info'],
+    ['WaterDeficit', 'water_deficit_start', 'alert'],
+    ['WaterRestored', 'water_deficit_end', 'info'],
+  ] as const)('maps %s to a %s narrative event with %s severity', (kind, type, severity) => {
+    const alert: SimAlert = { kind, message: 'msg', sticky: kind.endsWith('Deficit') };
+    const event = deriveNarrativeEventFromAlert(alert, 12345);
+    expect(event).toMatchObject({ type, category: 'utilities', severity, message: 'msg', timestamp: 12345 });
+    expect(event?.id).toBe(`${type}-12345`);
+  });
+
+  it('returns null for alert kinds with no narrative counterpart', () => {
+    const alert: SimAlert = { kind: 'BudgetWarning', message: 'msg', sticky: false };
+    expect(deriveNarrativeEventFromAlert(alert, 1)).toBeNull();
+  });
+});

--- a/app/src/game/protocol/deficitNarrative.ts
+++ b/app/src/game/protocol/deficitNarrative.ts
@@ -1,0 +1,41 @@
+// deficitNarrative.ts — derives the narrative-ticker event that pairs with a
+// utility deficit/restore alert.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import type { SimAlert, AlertKind } from './events';
+import type { SimEvent, SimEventType } from '../narrative/types';
+
+const EVENT_TYPE_BY_ALERT_KIND: Partial<Record<AlertKind, SimEventType>> = {
+  PowerDeficit: 'power_deficit_start',
+  PowerRestored: 'power_deficit_end',
+  WaterDeficit: 'water_deficit_start',
+  WaterRestored: 'water_deficit_end',
+};
+
+/**
+ * Derives the ticker/insights `SimEvent` that pairs with a deficit/restore
+ * `SimAlert`, or `null` for alert kinds with no narrative counterpart (e.g.
+ * `BudgetWarning`/`Abandonment`/`Info`, none of which the engine raises yet).
+ *
+ * Shared by `wasmSimBridge.ts` and `tauriSimBridge.ts` deliberately: the
+ * mapping from `AlertKind` to `SimEventType` and the wall-clock `timestamp`
+ * are display/narrative concerns, not simulation truth, so they stay out of
+ * Rust (see `sim.rs`'s `handle_resource_alerts`, which raises only the
+ * alert) — kept in exactly one TS place instead of two independently
+ * maintained copies, one per bridge.
+ */
+export function deriveNarrativeEventFromAlert(alert: SimAlert, now: number): SimEvent | null {
+  const type = EVENT_TYPE_BY_ALERT_KIND[alert.kind];
+  if (!type) return null;
+  const starting = type.endsWith('_start');
+  return {
+    id: `${type}-${now}`,
+    type,
+    timestamp: now,
+    category: 'utilities',
+    severity: starting ? 'alert' : 'info',
+    message: alert.message,
+  };
+}

--- a/app/src/game/tauriSimBridge.test.ts
+++ b/app/src/game/tauriSimBridge.test.ts
@@ -37,6 +37,12 @@ interface WireBuilding {
   originY: number;
 }
 
+interface SimAlert {
+  kind: 'PowerDeficit' | 'PowerRestored' | 'WaterDeficit' | 'WaterRestored' | 'BudgetWarning' | 'Abandonment' | 'Info';
+  message: string;
+  sticky: boolean;
+}
+
 interface TickEvent {
   tick: number; day: number; population: number; jobs: number; money: number;
   power: number; water: number; powerProduced: number; waterProduced: number;
@@ -46,6 +52,7 @@ interface TickEvent {
   tiles: number[];
   buildings: WireBuilding[];
   canUndo: boolean; canRedo: boolean;
+  alerts: SimAlert[];
 }
 
 const GRID_TILES = 8 * 8;
@@ -60,6 +67,7 @@ function baseTickEvent(overrides: Partial<TickEvent> = {}): TickEvent {
     tiles: new Array(GRID_TILES * BYTES_PER_TILE).fill(0),
     buildings: [],
     canUndo: false, canRedo: false,
+    alerts: [],
     ...overrides
   };
 }
@@ -67,7 +75,7 @@ function baseTickEvent(overrides: Partial<TickEvent> = {}): TickEvent {
 function makeFakePlugin(): TauriPluginBindings {
   return {
     start: vi.fn(),
-    applyTool: vi.fn(),
+    applyTool: vi.fn().mockResolvedValue({ success: true, message: null }),
     setSpeed: vi.fn(),
     setPolicies: vi.fn(),
     setNaturalTerrain: vi.fn(),
@@ -148,6 +156,20 @@ describe('TauriSimBridge command routing', () => {
 
     bridge.dispose();
     expect(plugin.stop).toHaveBeenCalled();
+  });
+
+  it('forwards a refused ApplyTool\'s message as a CommandResult once the plugin resolves', async () => {
+    const { bridge, plugin, events } = await makeBridge();
+    vi.mocked(plugin.applyTool).mockResolvedValueOnce({ success: false, message: 'Not enough funds' });
+
+    bridge.send(applyToolCmd(Tool.Road, 3, 4, nextStrokeId()));
+    // send() itself must still answer synchronously and optimistically —
+    // the real result arrives later, over the resolved promise.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const result = events.find((e) => e.type === 'CommandResult');
+    expect(result).toEqual({ type: 'CommandResult', success: false, message: 'Not enough funds' });
   });
 });
 
@@ -294,6 +316,25 @@ describe('TauriSimBridge onTick decode', () => {
     const after = historyEvents();
     expect(after.length).toBe(before + 1);
     expect(after[after.length - 1]).toMatchObject({ data: { canUndo: true, canRedo: false } });
+  });
+
+  it('forwards each alert as FromSim::Alert plus its paired narrative event', async () => {
+    const { emit, events } = await makeBridge();
+    emit(baseTickEvent({
+      alerts: [{ kind: 'PowerDeficit', message: 'Power deficit detected.', sticky: true }],
+    }));
+
+    const alert = events.find((e) => e.type === 'Alert');
+    expect(alert).toMatchObject({
+      type: 'Alert',
+      data: { kind: 'PowerDeficit', message: 'Power deficit detected.', sticky: true },
+    });
+
+    const narrative = events.find((e) => e.type === 'Narrative');
+    expect(narrative).toMatchObject({
+      type: 'Narrative',
+      data: { kind: 'Alert', payload: { type: 'power_deficit_start', category: 'utilities', severity: 'alert' } },
+    });
   });
 
   it('emits Ready once the plugin has started and the engine is seeded', async () => {

--- a/app/src/game/tauriSimBridge.ts
+++ b/app/src/game/tauriSimBridge.ts
@@ -40,6 +40,7 @@ import type { FromSim } from './protocol/events';
 import { tileKindFromU8, tileKindToU8 } from './protocol/tileKind';
 import { Occupant, Terrain, ZoneDensity, hasOccupant } from './protocol/occupants';
 import { decodeTileBuffer } from './protocol/tileBuffer';
+import { deriveNarrativeEventFromAlert } from './protocol/deficitNarrative';
 import { createTileServiceState } from './services';
 import { Tool } from './toolTypes';
 import {
@@ -170,10 +171,14 @@ export class TauriSimBridge implements SimBridge {
     switch (cmd.type) {
       case 'ApplyTool': {
         const id = TOOL_TO_ID[cmd.tool];
-        void this.plugin.applyTool(id, cmd.x, cmd.y, cmd.strokeId);
-        // Optimistic: the Rust side will reject invalid placements silently;
-        // a proper async result is deferred to P5 when we wire CommandResult
-        // events back through the Channel.
+        // Optimistic return: `send()` must answer synchronously (SimBridge's
+        // interface contract), but the real result comes back from the sim
+        // thread over IPC. Forward it once it lands, correlated to this exact
+        // call by promise identity ("keyed by stroke" in practice, since each
+        // call already carries its own strokeId).
+        void this.plugin.applyTool(id, cmd.x, cmd.y, cmd.strokeId).then((result) => {
+          this.handler?.({ type: 'CommandResult', success: result.success, message: result.message ?? undefined });
+        });
         return { success: true };
       }
       case 'SetSpeed':
@@ -355,6 +360,17 @@ export class TauriSimBridge implements SimBridge {
 
     // Education coverage keys off the rebuilt buildings list.
     s.education = recomputeEducation(s);
+
+    // Forward any deficit/restore alerts raised this tick, plus each one's
+    // paired narrative event — same derivation `wasmSimBridge.ts` uses, kept
+    // in one shared helper so the two bridges can't independently drift.
+    for (const alert of event.alerts) {
+      this.handler?.({ type: 'Alert', data: alert });
+      const narrative = deriveNarrativeEventFromAlert(alert, Date.now());
+      if (narrative) {
+        this.handler?.({ type: 'Narrative', data: { kind: 'Alert', payload: narrative } });
+      }
+    }
 
     // Forward TickStats to the UI handler
     this.handler?.({

--- a/app/src/game/wasmSimBridge.test.ts
+++ b/app/src/game/wasmSimBridge.test.ts
@@ -208,12 +208,18 @@ describe('WasmSimBridge undo/redo', () => {
     expect(result).toEqual({ type: 'CommandResult', success: false, message: 'Not enough funds' });
   });
 
-  it('forwards each step_result alert as FromSim::Alert plus its paired narrative event', () => {
-    const { worker, events } = makeBridge();
+  it('forwards each step_result alert as FromSim::Alert plus its paired narrative event, once step() flushes it', () => {
+    const { worker, bridge, events } = makeBridge();
     worker.emit({
       type: 'step_result', bytes: emptyTileBuffer(), stats: zeroStats(), mutationSeq: 0,
       alerts: [{ kind: 'WaterDeficit', message: 'Water deficit detected.', sticky: true }],
     });
+    // Alerts are staged like pendingStats/pendingTileBuffer, not dispatched
+    // on arrival — see pendingAlerts' field doc for why (undo/redo/load must
+    // be able to discard a stale one before it ever reaches the player).
+    expect(events.find(e => e.type === 'Alert')).toBeUndefined();
+
+    bridge.step(1 / 20);
 
     const alert = events.find(e => e.type === 'Alert');
     expect(alert).toMatchObject({
@@ -225,6 +231,28 @@ describe('WasmSimBridge undo/redo', () => {
     expect(narrative).toMatchObject({
       type: 'Narrative',
       data: { kind: 'Alert', payload: { type: 'water_deficit_start', category: 'utilities', severity: 'alert' } },
+    });
+  });
+
+  it('discards a pending alert when an undo lands before step() flushes it', () => {
+    const { worker, bridge, events } = makeBridge();
+    worker.emit({
+      type: 'step_result', bytes: emptyTileBuffer(), stats: zeroStats(), mutationSeq: 0,
+      alerts: [{ kind: 'PowerDeficit', message: 'Power deficit detected.', sticky: true }],
+    });
+
+    const pending = bridge.undo();
+    worker.emit({
+      type: 'undo_result', happened: true,
+      bytes: emptyTileBuffer(), stats: zeroStats(), history: flags(false, true)
+    });
+
+    return pending.then(() => {
+      bridge.step(1 / 20);
+      // The undo happened before the deficit-carrying step_result was ever
+      // flushed — since the Rust engine resyncs its latch silently on
+      // restore, no alert (deficit or restore) should surface for it.
+      expect(events.find(e => e.type === 'Alert')).toBeUndefined();
     });
   });
 

--- a/app/src/game/wasmSimBridge.test.ts
+++ b/app/src/game/wasmSimBridge.test.ts
@@ -175,8 +175,8 @@ describe('WasmSimBridge undo/redo', () => {
     const historyEvents = () => events.filter(e => e.type === 'HistoryChanged');
     const before = historyEvents().length;
     bridge.send(applyToolCmd(Tool.Road, 1, 0, nextStrokeId()));
-    worker.emit({ type: 'apply_result', success: true, history: flags(true, false) });
-    worker.emit({ type: 'apply_result', success: true, history: flags(true, false) });
+    worker.emit({ type: 'apply_result', success: true, message: null, history: flags(true, false) });
+    worker.emit({ type: 'apply_result', success: true, message: null, history: flags(true, false) });
     const after = historyEvents();
     expect(after.length).toBe(before + 1);
     expect(after[after.length - 1]).toMatchObject({ data: { canUndo: true, canRedo: false } });
@@ -185,7 +185,7 @@ describe('WasmSimBridge undo/redo', () => {
   it('discards a pending step_result when an undo lands', async () => {
     const { worker, state, bridge } = makeBridge();
     const staleStats = { ...zeroStats(), money: 424242 };
-    worker.emit({ type: 'step_result', bytes: emptyTileBuffer(), stats: staleStats });
+    worker.emit({ type: 'step_result', bytes: emptyTileBuffer(), stats: staleStats, alerts: [] });
     const pending = bridge.undo();
     const undoneStats = { ...zeroStats(), money: 1111 };
     worker.emit({
@@ -197,6 +197,35 @@ describe('WasmSimBridge undo/redo', () => {
     // step_result must be gone, leaving the undone stats in place.
     bridge.step(1 / 20);
     expect(state.money).toBe(1111);
+  });
+
+  it('forwards a refused apply_result as a CommandResult with the message', () => {
+    const { worker, bridge, events } = makeBridge();
+    bridge.send(applyToolCmd(Tool.Road, 1, 0, nextStrokeId()));
+    worker.emit({ type: 'apply_result', success: false, message: 'Not enough funds', history: flags(false, false) });
+
+    const result = events.find(e => e.type === 'CommandResult');
+    expect(result).toEqual({ type: 'CommandResult', success: false, message: 'Not enough funds' });
+  });
+
+  it('forwards each step_result alert as FromSim::Alert plus its paired narrative event', () => {
+    const { worker, events } = makeBridge();
+    worker.emit({
+      type: 'step_result', bytes: emptyTileBuffer(), stats: zeroStats(), mutationSeq: 0,
+      alerts: [{ kind: 'WaterDeficit', message: 'Water deficit detected.', sticky: true }],
+    });
+
+    const alert = events.find(e => e.type === 'Alert');
+    expect(alert).toMatchObject({
+      type: 'Alert',
+      data: { kind: 'WaterDeficit', message: 'Water deficit detected.', sticky: true },
+    });
+
+    const narrative = events.find(e => e.type === 'Narrative');
+    expect(narrative).toMatchObject({
+      type: 'Narrative',
+      data: { kind: 'Alert', payload: { type: 'water_deficit_start', category: 'utilities', severity: 'alert' } },
+    });
   });
 
   it('translates a worker init_error message into an InitError event', () => {

--- a/app/src/game/wasmSimBridge.ts
+++ b/app/src/game/wasmSimBridge.ts
@@ -21,7 +21,8 @@ import type { LegacyEngineImport, SimBridge } from './simBridge';
 import type { BudgetPolicy, SimCommand, CommandResult } from './protocol/commands';
 import { recordDailyBudget } from './economy';
 import type { FromSim } from './protocol/events';
-import type { SimStats } from '../workers/wasmSim.worker';
+import type { SimStats, SimAlertWire } from '../workers/wasmSim.worker';
+import { deriveNarrativeEventFromAlert } from './protocol/deficitNarrative';
 import { decodeTileBuffer } from './protocol/tileBuffer';
 import { tileKindFromU8, tileKindToU8 } from './protocol/tileKind';
 import { Occupant, Terrain, ZoneDensity, hasOccupant } from './protocol/occupants';
@@ -70,8 +71,8 @@ type WorkerToMain =
   /** Posted only when the WASM's `Last-Modified` changes under a live page. */
   | { type: 'build_update'; build: { lastModified: string | null } }
   | { type: 'init_error';   message: string }
-  | { type: 'step_result';  bytes: Uint8Array; stats: SimStats; buildingsJson: string; mutationSeq: number }
-  | { type: 'apply_result'; success: boolean; history: WorkerHistoryFlags }
+  | { type: 'step_result';  bytes: Uint8Array; stats: SimStats; buildingsJson: string; mutationSeq: number; alerts: SimAlertWire[] }
+  | { type: 'apply_result'; success: boolean; message: string | null; history: WorkerHistoryFlags }
   | { type: 'undo_result';  happened: false; history: WorkerHistoryFlags }
   | { type: 'undo_result';  happened: true; bytes: Uint8Array; stats: SimStats; buildingsJson: string; mutationSeq: number; history: WorkerHistoryFlags }
   | { type: 'redo_result';  happened: false; history: WorkerHistoryFlags }
@@ -386,11 +387,13 @@ export class WasmSimBridge implements SimBridge {
         this.pendingBuildingsJson = msg.buildingsJson;
         this.pendingStats = msg.stats;
         this.pendingMutationSeq = msg.mutationSeq;
+        // Dispatched immediately, not gated behind step()'s "nothing changed"
+        // skip — alerts are rare, edge-triggered events, not per-tick state
+        // the mirror can just re-derive next frame if one were dropped.
+        this.dispatchAlerts(msg.alerts);
         break;
       case 'apply_result':
-        if (!msg.success) {
-          console.warn('[WasmSimBridge] apply_tool rejected by Rust sim');
-        }
+        this.handler?.({ type: 'CommandResult', success: msg.success, message: msg.message ?? undefined });
         this.syncHistoryFlags(msg.history);
         break;
       case 'undo_result':
@@ -473,6 +476,17 @@ export class WasmSimBridge implements SimBridge {
       overhead: 0,
       density: ZoneDensity.Low,
     }));
+  }
+
+  /** Forward each alert as `FromSim::Alert`, plus its paired narrative event if any. */
+  private dispatchAlerts(alerts: SimAlertWire[]): void {
+    for (const alert of alerts) {
+      this.handler?.({ type: 'Alert', data: alert });
+      const narrative = deriveNarrativeEventFromAlert(alert, Date.now());
+      if (narrative) {
+        this.handler?.({ type: 'Narrative', data: { kind: 'Alert', payload: narrative } });
+      }
+    }
   }
 
   private syncHistoryFlags(flags: WorkerHistoryFlags): void {

--- a/app/src/game/wasmSimBridge.ts
+++ b/app/src/game/wasmSimBridge.ts
@@ -113,6 +113,17 @@ export class WasmSimBridge implements SimBridge {
   private pendingBuildingsJson = '';
   private pendingStats: SimStats | null = null;
   private pendingMutationSeq = 0;
+  /**
+   * Alerts from step_results not yet flushed by step() — staged the same way
+   * as pendingStats/pendingTileBuffer rather than dispatched on arrival, so
+   * an undo/redo/load that discards a stale step_result (see those handlers
+   * below) discards its alerts too. Without this, an alert raised by a
+   * step_result that predates a rollback could reach the player as a
+   * permanent sticky toast for a state transition the rollback undid, with
+   * no restore alert ever following it — the Rust-side latch resyncs
+   * silently on load_state, so nothing else would ever correct it.
+   */
+  private pendingAlerts: SimAlertWire[] = [];
   private pendingUndo: ((happened: boolean) => void) | null = null;
   private pendingRedo: ((happened: boolean) => void) | null = null;
   private canUndoFlag = false;
@@ -204,6 +215,7 @@ export class WasmSimBridge implements SimBridge {
     ) {
       this.pendingTileBuffer = null;
       this.pendingStats = null;
+      this.pendingAlerts = [];
       return this.consumeDirty();
     }
     if (this.pendingTileBuffer !== null) {
@@ -217,6 +229,10 @@ export class WasmSimBridge implements SimBridge {
       this.lastAppliedMutationSeq = this.pendingMutationSeq;
       this.pendingStats = null;
       this.dirtySinceLastStep = true;
+    }
+    if (this.pendingAlerts.length > 0) {
+      this.dispatchAlerts(this.pendingAlerts);
+      this.pendingAlerts = [];
     }
     return this.consumeDirty();
   }
@@ -387,10 +403,10 @@ export class WasmSimBridge implements SimBridge {
         this.pendingBuildingsJson = msg.buildingsJson;
         this.pendingStats = msg.stats;
         this.pendingMutationSeq = msg.mutationSeq;
-        // Dispatched immediately, not gated behind step()'s "nothing changed"
-        // skip — alerts are rare, edge-triggered events, not per-tick state
-        // the mirror can just re-derive next frame if one were dropped.
-        this.dispatchAlerts(msg.alerts);
+        // Staged, not dispatched here — see pendingAlerts' field doc. Concat
+        // rather than replace: if two step_results arrive before the next
+        // step() flush (a delayed rAF frame), neither's alerts are lost.
+        this.pendingAlerts = this.pendingAlerts.concat(msg.alerts);
         break;
       case 'apply_result':
         this.handler?.({ type: 'CommandResult', success: msg.success, message: msg.message ?? undefined });
@@ -398,9 +414,14 @@ export class WasmSimBridge implements SimBridge {
         break;
       case 'undo_result':
         // Discard any pending step_result — it was computed before the undo
-        // and would overwrite the rolled-back state on the next frame.
+        // and would overwrite the rolled-back state on the next frame. Its
+        // alerts go with it: the engine resyncs the deficit latches to the
+        // restored balance silently (see sim.rs's load_state), so an alert
+        // from a pre-undo step_result describes a transition the undo just
+        // erased, and no correcting alert will ever arrive to cancel it.
         this.pendingTileBuffer = null;
         this.pendingStats = null;
+        this.pendingAlerts = [];
         if (msg.happened) {
           this.applyTileBuffer(msg.bytes, msg.buildingsJson);
           this.updateStats(msg.stats);
@@ -413,8 +434,10 @@ export class WasmSimBridge implements SimBridge {
         this.pendingUndo = null;
         break;
       case 'redo_result':
+        // Same reasoning as undo_result above.
         this.pendingTileBuffer = null;
         this.pendingStats = null;
+        this.pendingAlerts = [];
         if (msg.happened) {
           this.applyTileBuffer(msg.bytes, msg.buildingsJson);
           this.updateStats(msg.stats);
@@ -440,9 +463,10 @@ export class WasmSimBridge implements SimBridge {
           break;
         }
         // Discard pre-load frames and refresh the mirror atomically before
-        // the caller's promise resolves.
+        // the caller's promise resolves — same reasoning as undo_result above.
         this.pendingTileBuffer = null;
         this.pendingStats = null;
+        this.pendingAlerts = [];
         this.adoptDimensions(msg.width, msg.height, msg.seed);
         this.state.policies = msg.policies;
         this.applyTileBuffer(msg.bytes, msg.buildingsJson);

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -446,6 +446,14 @@ function wireBridge(b: SimBridge): void {
       });
     } else if (msg.type === 'Narrative') {
       narrativeManager.onEvent(msg.data.payload as Parameters<typeof narrativeManager.onEvent>[0]);
+    } else if (msg.type === 'CommandResult') {
+      // The synchronous check in applyCurrentTool (bridge.send()'s return
+      // value) can never see a failure — both bridges answer optimistically
+      // before the engine has actually processed the command. This is the
+      // real result, arriving async; surface it the same way.
+      if (!msg.success && msg.message) {
+        showToast(msg.message, { severity: 'warning' });
+      }
     } else if (msg.type === 'HistoryChanged') {
       onHistoryChanged?.(msg.data);
     }
@@ -727,11 +735,13 @@ function applyCurrentTool(tilePos: Position) {
     }
     return;
   }
+  // Both bridges answer this optimistically (success:true, always) before the
+  // engine has actually processed the command — the real result, including
+  // any failure message, arrives async as a `CommandResult` FromSim message
+  // (see `wireBridge` above), not through this return value.
   const result = bridge.send(applyToolCmd(activeTool, tilePos.x, tilePos.y, strokeId));
   sfx?.playToolResult(activeTool, result.success);
-  if (!result.success && result.message) {
-    showToast(result.message);
-  } else if (result.success) {
+  if (result.success) {
     minimap?.markDirty();
     const now = Date.now();
     const message = getPlayerActionMessage(activeTool);

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -452,7 +452,12 @@ function wireBridge(b: SimBridge): void {
       // before the engine has actually processed the command. This is the
       // real result, arriving async; surface it the same way.
       if (!msg.success && msg.message) {
-        showToast(msg.message, { severity: 'warning' });
+        // Keyed by message text, same as the Alert branch above keys by
+        // kind: a drag-paint stroke can send one ApplyTool per tile, and a
+        // sustained failure (e.g. running out of funds mid-drag) would
+        // otherwise post one stacked toast per tile instead of one toast
+        // that keeps refreshing.
+        showToast(msg.message, { id: `command-result:${msg.message}`, severity: 'warning' });
       }
     } else if (msg.type === 'HistoryChanged') {
       onHistoryChanged?.(msg.data);

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -449,15 +449,22 @@ function wireBridge(b: SimBridge): void {
     } else if (msg.type === 'CommandResult') {
       // The synchronous check in applyCurrentTool (bridge.send()'s return
       // value) can never see a failure — both bridges answer optimistically
-      // before the engine has actually processed the command. This is the
-      // real result, arriving async; surface it the same way.
-      if (!msg.success && msg.message) {
-        // Keyed by message text, same as the Alert branch above keys by
-        // kind: a drag-paint stroke can send one ApplyTool per tile, and a
-        // sustained failure (e.g. running out of funds mid-drag) would
-        // otherwise post one stacked toast per tile instead of one toast
-        // that keeps refreshing.
-        showToast(msg.message, { id: `command-result:${msg.message}`, severity: 'warning' });
+      // before the engine has actually processed the command, so the click
+      // already played the success chime. This is the real result, arriving
+      // async; correct both the sound and the message the same way.
+      if (!msg.success) {
+        // playToolResult ignores `tool` entirely once `success` is false —
+        // it always plays the throttled 'error' cue — so which tool was
+        // active doesn't need to be correlated back to this specific call.
+        sfx?.playToolResult(activeTool, false);
+        if (msg.message) {
+          // Keyed by message text, same as the Alert branch above keys by
+          // kind: a drag-paint stroke can send one ApplyTool per tile, and a
+          // sustained failure (e.g. running out of funds mid-drag) would
+          // otherwise post one stacked toast per tile instead of one toast
+          // that keeps refreshing.
+          showToast(msg.message, { id: `command-result:${msg.message}`, severity: 'warning' });
+        }
       }
     } else if (msg.type === 'HistoryChanged') {
       onHistoryChanged?.(msg.data);

--- a/app/src/rendering/renderer.ts
+++ b/app/src/rendering/renderer.ts
@@ -566,17 +566,6 @@ export class MapRenderer {
     size: number,
     buildingLookup: Map<number, { template: ReturnType<typeof getBuildingTemplate>; origin: { x: number; y: number } }>
   ) {
-    // Determine which service types have infrastructure on the map so we only
-    // show "no service" indicators when the player has actually built that service.
-    let hasWaterInfra = false;
-    for (const tile of state.tiles) {
-      const templateKind = tile.buildingId !== undefined ? buildingLookup.get(tile.buildingId)?.template?.tileKind : undefined;
-      if (templateKind === TileKind.WaterPump || templateKind === TileKind.WaterTower) {
-        hasWaterInfra = true;
-        break;
-      }
-    }
-
     // Target display size = half a tile; sprite texture is 128×128.
     const iconPx = 128;
     const iconScale = (size * 0.5) / iconPx;
@@ -590,7 +579,12 @@ export class MapRenderer {
       let texture: import('pixi.js').Texture | undefined;
       if (status === BuildingStatus.InactiveNoPower) {
         texture = this.tileTextures.indicators.noPower;
-      } else if (status === BuildingStatus.InactiveNoWater && hasWaterInfra) {
+      } else if (status === BuildingStatus.InactiveNoWater) {
+        // No separate "does the map have water infra" check needed: both
+        // bridges only ever assign this status when their own hasWaterSystem
+        // scan (pipes included, mirroring `GameState::has_water_system`) was
+        // already true — re-deriving it here was both redundant and, because
+        // it only looked for pumps/towers, missed pipes-only cities entirely.
         texture = this.tileTextures.indicators.noWater;
       }
       if (!texture) continue;

--- a/app/src/rendering/renderer.ts
+++ b/app/src/rendering/renderer.ts
@@ -11,7 +11,7 @@ import { BuildingStatus } from '../game/buildings/state';
 import { getBuildingTemplate, getToolCost } from '../game/buildings/templates';
 import { computeEducationReach } from '../game/education';
 import type { TileTextures } from './tileAtlas';
-import { createBuildingLookup, getTileColour, resolveTileSprite } from './tileRenderUtils';
+import { createBuildingLookup, getTileColour, resolveIndicatorKey, resolveTileSprite } from './tileRenderUtils';
 import { GridDrawer } from './gridDrawer';
 import { isPowerCarrier, isZone, isWaterCarrier } from '../game/adjacency';
 import { Tool } from '../game/toolTypes';
@@ -573,20 +573,8 @@ export class MapRenderer {
 
     const seen = new Set<number>();
     for (const building of state.buildings) {
-      const { status } = building.state;
-      if (status === BuildingStatus.Active) continue;
-
-      let texture: import('pixi.js').Texture | undefined;
-      if (status === BuildingStatus.InactiveNoPower) {
-        texture = this.tileTextures.indicators.noPower;
-      } else if (status === BuildingStatus.InactiveNoWater) {
-        // No separate "does the map have water infra" check needed: both
-        // bridges only ever assign this status when their own hasWaterSystem
-        // scan (pipes included, mirroring `GameState::has_water_system`) was
-        // already true — re-deriving it here was both redundant and, because
-        // it only looked for pumps/towers, missed pipes-only cities entirely.
-        texture = this.tileTextures.indicators.noWater;
-      }
+      const indicatorKey = resolveIndicatorKey(building.state.status);
+      const texture = indicatorKey ? this.tileTextures.indicators[indicatorKey] : undefined;
       if (!texture) continue;
 
       const lookup = buildingLookup.get(building.id);

--- a/app/src/rendering/tileRenderUtils.test.ts
+++ b/app/src/rendering/tileRenderUtils.test.ts
@@ -9,7 +9,8 @@ import { createInitialState, getTile, setTile, TileKind } from '../game/gameStat
 import { PowerPlantType } from '../game/constants';
 import { createBuildingState } from '../game/buildings/state';
 import { Occupant, Terrain, setTileOccupant } from '../game/protocol/occupants';
-import { createBuildingLookup, getTileColour, resolveTileSprite, type BuildingLookup } from './tileRenderUtils';
+import { createBuildingLookup, getTileColour, resolveIndicatorKey, resolveTileSprite, type BuildingLookup } from './tileRenderUtils';
+import { BuildingStatus } from '../game/buildings/state';
 import type { TileTextures } from './tileAtlas';
 
 /** Sentinel "textures" — resolveTileSprite only passes them through, so plain
@@ -408,5 +409,14 @@ describe('getTileColour agrees with the sprite/connectivity derivation on what c
     const palette = { [TileKind.CoalPlant]: 0x804020 } as Record<TileKind, number>;
 
     expect(getTileColour(tile, palette, buildingLookup)).toBe(palette[TileKind.CoalPlant]);
+  });
+});
+
+describe('resolveIndicatorKey', () => {
+  it('maps InactiveNoPower/InactiveNoWater to their icon key, everything else to null', () => {
+    expect(resolveIndicatorKey(BuildingStatus.InactiveNoPower)).toBe('noPower');
+    expect(resolveIndicatorKey(BuildingStatus.InactiveNoWater)).toBe('noWater');
+    expect(resolveIndicatorKey(BuildingStatus.Active)).toBeNull();
+    expect(resolveIndicatorKey(BuildingStatus.InactiveDamaged)).toBeNull();
   });
 });

--- a/app/src/rendering/tileRenderUtils.ts
+++ b/app/src/rendering/tileRenderUtils.ts
@@ -10,7 +10,25 @@ import { getBuildingTemplate } from '../game/buildings/templates';
 import { getTile, TileKind, type GameState } from '../game/gameState';
 import { Occupant, Terrain, hasOccupant, zoneOccupant } from '../game/protocol/occupants';
 import { legacyKind } from '../game/protocol/legacyProjection';
+import { BuildingStatus } from '../game/buildings/state';
 import type { CarriagewayClass, HydroVariant, RoadVariant, TileTextures } from './tileAtlas';
+
+/**
+ * Which `tileTextures.indicators` key (if any) a building's status should
+ * show, or `null` for `Active` and any other status with no icon.
+ *
+ * A plain 1:1 mapping, deliberately: a building can only ever reach
+ * `InactiveNoWater` once the bridge that built it already confirmed a water
+ * system exists (pipes included, mirroring `GameState::has_water_system`),
+ * so this needs no further "does the map actually have water infra" gating —
+ * an earlier version of this logic re-derived that separately, scanning only
+ * for pump/tower buildings, and missed pipes-only cities entirely.
+ */
+export function resolveIndicatorKey(status: BuildingStatus): 'noPower' | 'noWater' | null {
+  if (status === BuildingStatus.InactiveNoPower) return 'noPower';
+  if (status === BuildingStatus.InactiveNoWater) return 'noWater';
+  return null;
+}
 
 export type BuildingLookupEntry = {
   template: ReturnType<typeof getBuildingTemplate>;

--- a/app/src/workers/wasmSim.worker.ts
+++ b/app/src/workers/wasmSim.worker.ts
@@ -18,6 +18,13 @@
 import init, { SimHost, version as engineVersion, build_sha as engineSha } from '../wasm/sim_wasm/sim_wasm.js';
 import wasmUrl from '../wasm/sim_wasm/sim_wasm_bg.wasm?url';
 
+/** Mirrors `city_sim_protocol::events::SimAlert` — see `take_alerts_json()`. */
+export interface SimAlertWire {
+  kind: 'PowerDeficit' | 'PowerRestored' | 'WaterDeficit' | 'WaterRestored' | 'BudgetWarning' | 'Abandonment' | 'Info';
+  message: string;
+  sticky: boolean;
+}
+
 export interface SimStats {
   tick: number;
   day: number;
@@ -189,8 +196,9 @@ function startStepLoop(): void {
     const bytes = host.tile_buffer();
     const stats = gatherStats(host);
     const buildingsJson = host.buildings_json();
+    const alerts: SimAlertWire[] = JSON.parse(host.take_alerts_json() || '[]');
     self.postMessage(
-      { type: 'step_result', bytes, stats, buildingsJson, mutationSeq },
+      { type: 'step_result', bytes, stats, buildingsJson, mutationSeq, alerts },
       { transfer: [bytes.buffer as ArrayBuffer] },
     );
   }, STEP_INTERVAL_MS);
@@ -352,11 +360,12 @@ self.onmessage = async (e: MessageEvent<MainToWorker>) => {
     case 'apply_tool': {
       if (!host) break;
       const success = host.apply_tool(msg.payload.tool, msg.payload.x, msg.payload.y, msg.payload.strokeId);
+      const message = host.last_apply_message() ?? null;
       // Bump unconditionally (not just on success) — cheap, and keeps this
       // simple; a rejected placement just costs one extra harmless apply on
       // the main thread instead of a missed one.
       mutationSeq++;
-      self.postMessage({ type: 'apply_result', success, history: historyFlags(host) });
+      self.postMessage({ type: 'apply_result', success, message, history: historyFlags(host) });
       break;
     }
     case 'set_speed': {

--- a/crates/city-sim-core/src/sim.rs
+++ b/crates/city-sim-core/src/sim.rs
@@ -784,6 +784,65 @@ mod tests {
         assert!(!alerts[0].sticky);
     }
 
+    /// A balance of exactly zero is not a deficit, and is the exact threshold
+    /// a recovery reads as "restored" — pins the boundary on both sides of
+    /// the `< 0` / `>= 0` comparisons in `handle_resource_alerts`.
+    #[test]
+    fn power_deficit_boundary_is_strictly_negative() {
+        let mut sim = Simulation::new(4, 4, 1);
+        sim.state.utilities.power = 0;
+        sim.handle_resource_alerts();
+        assert!(
+            sim.take_alerts().is_empty(),
+            "zero balance must not read as a deficit"
+        );
+
+        sim.state.utilities.power = -1;
+        sim.handle_resource_alerts();
+        let alerts = sim.take_alerts();
+        assert_eq!(alerts.len(), 1);
+        assert_eq!(alerts[0].kind, AlertKind::PowerDeficit);
+
+        sim.state.utilities.power = 0;
+        sim.handle_resource_alerts();
+        let alerts = sim.take_alerts();
+        assert_eq!(alerts.len(), 1);
+        assert_eq!(alerts[0].kind, AlertKind::PowerRestored);
+    }
+
+    /// Same boundary as `power_deficit_boundary_is_strictly_negative`, for
+    /// water — plus proves the deficit latch actually suppresses a second
+    /// fire while still negative (catches the `!` in
+    /// `!self.water_deficit_active` being dropped).
+    #[test]
+    fn water_deficit_boundary_and_no_refire_while_active() {
+        let mut sim = Simulation::new(4, 4, 1);
+        assert!(sim.water_enabled);
+
+        sim.state.utilities.water = 0;
+        sim.handle_resource_alerts();
+        assert!(
+            sim.take_alerts().is_empty(),
+            "zero balance must not read as a deficit"
+        );
+
+        sim.state.utilities.water = -1;
+        sim.handle_resource_alerts();
+        let alerts = sim.take_alerts();
+        assert_eq!(alerts.len(), 1);
+        assert_eq!(alerts[0].kind, AlertKind::WaterDeficit);
+
+        // Still negative and already active — must not re-fire.
+        sim.handle_resource_alerts();
+        assert!(sim.take_alerts().is_empty());
+
+        sim.state.utilities.water = 0;
+        sim.handle_resource_alerts();
+        let alerts = sim.take_alerts();
+        assert_eq!(alerts.len(), 1);
+        assert_eq!(alerts[0].kind, AlertKind::WaterRestored);
+    }
+
     #[test]
     fn water_deficit_alert_respects_water_enabled_gate() {
         let mut sim = Simulation::new(4, 4, 1);
@@ -813,6 +872,40 @@ mod tests {
         let alerts = sim.take_alerts();
         assert_eq!(alerts.len(), 1);
         assert_eq!(alerts[0].kind, AlertKind::PowerRestored);
+    }
+
+    /// Pins `load_state`'s latch resync to the same strictly-negative
+    /// boundary as `handle_resource_alerts` itself: a loaded balance of
+    /// exactly zero must resync to "not active", not "active".
+    #[test]
+    fn load_state_resyncs_latches_at_the_strictly_negative_boundary() {
+        let mut sim = Simulation::new(4, 4, 1);
+
+        let mut zero_balance = sim.state.clone();
+        zero_balance.utilities.power = 0;
+        zero_balance.utilities.water = 0;
+        sim.load_state(zero_balance);
+        sim.state.utilities.power = 0;
+        sim.state.utilities.water = 0;
+        sim.handle_resource_alerts();
+        assert!(
+            sim.take_alerts().is_empty(),
+            "a latch resynced from a zero balance must start inactive, so an unchanged zero balance is not a recovery"
+        );
+
+        let mut negative_balance = sim.state.clone();
+        negative_balance.utilities.power = -1;
+        negative_balance.utilities.water = -1;
+        sim.load_state(negative_balance);
+        sim.state.utilities.power = 0;
+        sim.state.utilities.water = 0;
+        sim.handle_resource_alerts();
+        let alerts = sim.take_alerts();
+        assert!(
+            alerts.iter().any(|a| a.kind == AlertKind::PowerRestored),
+            "a latch resynced from a negative balance must start active, so recovering to zero is a restore"
+        );
+        assert!(alerts.iter().any(|a| a.kind == AlertKind::WaterRestored));
     }
 
     #[test]

--- a/crates/city-sim-core/src/sim.rs
+++ b/crates/city-sim-core/src/sim.rs
@@ -908,6 +908,60 @@ mod tests {
         assert!(alerts.iter().any(|a| a.kind == AlertKind::WaterRestored));
     }
 
+    /// Every other alert test calls `handle_resource_alerts()` directly on
+    /// the private method — none of them would notice if a future refactor
+    /// of `compute_utility_use`/`tick_fixed` silently dropped the call that
+    /// wires it into the real tick path (exactly the class of bug #199
+    /// itself was: code that exists but is never actually invoked). This one
+    /// drives a real deficit through `step()` — the same entry point both
+    /// hosts call — via actual zone growth and network connectivity, not a
+    /// hand-set balance.
+    ///
+    /// Same road/plant/zone fixture as
+    /// `water_requirement_is_opt_in_until_infrastructure_exists` below, with
+    /// a 5 MW `SolarFarm` in place of an 80 MW `CoalPlant` — but built
+    /// directly via `place_zone_building` (same helper real zone growth
+    /// calls) instead of waiting on growth's own timing/RNG, since the
+    /// demand-vs-deficit feedback loop this branch's own economy now runs
+    /// (a live balance suppresses further growth) makes waiting for organic
+    /// growth to overshoot 5 MW non-deterministic — it settles into
+    /// equilibrium right at the boundary instead.
+    #[test]
+    fn step_wires_handle_resource_alerts_into_the_real_tick_path() {
+        use crate::commands::apply_tool;
+        use crate::zones::place_zone_building;
+        use city_sim_protocol::commands::Tool;
+
+        let mut sim = Simulation::new(16, 16, 42);
+        for x in 0..12 {
+            apply_tool(&mut sim.state, Tool::Road, x, 5);
+        }
+        apply_tool(&mut sim.state, Tool::SolarFarm, 0, 3);
+        // 5 zoned-and-built residential lots at 1.5 MW each = 7.5 MW,
+        // comfortably past the SolarFarm's 5 MW — not the razor-thin 4.5 MW
+        // (rounds to 5, exactly tying production) that 3 lots would give.
+        for x in 2..7 {
+            apply_tool(&mut sim.state, Tool::Residential, x, 4);
+            assert!(
+                place_zone_building(&mut sim.state, x, 4),
+                "zone tag must place a building on a tile this test just zoned"
+            );
+        }
+
+        let mut alerts = Vec::new();
+        for _ in 0..5 {
+            sim.step(1.0 / 20.0);
+            alerts.extend(sim.take_alerts());
+        }
+
+        assert!(
+            alerts.iter().any(|a| a.kind == AlertKind::PowerDeficit),
+            "5 active 1.5 MW lots against a 5 MW SolarFarm must raise PowerDeficit \
+             via handle_resource_alerts — if this fails, check compute_utility_use \
+             still calls it"
+        );
+    }
+
     #[test]
     fn sim_money_changes_over_time() {
         let mut sim = Simulation::new(8, 8, 0);

--- a/crates/city-sim-core/src/sim.rs
+++ b/crates/city-sim-core/src/sim.rs
@@ -281,7 +281,9 @@ impl Simulation {
             self.power_deficit_active = true;
             self.pending_alerts.push(SimAlert {
                 kind: AlertKind::PowerDeficit,
-                message: "Power deficit detected. Build more plants or reduce demand to restore growth.".into(),
+                message:
+                    "Power deficit detected. Build more plants or reduce demand to restore growth."
+                        .into(),
                 sticky: true,
             });
         } else if power_balance >= 0 && self.power_deficit_active {

--- a/crates/city-sim-core/src/sim.rs
+++ b/crates/city-sim-core/src/sim.rs
@@ -18,6 +18,7 @@ use crate::wilderness::{
     apply_happiness_drift, compute_wilderness, update_trend, WildernessTunables,
 };
 use crate::zones::ZoneGrowthSim;
+use city_sim_protocol::events::{AlertKind, SimAlert};
 
 // ---------------------------------------------------------------------------
 // Simulation driver
@@ -50,6 +51,16 @@ pub struct Simulation {
     /// accumulators (`day_frac`, `money_frac`) live in `GameState` instead so
     /// snapshot restores are exact.
     accumulator: f64,
+    /// Edge-triggered hysteresis latches for the deficit alerts below — set
+    /// the tick the balance is decided negative, cleared the tick it recovers,
+    /// so a balance sitting at exactly the boundary doesn't re-fire every tick.
+    power_deficit_active: bool,
+    water_deficit_active: bool,
+    /// Alerts raised since the last `take_alerts()` call. A `Vec` rather than
+    /// firing a callback directly: `step()` can run several `tick_fixed()`s
+    /// per call (see `MAX_TICKS_PER_STEP`), and both hosts drain this once per
+    /// external step/tick rather than per fixed tick, so none can be dropped.
+    pending_alerts: Vec<SimAlert>,
 }
 
 impl Simulation {
@@ -64,6 +75,9 @@ impl Simulation {
             ticks_per_second: 20,
             speed: 1.0,
             accumulator: 0.0,
+            power_deficit_active: false,
+            water_deficit_active: false,
+            pending_alerts: Vec::new(),
         }
     }
 
@@ -206,9 +220,21 @@ impl Simulation {
     /// accumulators (`day_frac`, `money_frac`) travel inside `GameState`, so
     /// a restore continues the clock and treasury exactly.
     pub fn load_state(&mut self, state: GameState) {
+        // Resync the deficit latches to the loaded balance without alerting —
+        // this is a restore, not a live transition, and a save can easily
+        // load into an already-negative balance.
+        self.power_deficit_active = state.utilities.power < 0;
+        self.water_deficit_active = self.water_enabled && state.utilities.water < 0;
+        self.pending_alerts.clear();
         self.state = state;
         self.zone_growth = ZoneGrowthSim::new();
         self.accumulator = 0.0;
+    }
+
+    /// Drain and return alerts raised since the last call. Both hosts call
+    /// this once per external step/tick to forward to their UI transport.
+    pub fn take_alerts(&mut self) -> Vec<SimAlert> {
+        std::mem::take(&mut self.pending_alerts)
     }
 
     // --- internal ---
@@ -243,6 +269,49 @@ impl Simulation {
         } else {
             1_000_000
         };
+        self.handle_resource_alerts();
+    }
+
+    /// Edge-triggered power/water deficit alerts — ported from the deleted TS
+    /// oracle's `handleResourceAlerts` (`git show 1f8140a:app/src/game/simulation.ts:742-812`),
+    /// now the sole producer since neither host re-derives this state machine.
+    fn handle_resource_alerts(&mut self) {
+        let power_balance = self.state.utilities.power;
+        if power_balance < 0 && !self.power_deficit_active {
+            self.power_deficit_active = true;
+            self.pending_alerts.push(SimAlert {
+                kind: AlertKind::PowerDeficit,
+                message: "Power deficit detected. Build more plants or reduce demand to restore growth.".into(),
+                sticky: true,
+            });
+        } else if power_balance >= 0 && self.power_deficit_active {
+            self.power_deficit_active = false;
+            self.pending_alerts.push(SimAlert {
+                kind: AlertKind::PowerRestored,
+                message: "Power restored. Zones can grow again.".into(),
+                sticky: false,
+            });
+        }
+
+        if !self.water_enabled {
+            return;
+        }
+        let water_balance = self.state.utilities.water;
+        if water_balance < 0 && !self.water_deficit_active {
+            self.water_deficit_active = true;
+            self.pending_alerts.push(SimAlert {
+                kind: AlertKind::WaterDeficit,
+                message: "Water deficit detected. Add pumps/towers or cut usage.".into(),
+                sticky: true,
+            });
+        } else if water_balance >= 0 && self.water_deficit_active {
+            self.water_deficit_active = false;
+            self.pending_alerts.push(SimAlert {
+                kind: AlertKind::WaterRestored,
+                message: "Water restored. Supply is stable again.".into(),
+                sticky: false,
+            });
+        }
     }
 }
 
@@ -689,6 +758,59 @@ mod tests {
                 < 0.001,
             "tourism must be the only revenue difference"
         );
+    }
+
+    #[test]
+    fn power_deficit_alert_fires_once_and_clears_on_recovery() {
+        let mut sim = Simulation::new(4, 4, 1);
+        sim.state.utilities.power = -5;
+        sim.handle_resource_alerts();
+        let alerts = sim.take_alerts();
+        assert_eq!(alerts.len(), 1);
+        assert_eq!(alerts[0].kind, AlertKind::PowerDeficit);
+        assert!(alerts[0].sticky);
+
+        // Still negative — must not re-fire every tick.
+        sim.handle_resource_alerts();
+        assert!(sim.take_alerts().is_empty());
+
+        sim.state.utilities.power = 3;
+        sim.handle_resource_alerts();
+        let alerts = sim.take_alerts();
+        assert_eq!(alerts.len(), 1);
+        assert_eq!(alerts[0].kind, AlertKind::PowerRestored);
+        assert!(!alerts[0].sticky);
+    }
+
+    #[test]
+    fn water_deficit_alert_respects_water_enabled_gate() {
+        let mut sim = Simulation::new(4, 4, 1);
+        sim.water_enabled = false;
+        sim.state.utilities.water = -10;
+        sim.handle_resource_alerts();
+        assert!(
+            sim.take_alerts().is_empty(),
+            "water alerts must not fire while water_enabled is false"
+        );
+    }
+
+    #[test]
+    fn load_state_resyncs_latches_without_alerting() {
+        let mut sim = Simulation::new(4, 4, 1);
+        let mut loaded = sim.state.clone();
+        loaded.utilities.power = -5;
+        sim.load_state(loaded);
+        assert!(
+            sim.take_alerts().is_empty(),
+            "a load must resync the latch silently, not raise an alert"
+        );
+        // Recovering from here proves the latch resynced to active=true —
+        // if it hadn't, this transition wouldn't be seen as a recovery at all.
+        sim.state.utilities.power = 3;
+        sim.handle_resource_alerts();
+        let alerts = sim.take_alerts();
+        assert_eq!(alerts.len(), 1);
+        assert_eq!(alerts[0].kind, AlertKind::PowerRestored);
     }
 
     #[test]

--- a/crates/city-sim-wasm/src/lib.rs
+++ b/crates/city-sim-wasm/src/lib.rs
@@ -44,6 +44,11 @@ pub fn build_sha() -> String {
 pub struct SimHost {
     sim: Simulation,
     history: History,
+    /// The `message` from the most recent `apply_tool` call's `CommandResult`
+    /// — `apply_tool` itself can only return `bool` across the wasm-bindgen
+    /// boundary without a breaking signature change, so the message is read
+    /// separately via `last_apply_message()` right after each call.
+    last_apply_message: Option<String>,
 }
 
 impl SimHost {
@@ -64,6 +69,7 @@ impl SimHost {
         SimHost {
             sim: Simulation::new(width, height, seed),
             history: History::new(HistoryConfig::default()),
+            last_apply_message: None,
         }
     }
 
@@ -281,6 +287,7 @@ impl SimHost {
     /// insufficient funds, invalid placement).
     pub fn apply_tool(&mut self, tool_idx: u8, x: u32, y: u32, stroke_id: u32) -> bool {
         let Ok(tool) = Tool::try_from(tool_idx) else {
+            self.last_apply_message = None;
             return false;
         };
         let pending = self.history.prepare(&self.sim.state, stroke_id as u64);
@@ -290,7 +297,21 @@ impl SimHost {
                 self.history.commit(bytes, stroke_id as u64);
             }
         }
+        self.last_apply_message = result.message;
         result.success
+    }
+
+    /// The `message` from the most recent `apply_tool` call, if any — `Some`
+    /// on both a refused command ("Not enough funds") and, occasionally, a
+    /// successful one; `None` otherwise. Read this right after `apply_tool`.
+    pub fn last_apply_message(&self) -> Option<String> {
+        self.last_apply_message.clone()
+    }
+
+    /// Alerts raised since the last call — drains the queue. Call once per
+    /// `step()` from the host and forward each entry as `FromSim::Alert`.
+    pub fn take_alerts_json(&mut self) -> String {
+        serde_json::to_string(&self.sim.take_alerts()).unwrap_or_default()
     }
 
     /// Set the simulation speed multiplier (0.0 = paused, 1.0 = normal).

--- a/crates/tauri-plugin-city-sim/guest-js/index.ts
+++ b/crates/tauri-plugin-city-sim/guest-js/index.ts
@@ -60,6 +60,19 @@ export interface TickEvent {
   /** Whether an undo/redo step is currently available — drives button state. */
   canUndo:            boolean
   canRedo:            boolean
+  /**
+   * Utility deficit/restore alerts raised since the previous tick — see
+   * `city_sim_core::sim::Simulation::take_alerts`. Empty on most ticks; only
+   * non-empty the tick a power/water balance actually crosses zero.
+   */
+  alerts:             SimAlert[]
+}
+
+/** Mirrors `city_sim_protocol::events::SimAlert`. */
+export interface SimAlert {
+  kind:    'PowerDeficit' | 'PowerRestored' | 'WaterDeficit' | 'WaterRestored' | 'BudgetWarning' | 'Abandonment' | 'Info'
+  message: string
+  sticky:  boolean
 }
 
 /** One entry in {@link TickEvent.buildings}. */
@@ -130,11 +143,18 @@ export async function start(
   await invoke('plugin:city-sim|start', { width, height, seed, onTick: channel })
 }
 
+/** Mirrors `city_sim_protocol::commands::CommandResult`. */
+export interface CommandResult {
+  success: boolean
+  message: string | null
+}
+
 /**
  * Apply a player tool at tile coordinates (x, y).
  *
- * Fire-and-forget: the command is queued into the sim thread and applied
- * before the next tick. Returns once the command is enqueued (not applied).
+ * Resolves once the sim thread has actually processed the command (not just
+ * enqueued it) — the sim thread drains all pending commands before ticking,
+ * so this normally resolves within one frame (≤50 ms).
  *
  * @param tool     A `TOOL_ID` value — the u8 discriminant from `sim_protocol::commands::Tool`.
  * @param x        Tile column (0-indexed from left).
@@ -142,8 +162,8 @@ export async function start(
  * @param strokeId Groups the calls of one drag-paint gesture into a single
  *                 undo step; bump it on every new gesture.
  */
-export async function applyTool(tool: ToolId, x: number, y: number, strokeId: number): Promise<void> {
-  await invoke('plugin:city-sim|apply_tool', { tool, x, y, strokeId })
+export async function applyTool(tool: ToolId, x: number, y: number, strokeId: number): Promise<CommandResult> {
+  return await invoke('plugin:city-sim|apply_tool', { tool, x, y, strokeId })
 }
 
 /**

--- a/crates/tauri-plugin-city-sim/src/commands.rs
+++ b/crates/tauri-plugin-city-sim/src/commands.rs
@@ -299,7 +299,10 @@ pub fn start(
             sim.step(dt);
             let alerts = sim.take_alerts();
 
-            if on_tick.send(build_tick_event(&sim, &history, alerts)).is_err() {
+            if on_tick
+                .send(build_tick_event(&sim, &history, alerts))
+                .is_err()
+            {
                 break; // JS side closed the channel
             }
 

--- a/crates/tauri-plugin-city-sim/src/commands.rs
+++ b/crates/tauri-plugin-city-sim/src/commands.rs
@@ -14,7 +14,8 @@ use city_sim_core::sim::Simulation;
 use city_sim_core::snapshot;
 use city_sim_core::state::GameState;
 use city_sim_core::wire::encode_tile_buffer;
-use city_sim_protocol::commands::{Policies, Tool};
+use city_sim_protocol::commands::{CommandResult, Policies, Tool};
+use city_sim_protocol::events::SimAlert;
 use serde::Serialize;
 use tauri::{ipc::Channel, State};
 
@@ -66,6 +67,10 @@ pub struct TickEvent {
     /// Whether an undo/redo step is currently available — drives button state.
     pub can_undo: bool,
     pub can_redo: bool,
+    /// Utility deficit/restore alerts raised since the previous tick — see
+    /// `city_sim_core::sim::Simulation::take_alerts`. Empty on most ticks;
+    /// only non-empty the tick a power/water balance crosses zero.
+    pub alerts: Vec<SimAlert>,
 }
 
 /// One entry in [`TickEvent::buildings`].
@@ -83,7 +88,7 @@ pub struct WireBuilding {
 // ── Internal command sent from invoke handlers to the sim thread ──────────────
 
 pub enum SimCmd {
-    ApplyTool(Tool, u32, u32, u64),
+    ApplyTool(Tool, u32, u32, u64, mpsc::SyncSender<CommandResult>),
     SetSpeed(f32),
     SetPolicies(Policies),
     SetNaturalTerrain(Vec<u8>),
@@ -137,7 +142,7 @@ impl SimState {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-fn build_tick_event(sim: &Simulation, history: &History) -> TickEvent {
+fn build_tick_event(sim: &Simulation, history: &History, alerts: Vec<SimAlert>) -> TickEvent {
     let s = &sim.state;
     // Same encoder the WASM host's `tile_buffer()` calls — one wire format,
     // shared, so this transport cannot silently drift from that one.
@@ -173,6 +178,7 @@ fn build_tick_event(sim: &Simulation, history: &History) -> TickEvent {
         buildings,
         can_undo: history.can_undo(),
         can_redo: history.can_redo(),
+        alerts,
     }
 }
 
@@ -230,7 +236,7 @@ pub fn start(
             // Drain all pending commands before ticking
             loop {
                 match rx.try_recv() {
-                    Ok(SimCmd::ApplyTool(tool, x, y, stroke)) => {
+                    Ok(SimCmd::ApplyTool(tool, x, y, stroke, tx)) => {
                         let pending = history.prepare(&sim.state, stroke);
                         let result = sim_apply_tool(&mut sim.state, tool, x, y);
                         if result.success {
@@ -238,6 +244,7 @@ pub fn start(
                                 history.commit(bytes, stroke);
                             }
                         }
+                        let _ = tx.send(result);
                     }
                     Ok(SimCmd::SetSpeed(m)) => {
                         sim.set_speed(m);
@@ -290,8 +297,9 @@ pub fn start(
             }
 
             sim.step(dt);
+            let alerts = sim.take_alerts();
 
-            if on_tick.send(build_tick_event(&sim, &history)).is_err() {
+            if on_tick.send(build_tick_event(&sim, &history, alerts)).is_err() {
                 break; // JS side closed the channel
             }
 
@@ -306,6 +314,12 @@ pub fn start(
 
 /// Apply a player tool at tile (x, y). `tool` is the `Tool` u8 discriminant
 /// (matching `city_sim_protocol::commands::Tool as u8`).
+///
+/// Blocks until the sim thread has actually processed the command (max 2 s,
+/// same budget as `get_snapshot`) and returns its real `CommandResult` —
+/// success and, on failure, the reason ("Not enough funds", "Bulldoze
+/// first"). The sim thread drains all pending commands before ticking, so
+/// this normally resolves within one frame (≤50 ms), not a full timeout.
 #[tauri::command]
 pub fn apply_tool(
     state: State<'_, SimState>,
@@ -313,9 +327,15 @@ pub fn apply_tool(
     x: u32,
     y: u32,
     stroke_id: u32,
-) -> Result<(), Error> {
+) -> Result<CommandResult, Error> {
     let tool = Tool::try_from(tool).map_err(|_| Error::InvalidTool(tool))?;
-    state.send(SimCmd::ApplyTool(tool, x, y, stroke_id as u64))
+    let (tx, rx) = mpsc::sync_channel(0);
+    state.send(SimCmd::ApplyTool(tool, x, y, stroke_id as u64, tx))?;
+    rx.recv_timeout(Duration::from_secs(2))
+        .map_err(|e| match e {
+            RecvTimeoutError::Timeout => Error::ApplyToolTimeout,
+            RecvTimeoutError::Disconnected => Error::ChannelClosed,
+        })
 }
 
 /// Adjust simulation speed. `multiplier` is relative to the base 20 Hz rate.

--- a/crates/tauri-plugin-city-sim/src/error.rs
+++ b/crates/tauri-plugin-city-sim/src/error.rs
@@ -19,6 +19,8 @@ pub enum Error {
     Snapshot(String),
     #[error("timed out waiting for snapshot from sim thread")]
     SnapshotTimeout,
+    #[error("timed out waiting for apply_tool result from sim thread")]
+    ApplyToolTimeout,
     #[error(transparent)]
     Tauri(#[from] tauri::Error),
 }

--- a/docs/features/sim-feedback-channel.md
+++ b/docs/features/sim-feedback-channel.md
@@ -1,6 +1,6 @@
 # Simulation Feedback Channel — Alerts, Command Results, and Failure Icons
 
-**Status:** regressed in the Rust migration. Audit items B2 and B5 in `docs/wasm-sim-audit.md`, plus a renderer gate bug that compounds them.
+**Status:** fixed (#199). Audit items B2 and B5 in `docs/wasm-sim-audit.md`, plus a renderer gate bug that compounded them, are resolved — all three paths described below are live on both bridges.
 
 ## Purpose
 
@@ -8,24 +8,23 @@ When the simulation refuses a command or the city starts failing, the player mus
 
 ## The three broken paths
 
-### 1. Utility deficit alerts never fire (B2)
+### 1. Utility deficit alerts never fire (B2) — fixed
 
 * Promise: `app/public/manual.html` — "When power or water drops below zero you'll see a sticky warning toast; it clears with a follow-up notice once supply returns", plus persistent news-ticker alerts (`manual.html`, `SPEC.md`, `docs/game-parameters.md` all repeat it).
 * Old: the TS sim ran a deficit state machine and raised alerts + narrative events (`app/src/game/simulation.ts:746-800` at `1f8140a`; oracle removed 2026-07-30, view with `git show 1f8140a:app/src/game/simulation.ts`).
-* Now: no Rust code constructs `FromSim::Alert` — `app/src/main.ts:441-447` is a dead handler, and the `power_deficit_*` narrative event types (`narrative/types.ts:6-9`) have no producer.
-* Recovery: port the deficit state machine into the engine tick, emit `Alert` events over both bridges (WASM worker message + Tauri channel), and reconnect the toast/ticker/narrative consumers that are already sitting there waiting.
+* Fix: the edge-triggered deficit state machine now lives in `crates/city-sim-core/src/sim.rs`'s `Simulation::handle_resource_alerts` (ported from the TS oracle above), raising `city_sim_protocol::events::SimAlert`s into a `pending_alerts` queue drained once per host step/tick via `Simulation::take_alerts`. `SimHost::take_alerts_json` (WASM, forwarded through `wasmSim.worker.ts`'s `step_result`) and `TickEvent.alerts` (Tauri, built in `build_tick_event`) both carry it to `main.ts`'s previously-dead `Alert` handler. Each alert's paired ticker event (`power_deficit_start`/`_end` etc.) is derived TS-side, in `protocol/deficitNarrative.ts`'s `deriveNarrativeEventFromAlert` — shared by both bridges rather than reimplemented per transport.
 
-### 2. Command results are swallowed (B5)
+### 2. Command results are swallowed (B5) — fixed
 
 * Old: the in-process TS sim returned `ChangeResult` synchronously — a refused or underfunded placement produced an immediate toast.
-* Now: both bridges are optimistic — `wasmSimBridge.send` always returns `{success: true}` (`wasmSimBridge.ts:257`) and the real result arrives async as `apply_result`, where only the success flag crosses the worker boundary; `tauriSimBridge` is optimistic the same way. `main.ts:732`'s failure toast can never fire on the production paths.
-* Recovery: route the async `apply_result` (success **and** message) back into the toast/SFX path keyed by stroke, so "Not enough funds" / "Bulldoze first" reach the player again. This is also a prerequisite for the layer-scoped bulldozer's "Nothing to demolish here" no-op message (see `layer-scoped-bulldozer.md`).
+* Was: both bridges were optimistic — `wasmSimBridge.send` always returned `{success: true}` and the real result arrived async as `apply_result`, where only the success flag crossed the worker boundary; Tauri's `apply_tool` was fire-and-forget with no result path at all.
+* Fix: `send()` still answers synchronously/optimistically (the `SimBridge` interface contract), but the real result now reaches `main.ts` asynchronously as a `FromSim::CommandResult` message. WASM: `SimHost::last_apply_message` exposes the `CommandResult.message` Rust already computed, read by `wasmSim.worker.ts` right after `apply_tool` and forwarded by `wasmSimBridge.ts`. Tauri: `SimCmd::ApplyTool` gained a reply channel (`mpsc::SyncSender<CommandResult>`, mirroring the existing `Undo`/`Redo`/`GetSnapshot` pattern), so the `apply_tool` Tauri command — and `tauriSimBridge.ts`'s `.applyTool()` promise — now resolve with the real result instead of `void`. `main.ts`'s failure toast fires on the `CommandResult` message now, not on `bridge.send()`'s (still-optimistic) return value. Not done: correcting the immediate/optimistic SFX cue to match the async result — left as a known limitation, since it needs per-stroke correlation the drag-paint gesture model doesn't cleanly support yet.
 
-### 3. The no-water icon is suppressed exactly when it's needed most
+### 3. The no-water icon is suppressed exactly when it's needed most — fixed
 
 * Promise: `manual.html` — "Buildings without water will stop working and show a water-drop icon", and water becomes a requirement "until you place your first pump, water tower, or pipe".
-* Now: the engine opts a city into the water requirement on pipes too (`crates/city-sim-core/src/state.rs:518-523`, `has_water_system`), but the renderer's icon gate only scans for pump/tower templates (`app/src/rendering/renderer.ts:571-580`), so a pipes-only city flips every building to `InactiveNoWater` — production and growth stop — with no icon, no alert (path 1 is dead), and no explanation anywhere in the UI. This is the worst compound failure of the three: two independent regressions overlapping to make a fully silent city-killer.
-* Recovery: make the renderer's gate ask the same question as the engine (mirror `has_water_system` — pipes included), ideally by reading an engine-provided flag rather than re-deriving it client-side.
+* Was: the engine opts a city into the water requirement on pipes too (`crates/city-sim-core/src/state.rs:518-523`, `has_water_system`), but the renderer's icon gate only scanned for pump/tower templates, so a pipes-only city flipped every building to `InactiveNoWater` — production and growth stopped — with no icon, no alert, and no explanation anywhere in the UI.
+* Fix: both bridges already mirrored `has_water_system` correctly (pipes included) as a side effect of the #177 TS/wire follow-up — a building can only ever reach `BuildingStatus.InactiveNoWater` when that mirror decided a water system exists. `app/src/rendering/renderer.ts`'s icon gate now reads that status directly instead of re-deriving "does the map have water infra" from a second, pump/tower-only template scan.
 
 ## Codifying
 

--- a/docs/wasm-sim-audit.md
+++ b/docs/wasm-sim-audit.md
@@ -76,8 +76,10 @@ TS `BudgetStats.breakdown.details.buildings` includes `powerByType`, `civicByTyp
 - Effect: loading any save older than 6 seconds of sim time (120 ticks) silently rewinds tick/day/population/jobs/budget history to ≈tick 120. The display shows the saved values until the first `step_result` overwrites them. Task **P5-1 is marked done but is Tauri-only**.
 - Also: saves without a `cmdLog` (older saves; `persistence.ts:246–250`) fall back to a seed-only `reset` — the sim becomes a blank map while the display still shows the loaded city until the next buffer apply erases it.
 
-### B2. Sim events never emitted (P0)
+### B2. Sim events never emitted (P0) — ✅ resolved 2026-07-30 (#199)
 `FromSim` (`crates/city-sim-protocol/src/events.rs`) defines `Alert`, `Narrative`, `CommandResult`, `TickStats`, but no Rust code constructs `Alert`/`Narrative`/`CommandResult` anywhere (wasm crate, core, or Tauri plugin). The TS oracle emits power/water deficit alerts and narrative events (`simulation.ts:715–787`); `main.ts` has handlers wired for them (`main.ts:199–209`) that can never fire in WASM mode. The narrative layer in WASM mode is reduced to player-action events and month-end snapshots generated TS-side.
+
+Fixed by porting the deficit state machine into `Simulation::handle_resource_alerts` (`sim.rs`), drained per host step via `Simulation::take_alerts` and forwarded over both the WASM worker's `step_result` and the Tauri `TickEvent.alerts`. See `docs/features/sim-feedback-channel.md` for the full recovery.
 
 ### B3. Natural terrain not seeded into the Rust sim (P0) — ✅ resolved 2026-07-21 (#101)
 - TS `createInitialState` generates a water border and centre speckle (`gameState.ts:241–257`); Rust `GameState::new` is all-Land (`state.rs:336–341`).
@@ -90,8 +92,10 @@ TS `BudgetStats.breakdown.details.buildings` includes `powerByType`, `civicByTyp
 ### B4. Command-log desync on rejected commands (P0)
 `WasmSimBridge.send` pushes to its TS-side `cmdLog` **before** the async result arrives (`wasmSimBridge.ts:143–150`); Rust pops its own `CommandLog` when `apply_tool` fails (`crates/city-sim-wasm/src/lib.rs:153–164`), but the bridge's `apply_result` handler only `console.warn`s and never removes the rejected entry (`wasmSimBridge.ts:252–255`). The two logs then disagree. Since the TS `cmdLog` is what gets saved (`persistence.ts`) and replayed on load/engine-swap, a command rejected live (e.g. insufficient funds) can *succeed* during replay when money differs at that tick — replayed state diverges from the session the player actually had.
 
-### B5. Rejected placements give no user feedback (P2)
+### B5. Rejected placements give no user feedback (P2) — ✅ resolved 2026-07-30 (#199)
 `send()` returns an optimistic `{ success: true }` and `FromSim::CommandResult` is never emitted (B2), so a failed placement is invisible except for the money display correcting on the next stats tick. The TS path returned the real result synchronously.
+
+Fixed alongside B2: the async result (success and message) now reaches `main.ts` as a `CommandResult` message on both bridges — WASM via `SimHost::last_apply_message`, Tauri via a new reply channel on `SimCmd::ApplyTool`. See `docs/features/sim-feedback-channel.md`.
 
 ### B6. `getMetadata()` returns null (P2)
 The "Option B" Rust `building_metadata()` export was never implemented (`wasmSimBridge.ts:228–229`, `simBridge.ts:70–76`); UI callers fall back to TS `templates.ts`. Acceptable while templates are hand-mirrored, but it is a second source of truth for costs/footprints/capacities that can drift silently from `buildings.rs` (`building_template!` macro table).
@@ -135,7 +139,7 @@ Rust computes education for demand/decay (`education.rs`, wired in `sim.rs:133`)
 |-----|------|---------|
 | P0 | Money truncated every tick (frozen income below 30/day) | A4 |
 | P0 | No WASM snapshot API; loads capped at 120-tick replay | B1 |
-| P0 | `FromSim` alerts/narrative never emitted | B2 |
+| ~~P0~~ | ~~`FromSim` alerts/narrative never emitted~~ — resolved (#199) | B2 |
 | ~~P0~~ | ~~Natural terrain absent from Rust sim; display-only mask~~ — resolved (#101) | B3 |
 | P0 | TS/Rust command-log desync on rejected commands | B4 |
 | P1 | Power line destroys zones | A1 |
@@ -147,7 +151,7 @@ Rust computes education for demand/decay (`education.rs`, wired in `sim.rs:133`)
 | P1 | No Rust-vs-TS parity harness for the golden fixtures | D1 |
 | P1 | P4-3 cross-platform determinism unproven | D2 |
 | P2 | Happiness dynamics absent; rounding/type divergences | A7, A9 |
-| P2 | No placement-failure feedback; `getMetadata()` null | B5, B6 |
+| P2 | ~~No placement-failure feedback~~ (resolved, #199); `getMetadata()` null | B5, B6 |
 | P2 | Undo rewinds sim time | B7 |
 | P2 | Mirror loses building state; duplicate education calc | C1, C2 |
 | P2 | WASM crate untested in CI; docs drift | D3, D4 |
@@ -158,5 +162,5 @@ Rust computes education for demand/decay (`education.rs`, wired in `sim.rs:133`)
 2. **B4** (pop TS `cmdLog` on `apply_result: false`) — small bridge fix protecting every save made from now on.
 3. **B1** (expose `snapshot_bytes()`/`load_snapshot_bytes()` on `SimHost`, store snapshot in the save alongside the cmdLog) — removes the 120-tick cap and the money/set_money workaround.
 4. **B3** (seed terrain in `city-sim-core` from the seed; delete the display mask) — unblocks A3-style water rules and makes the tile buffer authoritative.
-5. **B2** (emit `FromSim` events from the tick loop; forward via worker/Channel) — restores alerts + narrative on the production path.
+5. ~~**B2** (emit `FromSim` events from the tick loop; forward via worker/Channel) — restores alerts + narrative on the production path.~~ — done (#199).
 6. **D1** (native fixture parity harness) — then burn down the A-section drift items with the harness as the referee, and decide each one: match the TS behaviour, or ratify the Rust behaviour and update the oracle/fixtures + `docs/game-parameters.md`/manual.


### PR DESCRIPTION
## Summary

- **Utility deficit alerts now fire.** No Rust code ever constructed `FromSim::Alert` — the deficit state machine that used to raise power/water deficit toasts and ticker events only ever lived in the now-deleted TS oracle. `Simulation::handle_resource_alerts` (`sim.rs`) ports it into the real engine tick, edge-triggered with hysteresis latches, drained per host step via `Simulation::take_alerts` and forwarded over both the WASM worker's `step_result` and the Tauri `TickEvent.alerts`.
- **Command results reach the player.** Both bridges answered `ApplyTool` optimistically (`{success: true}`) and threw away the real async result. WASM: `SimHost::last_apply_message` exposes the `CommandResult.message` Rust already computed. Tauri: `SimCmd::ApplyTool` gained a reply channel (mirroring the existing `Undo`/`Redo`/`GetSnapshot` pattern), so `apply_tool` now returns the real result instead of `()` — it had no result path at all before. "Not enough funds" / "Bulldoze first" now reach the player as a toast.
- **The no-water icon works on pipes-only cities.** The renderer's icon gate only scanned for pump/tower buildings, missing pipes — both bridges already computed the correct `hasWaterSystem` (pipes included) as a side effect of an earlier migration, so the fix is deleting the renderer's second, narrower re-derivation and reading `BuildingStatus.InactiveNoWater` directly.
- **Each alert's paired ticker event** (`power_deficit_start`/`_end` etc.) is derived by one shared TS helper (`protocol/deficitNarrative.ts`) both bridges call, instead of two independently-maintained copies of the mapping.

### Maintainer-facing changes

- New `crates/city-sim-core/src/sim.rs` fields: `power_deficit_active`/`water_deficit_active` (hysteresis latches) and `pending_alerts: Vec<SimAlert>`, drained via `Simulation::take_alerts()`. `load_state` resyncs the latches to the loaded balance silently (no alert) since a restore isn't a live transition.
- `crates/tauri-plugin-city-sim`'s `SimCmd::ApplyTool` gained a 5th field, an `mpsc::SyncSender<CommandResult>` reply channel — `apply_tool` now blocks (≤2s, same budget as `get_snapshot`) on the sim thread's actual response instead of firing and forgetting.
- New `app/src/game/protocol/deficitNarrative.ts` — shared `AlertKind` → narrative `SimEventType` mapping.
- `app/src/main.ts`'s `wireBridge` gained a `CommandResult` branch; the old synchronous dead-code check in `applyCurrentTool` (`bridge.send()`'s return value can never carry a real failure) was removed.

### Workflow and infrastructure

- Mutation testing (`cargo mutants --in-diff`) found and closed 8 initially-surviving boundary mutants in `sim.rs` (strict `<` vs `<=`/`==` at the zero boundary, and the `!` on the re-fire guard) — 26/26 viable mutants now caught.
- An independent multi-agent code review (5 dimensions, each finding adversarially re-verified) caught 3 real bugs after the initial implementation, all fixed in follow-up commits:
  - A staged-but-undispatched `step_result`'s alert could survive an undo/redo/load rollback as a permanent stale toast, since the Rust latch resyncs silently on restore. Alerts are now staged and flushed alongside `pendingStats`/`pendingTileBuffer`, discarded together on rollback.
  - The new `CommandResult` failure toast had no dedup, so a drag-paint stroke that ran out of funds partway through could stack one toast per remaining tile. Now keyed by message text, same as the existing `Alert` toast.
  - No test drove the deficit alert through the real `step()` path — every test called the private `handle_resource_alerts()` directly, so a future refactor silently dropping that call from `compute_utility_use` would have gone unnoticed. Added one that does, via real zone placement and network connectivity.
- The click-time SFX cue is now corrected on a failed command too, not just the toast — `playToolResult` already ignores `tool` entirely once `success` is false (always plays the throttled `error` cue), so no per-stroke tool correlation was actually needed to fix this.
- The no-water icon's status→icon decision (`drawBuildingIndicators`, previously untested — canvas-only, no unit tests) is now a pure `resolveIndicatorKey` function in `tileRenderUtils.ts`, alongside `resolveTileSprite`'s existing extraction, with its own unit test.

### Documentation

- `docs/features/sim-feedback-channel.md` and `docs/wasm-sim-audit.md` (items B2/B5) updated from "regressed"/open to fixed, describing what actually shipped.

## Test plan

- [x] `cargo test --workspace` (331 tests) — includes the new deficit-alert boundary tests, the real-tick-path regression test, and the alert-rollback discard behaviour.
- [x] `cargo fmt --check`, `cargo clippy --workspace --all-targets` clean.
- [x] `cargo mutants --in-diff` against the full branch diff — 26/26 viable mutants caught.
- [x] `bun run lint` (`tsc --noEmit`) clean.
- [x] `bun run test` (267 tests) — includes new `deficitNarrative.test.ts`, extended `wasmSimBridge.test.ts`/`tauriSimBridge.test.ts` coverage for alert forwarding, command-result forwarding, and the undo-discards-a-pending-alert case, and `resolveIndicatorKey`'s unit test.
- [x] `bun run build` succeeds.
- [ ] Not manually verified in a running browser/desktop session — no dev server smoke test was run for this PR.

Fixes #199.
