### PR TITLE
View layers PR 1/2 — split the edit stratum out of the minimap overlay enum

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,13 +133,25 @@ When rewriting history (which requires the branch to be unpushed, and should be 
 
 ## Licence and Copyright
 
-New `.rs` and `.ts`/`.tsx` source files should include a header before `use`/`import` statements:
+Every `.rs`, `.ts`/`.tsx`, and `.sh` file — including extensionless shebang scripts like git hooks — carries a header. This applies whenever such a file is created *or* edited: if it's missing the header, add it as part of that same change, not just on brand-new files.
+
+Rust/TypeScript headers go before `use`/`import` statements:
 
 ```rust
 // Brief one-line summary of what this file does.
 //
 // (c) Copyright 2026 Liminal HQ, Scott Morris
 // SPDX-License-Identifier: MIT
+```
+
+Shell script headers go after the `#!` line:
+
+```bash
+#!/usr/bin/env bash
+# Brief one-line summary of what this script does.
+#
+# (c) Copyright 2026 Liminal HQ, Scott Morris
+# SPDX-License-Identifier: MIT
 ```
 
 - One blank line between the header and the first code line.

--- a/app/public/manual.html
+++ b/app/public/manual.html
@@ -95,7 +95,8 @@
       <li>The minimap lives in the bottom-right of the HUD with a base view showing terrain, zones, roads/rail, power lines, and buildings.</li>
       <li>Click or drag on the minimap to jump or slide the main camera; the current viewport stays outlined so you always know where you are.</li>
       <li>Use the toggle button or hotkey <code>M</code> to collapse or expand the panel; size presets keep it readable without crowding the HUD.</li>
-      <li>Overlay modes: <em>Base</em> (everything), <em>Power</em> (powered green, unpowered red, generation/lines teal), <em>Water</em> (water tiles, pumps, towers, pipes in blue), <em>Education</em> (schools purple, served zones green, underserved amber), <em>Wilderness</em> (eco heatmap — lush green to urban grey), <em>Underground</em> (ghosts surface buildings to show pipe network and subsurface infrastructure), and <em>Alerts</em> (abandoned/unpowered/unhappy zones glow warm). The same mode tints the main map so you can spot issues without relying on the minimap alone.</li>
+      <li>The <strong>View</strong> toggle switches what your tools can touch: <em>Surface</em> (the default — surface and overhead, including power lines) or <em>Underground</em> (dims the surface and shows the pipe network instead). It's a different control from the overlay chips below — some tools (like Pipes) switch it for you automatically.</li>
+      <li>Overlay chips: <em>Base</em> (everything), <em>Power</em> (powered green, unpowered red, generation/lines teal), <em>Water</em> (water tiles, pumps, towers, pipes in blue), <em>Education</em> (schools purple, served zones green, underserved amber), <em>Wilderness</em> (eco heatmap — lush green to urban grey), and <em>Alerts</em> (abandoned/unpowered/unhappy zones glow warm). These are read-only diagnostics — they tint both the minimap and the main map, in either View, but never change what a tool can touch.</li>
     </ul>
 
     <h2>Tools</h2>

--- a/app/src/game/clientState.test.ts
+++ b/app/src/game/clientState.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { ensureSettingsShape } from './clientState';
+import { createDefaultMinimapSettings, MINIMAP_OVERLAYS } from './gameState';
+
+describe('ensureSettingsShape — minimap overlay sanitiser', () => {
+  it('defaults to base when settings are absent', () => {
+    expect(ensureSettingsShape().minimap).toEqual(createDefaultMinimapSettings());
+  });
+
+  it('accepts every valid overlay, including wilderness', () => {
+    for (const overlay of MINIMAP_OVERLAYS) {
+      expect(ensureSettingsShape({ minimap: { open: true, size: 'medium', overlay } }).minimap.overlay).toBe(
+        overlay
+      );
+    }
+  });
+
+  it('falls back to base for an overlay value outside the allow-list', () => {
+    const settings = ensureSettingsShape({
+      minimap: { open: true, size: 'medium', overlay: 'not-a-real-overlay' as never }
+    });
+    expect(settings.minimap.overlay).toBe('base');
+  });
+
+  it('drops an old mode: underground save field instead of migrating it', () => {
+    const settings = ensureSettingsShape({
+      minimap: { open: true, size: 'medium', mode: 'underground' } as never
+    });
+    expect(settings.minimap.overlay).toBe('base');
+    expect(settings.minimap).not.toHaveProperty('mode');
+  });
+
+  it('preserves open/size while defaulting a missing overlay', () => {
+    const settings = ensureSettingsShape({ minimap: { open: false, size: 'small' } as never });
+    expect(settings.minimap).toEqual({ open: false, size: 'small', overlay: 'base' });
+  });
+});

--- a/app/src/game/clientState.ts
+++ b/app/src/game/clientState.ts
@@ -16,6 +16,7 @@ import {
   createDefaultMinimapSettings,
   createDefaultNarrativeSettings,
   createDefaultUiSettings,
+  MINIMAP_OVERLAYS,
   type GameSettings,
   type GameState
 } from './gameState';
@@ -35,12 +36,16 @@ export interface ClientState {
  */
 export function ensureSettingsShape(settings?: Partial<GameSettings>): GameSettings {
   const minimapDefaults = createDefaultMinimapSettings();
+  // A save's `minimap` may still carry an old `mode: 'underground'` key from
+  // before the stratum/overlay split — it has no `overlay` field of its own,
+  // so the default above wins and the old edit-stratum value is dropped
+  // rather than migrated (stratum was never meant to persist anyway).
   const minimapSettings = {
     ...minimapDefaults,
     ...(settings?.minimap ?? {})
   };
-  if (!['base', 'power', 'water', 'alerts', 'education', 'underground'].includes(minimapSettings.mode)) {
-    minimapSettings.mode = 'base';
+  if (!MINIMAP_OVERLAYS.includes(minimapSettings.overlay)) {
+    minimapSettings.overlay = 'base';
   }
   const inputDefaults = createDefaultInputSettings();
   const accessibilityDefaults = createDefaultAccessibilitySettings();

--- a/app/src/game/clientState.ts
+++ b/app/src/game/clientState.ts
@@ -18,7 +18,9 @@ import {
   createDefaultUiSettings,
   MINIMAP_OVERLAYS,
   type GameSettings,
-  type GameState
+  type GameState,
+  type MinimapOverlay,
+  type MinimapSettings
 } from './gameState';
 import { DEFAULT_BYLAWS, type BylawState } from './bylaws';
 import { defaultHotkeys } from '../ui/hotkeys';
@@ -37,16 +39,18 @@ export interface ClientState {
 export function ensureSettingsShape(settings?: Partial<GameSettings>): GameSettings {
   const minimapDefaults = createDefaultMinimapSettings();
   // A save's `minimap` may still carry an old `mode: 'underground'` key from
-  // before the stratum/overlay split — it has no `overlay` field of its own,
-  // so the default above wins and the old edit-stratum value is dropped
-  // rather than migrated (stratum was never meant to persist anyway).
-  const minimapSettings = {
-    ...minimapDefaults,
-    ...(settings?.minimap ?? {})
+  // before the stratum/overlay split. Picking fields explicitly (rather than
+  // spreading the incoming object) both drops that stray key — instead of
+  // letting it round-trip into every future save — and drops the old
+  // edit-stratum value itself rather than migrating it (stratum was never
+  // meant to persist anyway).
+  const incomingMinimap = settings?.minimap;
+  const incomingOverlay = incomingMinimap?.overlay as MinimapOverlay | undefined;
+  const minimapSettings: MinimapSettings = {
+    open: incomingMinimap?.open ?? minimapDefaults.open,
+    size: incomingMinimap?.size ?? minimapDefaults.size,
+    overlay: incomingOverlay && MINIMAP_OVERLAYS.includes(incomingOverlay) ? incomingOverlay : minimapDefaults.overlay
   };
-  if (!MINIMAP_OVERLAYS.includes(minimapSettings.overlay)) {
-    minimapSettings.overlay = 'base';
-  }
   const inputDefaults = createDefaultInputSettings();
   const accessibilityDefaults = createDefaultAccessibilitySettings();
   const audioDefaults = createDefaultAudioSettings();

--- a/app/src/game/gameState.ts
+++ b/app/src/game/gameState.ts
@@ -64,14 +64,28 @@ export interface Tile {
   density: ZoneDensity;
 }
 
-export type MinimapMode = 'base' | 'power' | 'water' | 'alerts' | 'education' | 'wilderness' | 'underground';
+/**
+ * Read-only diagnostic filters painted over the world — never gate what
+ * tools may touch. `ViewStratum` (below) is the orthogonal axis that does.
+ */
+export type MinimapOverlay = 'base' | 'power' | 'water' | 'alerts' | 'education' | 'wilderness';
+
+/** Single validated list — `clientState.ts`'s sanitiser and `minimap.ts`'s chip set both read this so they can't drift apart again. */
+export const MINIMAP_OVERLAYS: MinimapOverlay[] = ['base', 'power', 'water', 'alerts', 'education', 'wilderness'];
+
+/**
+ * What the player's tools may touch — orthogonal to `MinimapOverlay`. Owned
+ * by `main.ts` alongside the active tool, not persisted with `ClientState`;
+ * a session always starts at `surface`. See `docs/features/view-layers.md`.
+ */
+export type ViewStratum = 'surface' | 'underground';
 
 export type MinimapSize = 'small' | 'medium';
 
 export interface MinimapSettings {
   open: boolean;
   size: MinimapSize;
-  mode: MinimapMode;
+  overlay: MinimapOverlay;
 }
 
 export type PanSpeedPreset = 'slow' | 'normal' | 'fast';
@@ -237,7 +251,7 @@ export interface GameState {
 }
 
 export function createDefaultMinimapSettings(): MinimapSettings {
-  return { open: true, size: 'medium', mode: 'base' };
+  return { open: true, size: 'medium', overlay: 'base' };
 }
 
 export function createDefaultInputSettings(): InputSettings {

--- a/app/src/game/viewStratum.test.ts
+++ b/app/src/game/viewStratum.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { resolveStratumForTool } from './viewStratum';
+import { Tool } from './toolTypes';
+
+describe('resolveStratumForTool', () => {
+  it('WaterPipe always forces underground', () => {
+    expect(resolveStratumForTool(Tool.WaterPipe, 'surface')).toBe('underground');
+    expect(resolveStratumForTool(Tool.WaterPipe, 'underground')).toBe('underground');
+  });
+
+  it('Bulldoze is stratum-neutral and follows whatever is already active', () => {
+    expect(resolveStratumForTool(Tool.Bulldoze, 'surface')).toBe('surface');
+    expect(resolveStratumForTool(Tool.Bulldoze, 'underground')).toBe('underground');
+  });
+
+  it('every other tool snaps the view back to surface', () => {
+    for (const tool of [Tool.Inspect, Tool.Road, Tool.Park, Tool.TerraformRaise, Tool.PowerLine]) {
+      expect(resolveStratumForTool(tool, 'surface')).toBe('surface');
+      expect(resolveStratumForTool(tool, 'underground')).toBe('surface');
+    }
+  });
+});

--- a/app/src/game/viewStratum.ts
+++ b/app/src/game/viewStratum.ts
@@ -1,0 +1,21 @@
+// viewStratum.ts — tool-implied ViewStratum switching, pulled out of main.ts's setTool so it's unit-testable.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { Tool } from './toolTypes';
+import type { ViewStratum } from './gameState';
+
+/**
+ * What stratum selecting `tool` should leave the view on. Tools with a home
+ * stratum (`WaterPipe`) force it; `Bulldoze` is stratum-neutral and follows
+ * whatever is already active (that's what makes it layer-scoped); every
+ * other tool is a surface tool and snaps the view back. See
+ * `docs/features/view-layers.md`'s "Entry points for the underground
+ * stratum".
+ */
+export function resolveStratumForTool(tool: Tool, currentStratum: ViewStratum): ViewStratum {
+  if (tool === Tool.WaterPipe) return 'underground';
+  if (tool === Tool.Bulldoze) return currentStratum;
+  return 'surface';
+}

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -16,9 +16,11 @@ import {
   createInitialState,
   GameState,
   getTile,
-  MinimapMode
+  MinimapOverlay,
+  ViewStratum
 } from './game/gameState';
 import { Tool } from './game/toolTypes';
+import { resolveStratumForTool } from './game/viewStratum';
 import { WasmSimBridge } from './game/wasmSimBridge';
 import { TauriSimBridge } from './game/tauriSimBridge';
 import type { SimBridge } from './game/simBridge';
@@ -385,6 +387,10 @@ function cancelPendingTouchApply() {
 let activeTool: Tool = Tool.Inspect;
 let selectedTool: Tool = Tool.Inspect;
 let temporaryTool: Tool | null = null;
+// Edit stratum: app state alongside the active tool, not part of
+// `state.settings` — never persisted, always starts at `surface`. See
+// `docs/features/view-layers.md`.
+let viewStratum: ViewStratum = 'surface';
 // The bridge always boots a fresh city; any browser save (CSAV in
 // IndexedDB, or a legacy localStorage JSON) is loaded asynchronously right
 // after the engine is ready — see `bootLoadSave` below.
@@ -1030,7 +1036,8 @@ let lastRenderCameraScale = camera.scale;
 let lastRenderHovered: Position | null = hovered;
 let lastRenderSelected: Position | null = selected;
 let lastRenderTool: Tool = activeTool;
-let lastRenderOverlayMode: MinimapMode | null = null;
+let lastRenderOverlay: MinimapOverlay | null = null;
+let lastRenderStratum: ViewStratum | null = null;
 let lastRenderPointerActive = pointerActive;
 let hasRenderedOnce = false;
 
@@ -1064,7 +1071,7 @@ function gameLoop(renderer: MapRenderer, hud: ReturnType<typeof createHud>) {
       narrativeManager.gc(nowMs);
       lastNarrativeGc = nowMs;
     }
-    const overlayMode = state.settings?.minimap?.mode ?? 'base';
+    const overlay = state.settings?.minimap?.overlay ?? 'base';
     const canSkipRender =
       hasRenderedOnce &&
       isPaused &&
@@ -1075,23 +1082,25 @@ function gameLoop(renderer: MapRenderer, hud: ReturnType<typeof createHud>) {
       positionsEqual(hovered, lastRenderHovered) &&
       positionsEqual(selected, lastRenderSelected) &&
       activeTool === lastRenderTool &&
-      overlayMode === lastRenderOverlayMode &&
+      overlay === lastRenderOverlay &&
+      viewStratum === lastRenderStratum &&
       pointerActive === lastRenderPointerActive;
     if (!canSkipRender) {
-      renderer.render(state, hovered, selected, overlayMode, pointerActive, activeTool);
+      renderer.render(state, hovered, selected, viewStratum, overlay, pointerActive, activeTool);
       lastRenderCameraX = camera.x;
       lastRenderCameraY = camera.y;
       lastRenderCameraScale = camera.scale;
       lastRenderHovered = hovered;
       lastRenderSelected = selected;
       lastRenderTool = activeTool;
-      lastRenderOverlayMode = overlayMode;
+      lastRenderOverlay = overlay;
+      lastRenderStratum = viewStratum;
       lastRenderPointerActive = pointerActive;
       hasRenderedOnce = true;
     }
     hud.update(state);
     hud.renderOverlays(state, selected, activeTool);
-    minimap?.update(state, camera);
+    minimap?.update(state, camera, viewStratum);
     newsTicker?.update();
     debugOverlay?.update(state);
   } catch (err) {
@@ -1199,15 +1208,11 @@ function gameLoop(renderer: MapRenderer, hud: ReturnType<typeof createHud>) {
 
   const setTool = (nextTool: Tool) => {
     selectTool(nextTool);
-    if (nextTool === Tool.WaterPipe && state.settings.minimap.mode !== 'underground') {
-      applySettings({ ...state.settings, minimap: { ...state.settings.minimap, mode: 'underground' } });
-    } else if (
-      nextTool !== Tool.WaterPipe &&
-      nextTool !== Tool.Bulldoze &&
-      state.settings.minimap.mode === 'underground'
-    ) {
-      applySettings({ ...state.settings, minimap: { ...state.settings.minimap, mode: 'base' } });
-    }
+    viewStratum = resolveStratumForTool(nextTool, viewStratum);
+  };
+
+  const toggleViewStratum = () => {
+    viewStratum = viewStratum === 'surface' ? 'underground' : 'surface';
   };
 
   const setSimSpeed = (speed: SimSpeedKey, opts: { silent?: boolean } = {}) => {
@@ -1358,7 +1363,7 @@ function gameLoop(renderer: MapRenderer, hud: ReturnType<typeof createHud>) {
     const minimapChanged =
       previous.minimap.open !== normalized.minimap.open ||
       previous.minimap.size !== normalized.minimap.size ||
-      previous.minimap.mode !== normalized.minimap.mode;
+      previous.minimap.overlay !== normalized.minimap.overlay;
     const hotkeysChanged =
       JSON.stringify(previous.hotkeys ?? {}) !== JSON.stringify(normalized.hotkeys ?? {});
     state.settings = normalized;
@@ -1406,6 +1411,7 @@ function gameLoop(renderer: MapRenderer, hud: ReturnType<typeof createHud>) {
     },
     onJumpToTile: ({ x, y }) => centerCameraOnTile(x, y),
     getViewportSize: minimapViewport,
+    onStratumToggle: toggleViewStratum,
     palette
   });
   syncMinimapSettings(state.settings.minimap);

--- a/app/src/rendering/renderer.ts
+++ b/app/src/rendering/renderer.ts
@@ -5,7 +5,7 @@
 
 import { Application, Container, Graphics, Sprite, Text, Texture } from 'pixi.js';
 import { Camera } from './camera';
-import { GameState, MinimapMode, TileKind, getTile } from '../game/gameState';
+import { GameState, MinimapOverlay, TileKind, ViewStratum, getTile } from '../game/gameState';
 import { Occupant, Terrain, hasOccupant } from '../game/protocol/occupants';
 import { BuildingStatus } from '../game/buildings/state';
 import { getBuildingTemplate, getToolCost } from '../game/buildings/templates';
@@ -136,7 +136,8 @@ export class MapRenderer {
     state: GameState,
     hovered: Position | null,
     selected: Position | null,
-    overlayMode: MinimapMode = 'base',
+    stratum: ViewStratum = 'surface',
+    overlay: MinimapOverlay = 'base',
     pointerActive = false,
     activeTool: Tool = Tool.Inspect
   ) {
@@ -151,7 +152,7 @@ export class MapRenderer {
     for (const building of state.buildings) {
       buildingStatuses.set(building.id, building.state.status);
     }
-    const isUnderground = overlayMode === 'underground';
+    const isUnderground = stratum === 'underground';
     const surfaceAlpha = isUnderground ? 0.25 : 1.0;
 
     for (let y = 0; y < state.height; y++) {
@@ -271,7 +272,7 @@ export class MapRenderer {
     this.gridDrawer.draw(state, size, multiTileCoverage, this.camera);
 
     this.overlayLayer.clear();
-    this.drawOverlayTints(state, size, overlayMode, buildingStatuses, buildingLookup);
+    this.drawOverlayTints(state, size, overlay, buildingStatuses, buildingLookup);
     const educationPreview = this.pickEducationPreview(state, hovered, selected, activeTool, buildingLookup);
     if (educationPreview) {
       this.drawEducationPreview(
@@ -383,11 +384,11 @@ export class MapRenderer {
   private drawOverlayTints(
     state: GameState,
     size: number,
-    overlayMode: MinimapMode,
+    overlay: MinimapOverlay,
     buildingStatuses: Map<number, BuildingStatus>,
     buildingLookup: Map<number, { template: ReturnType<typeof getBuildingTemplate>; origin: { x: number; y: number } }>
   ) {
-    if (overlayMode === 'base') return;
+    if (overlay === 'base') return;
 
     const templateKindOf = (tile: NonNullable<ReturnType<typeof getTile>>) =>
       tile.buildingId !== undefined ? buildingLookup.get(tile.buildingId)?.template?.tileKind : undefined;
@@ -395,7 +396,7 @@ export class MapRenderer {
     const pickTint = (tile: ReturnType<typeof getTile>) => {
       if (!tile) return null;
 
-      if (overlayMode === 'power') {
+      if (overlay === 'power') {
         if (tile.powerPlantType) return { color: 0x81e8ff, alpha: 0.35 };
         if (hasOccupant(tile.overhead, Occupant.PowerLine)) {
           return { color: tile.powered ? 0x7bf0ff : 0xff99c2, alpha: 0.35 };
@@ -406,7 +407,7 @@ export class MapRenderer {
         return null;
       }
 
-      if (overlayMode === 'water' || overlayMode === 'underground') {
+      if (overlay === 'water') {
         if (tile.terrain === Terrain.Water) return { color: 0x2f7be5, alpha: 0.32 };
         if (hasOccupant(tile.underground, Occupant.Pipe)) {
           return { color: tile.watered ? WATER_OVERLAY_COLOUR : 0x888888, alpha: 0.6 };
@@ -421,7 +422,7 @@ export class MapRenderer {
         return null;
       }
 
-      if (overlayMode === 'alerts') {
+      if (overlay === 'alerts') {
         const zone = isZone(tile);
         const buildingStatus = tile.buildingId !== undefined ? buildingStatuses.get(tile.buildingId) : undefined;
         let severity = 0;
@@ -440,7 +441,7 @@ export class MapRenderer {
         return { color: 0xff7b7b, alpha: 0.33 };
       }
 
-      if (overlayMode === 'wilderness') {
+      if (overlay === 'wilderness') {
         if (tile.terrain === Terrain.Water) return null;
         // 0–1 with 0.5 neutral (see tileBuffer decodeEco); tint strength
         // scales with distance from neutral — lush green up, urban grey down.
@@ -450,7 +451,7 @@ export class MapRenderer {
         return null;
       }
 
-      if (overlayMode === 'education') {
+      if (overlay === 'education') {
         const templateKind = templateKindOf(tile);
         if (templateKind === TileKind.ElementarySchool || templateKind === TileKind.HighSchool) {
           return { color: 0x8f7bff, alpha: 0.4 };

--- a/app/src/rendering/renderer.ts
+++ b/app/src/rendering/renderer.ts
@@ -272,7 +272,7 @@ export class MapRenderer {
     this.gridDrawer.draw(state, size, multiTileCoverage, this.camera);
 
     this.overlayLayer.clear();
-    this.drawOverlayTints(state, size, overlay, buildingStatuses, buildingLookup);
+    this.drawOverlayTints(state, size, overlay, stratum, buildingStatuses, buildingLookup);
     const educationPreview = this.pickEducationPreview(state, hovered, selected, activeTool, buildingLookup);
     if (educationPreview) {
       this.drawEducationPreview(
@@ -385,10 +385,17 @@ export class MapRenderer {
     state: GameState,
     size: number,
     overlay: MinimapOverlay,
+    stratum: ViewStratum,
     buildingStatuses: Map<number, BuildingStatus>,
     buildingLookup: Map<number, { template: ReturnType<typeof getBuildingTemplate>; origin: { x: number; y: number } }>
   ) {
-    if (overlay === 'base') return;
+    // `overlay === 'base'` still has a tint while underground: the
+    // watered/dry pipe distinction below, restoring what the old combined
+    // `overlayMode === 'underground'` used to draw unconditionally. Overlays
+    // otherwise take priority over it — they're meaningful in either
+    // stratum (see docs/features/view-layers.md) — so this only kicks in
+    // once none of the explicit overlay branches below have already matched.
+    if (overlay === 'base' && stratum !== 'underground') return;
 
     const templateKindOf = (tile: NonNullable<ReturnType<typeof getTile>>) =>
       tile.buildingId !== undefined ? buildingLookup.get(tile.buildingId)?.template?.tileKind : undefined;
@@ -467,6 +474,19 @@ export class MapRenderer {
         return null;
       }
 
+      // `overlay === 'base'` beyond this point — only reached while
+      // underground (guarded above): the same watered/dry pipe tint the
+      // `'water'` overlay draws, so the distinction is visible by default
+      // without an extra overlay pick.
+      if (tile.terrain === Terrain.Water) return { color: 0x2f7be5, alpha: 0.32 };
+      if (hasOccupant(tile.underground, Occupant.Pipe)) {
+        return { color: tile.watered ? WATER_OVERLAY_COLOUR : 0x888888, alpha: 0.6 };
+      }
+      const templateKind = templateKindOf(tile);
+      if (templateKind === TileKind.WaterPump || templateKind === TileKind.WaterTower) {
+        return { color: tile.powered ? 0x7ad5ff : 0xffcc70, alpha: 0.4 };
+      }
+      if (tile.watered) return { color: WATER_OVERLAY_COLOUR, alpha: 0.2 };
       return null;
     };
 

--- a/app/src/styles/minimap.css
+++ b/app/src/styles/minimap.css
@@ -39,6 +39,24 @@
   color: var(--text-dim);
 }
 
+/* The edit-stratum toggle is a different axis from the overlay chips below
+   (see docs/features/view-layers.md) — its own row keeps it from reading as
+   a seventh overlay choice. */
+.minimap-stratum-row {
+  display: flex;
+  width: 100%;
+}
+
+.minimap-stratum-row .chip-button {
+  width: 100%;
+  min-width: 0;
+}
+
+.minimap-stratum-button.active {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
 .minimap-actions {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/app/src/ui/minimap.ts
+++ b/app/src/ui/minimap.ts
@@ -6,10 +6,12 @@
 import { Camera } from '../rendering/camera';
 import {
   GameState,
-  MinimapMode,
+  MINIMAP_OVERLAYS,
+  MinimapOverlay,
   MinimapSettings,
   MinimapSize,
   TileKind,
+  ViewStratum,
   createDefaultMinimapSettings,
   getTile
 } from '../game/gameState';
@@ -27,14 +29,16 @@ export interface MinimapOptions {
   onSettingsChange: (settings: MinimapSettings) => void;
   onJumpToTile: (tile: { x: number; y: number }) => void;
   getViewportSize: () => { width: number; height: number };
+  /** Stratum lives outside `ClientState` (see `ViewStratum`), so toggling it is a plain callback rather than a settings patch. */
+  onStratumToggle: () => void;
   palette?: Record<TileKind, number>;
 }
 
 export interface MinimapController {
-  update: (state: GameState, camera: Camera) => void;
+  update: (state: GameState, camera: Camera, stratum: ViewStratum) => void;
   toggleOpen: () => void;
   setSize: (size: MinimapSize) => void;
-  setMode: (mode: MinimapMode) => void;
+  setOverlay: (overlay: MinimapOverlay) => void;
   markDirty: () => void;
   syncSettings: (settings: MinimapSettings) => void;
 }
@@ -45,7 +49,7 @@ const SIZE_PRESETS: Record<MinimapSize, number> = {
 };
 const MIN_PANEL_WIDTH = 220;
 const PANEL_PADDING = 10 * 2; // matches .minimap-panel padding
-const MODE_COPY: Record<MinimapMode, { subtitle: string; hint: string }> = {
+const OVERLAY_COPY: Record<MinimapOverlay, { subtitle: string; hint: string }> = {
   base: { subtitle: 'Base view', hint: 'Terrain, zones, transport, and power lines.' },
   power: { subtitle: 'Power overlay', hint: 'Green = powered, red = unpowered; teal = generation/lines.' },
   water: { subtitle: 'Water overlay', hint: 'Water tiles, pumps, towers, and pipes pop in blue for now.' },
@@ -57,10 +61,8 @@ const MODE_COPY: Record<MinimapMode, { subtitle: string; hint: string }> = {
   wilderness: {
     subtitle: 'Wilderness overlay',
     hint: 'Heatmap of the eco field: lush green for thriving nature, grey for urban pressure.'
-  },
-  underground: { subtitle: 'Underground', hint: 'View pipes and subsurface infrastructure.' }
+  }
 };
-const ALLOWED_MODES: MinimapMode[] = ['base', 'power', 'water', 'alerts', 'education', 'wilderness', 'underground'];
 
 interface LayoutInfo {
   sizePx: number;
@@ -97,43 +99,41 @@ export function initMinimap(options: MinimapOptions): MinimapController {
   const header = document.createElement('div');
   header.className = 'minimap-header';
 
+  let stratum: ViewStratum = 'surface';
+
   const titleBlock = document.createElement('div');
   const title = document.createElement('div');
   title.className = 'minimap-title';
   title.textContent = 'Minimap';
   const subtitle = document.createElement('div');
   subtitle.className = 'minimap-subtitle';
-  subtitle.textContent = MODE_COPY[settings.mode].subtitle;
+  subtitle.textContent = subtitleText();
   titleBlock.append(title, subtitle);
 
   const baseModeBtn = document.createElement('button');
   baseModeBtn.className = 'chip-button';
   baseModeBtn.textContent = 'Base';
-  baseModeBtn.addEventListener('click', () => setMode('base'));
+  baseModeBtn.addEventListener('click', () => setOverlay('base'));
   const powerModeBtn = document.createElement('button');
   powerModeBtn.className = 'chip-button';
   powerModeBtn.textContent = 'Power';
-  powerModeBtn.addEventListener('click', () => setMode('power'));
+  powerModeBtn.addEventListener('click', () => setOverlay('power'));
   const waterModeBtn = document.createElement('button');
   waterModeBtn.className = 'chip-button';
   waterModeBtn.textContent = 'Water';
-  waterModeBtn.addEventListener('click', () => setMode('water'));
+  waterModeBtn.addEventListener('click', () => setOverlay('water'));
   const alertsModeBtn = document.createElement('button');
   alertsModeBtn.className = 'chip-button';
   alertsModeBtn.textContent = 'Alerts';
-  alertsModeBtn.addEventListener('click', () => setMode('alerts'));
+  alertsModeBtn.addEventListener('click', () => setOverlay('alerts'));
   const educationModeBtn = document.createElement('button');
   educationModeBtn.className = 'chip-button';
   educationModeBtn.textContent = 'Education';
-  educationModeBtn.addEventListener('click', () => setMode('education'));
+  educationModeBtn.addEventListener('click', () => setOverlay('education'));
   const wildernessModeBtn = document.createElement('button');
   wildernessModeBtn.className = 'chip-button';
   wildernessModeBtn.textContent = 'Wilderness';
-  wildernessModeBtn.addEventListener('click', () => setMode('wilderness'));
-  const undergroundModeBtn = document.createElement('button');
-  undergroundModeBtn.className = 'chip-button';
-  undergroundModeBtn.textContent = 'Underground';
-  undergroundModeBtn.addEventListener('click', () => setMode('underground'));
+  wildernessModeBtn.addEventListener('click', () => setOverlay('wilderness'));
 
   const sizeBtn = document.createElement('button');
   sizeBtn.className = 'chip-button';
@@ -155,9 +155,19 @@ export function initMinimap(options: MinimapOptions): MinimapController {
   const body = document.createElement('div');
   body.className = 'minimap-body';
 
+  // The edit stratum is a different axis from the overlay chips below (see
+  // `docs/features/view-layers.md`) — its own row keeps it from reading as a
+  // seventh overlay choice.
+  const stratumRow = document.createElement('div');
+  stratumRow.className = 'minimap-stratum-row';
+  const stratumBtn = document.createElement('button');
+  stratumBtn.className = 'chip-button minimap-stratum-button';
+  stratumBtn.addEventListener('click', () => options.onStratumToggle());
+  stratumRow.append(stratumBtn);
+
   const actions = document.createElement('div');
   actions.className = 'minimap-actions';
-  [baseModeBtn, powerModeBtn, waterModeBtn, alertsModeBtn, educationModeBtn, wildernessModeBtn, undergroundModeBtn, sizeBtn].forEach((btn) => {
+  [baseModeBtn, powerModeBtn, waterModeBtn, alertsModeBtn, educationModeBtn, wildernessModeBtn, sizeBtn].forEach((btn) => {
     if (btn === sizeBtn) {
       btn.classList.add('minimap-span');
     }
@@ -171,7 +181,7 @@ export function initMinimap(options: MinimapOptions): MinimapController {
   const overlayCanvas = document.createElement('canvas');
   overlayCanvas.className = 'minimap-overlay-canvas';
   canvasWrapper.append(baseCanvas, overlayCanvas);
-  body.append(actions, canvasWrapper);
+  body.append(stratumRow, actions, canvasWrapper);
 
   const legendDetails = document.createElement('details');
   legendDetails.className = 'minimap-legend';
@@ -182,7 +192,7 @@ export function initMinimap(options: MinimapOptions): MinimapController {
 
   const hint = document.createElement('div');
   hint.className = 'minimap-hint';
-  hint.textContent = MODE_COPY[settings.mode].hint;
+  hint.textContent = OVERLAY_COPY[settings.overlay].hint;
   legendDetails.append(legendSummary, hint);
   body.append(legendDetails);
 
@@ -214,12 +224,17 @@ export function initMinimap(options: MinimapOptions): MinimapController {
       ...createDefaultMinimapSettings(),
       ...(next ?? {})
     };
-    const safeMode = ALLOWED_MODES.includes(merged.mode) ? merged.mode : 'base';
-    return { ...merged, mode: safeMode };
+    const safeOverlay = MINIMAP_OVERLAYS.includes(merged.overlay) ? merged.overlay : 'base';
+    return { ...merged, overlay: safeOverlay };
   }
 
-  function setMode(mode: MinimapMode) {
-    settings = { ...settings, mode };
+  function subtitleText(): string {
+    const base = OVERLAY_COPY[settings.overlay].subtitle;
+    return stratum === 'underground' ? `${base} · Underground` : base;
+  }
+
+  function setOverlay(overlay: MinimapOverlay) {
+    settings = { ...settings, overlay };
     dirty = true;
     syncUi();
     options.onSettingsChange(settings);
@@ -248,18 +263,19 @@ export function initMinimap(options: MinimapOptions): MinimapController {
 
   function syncUi() {
     container.classList.toggle('minimap-collapsed', !settings.open);
-    baseModeBtn.classList.toggle('active', settings.mode === 'base');
-    powerModeBtn.classList.toggle('active', settings.mode === 'power');
-    waterModeBtn.classList.toggle('active', settings.mode === 'water');
-    alertsModeBtn.classList.toggle('active', settings.mode === 'alerts');
-    educationModeBtn.classList.toggle('active', settings.mode === 'education');
-    wildernessModeBtn.classList.toggle('active', settings.mode === 'wilderness');
-    undergroundModeBtn.classList.toggle('active', settings.mode === 'underground');
+    baseModeBtn.classList.toggle('active', settings.overlay === 'base');
+    powerModeBtn.classList.toggle('active', settings.overlay === 'power');
+    waterModeBtn.classList.toggle('active', settings.overlay === 'water');
+    alertsModeBtn.classList.toggle('active', settings.overlay === 'alerts');
+    educationModeBtn.classList.toggle('active', settings.overlay === 'education');
+    wildernessModeBtn.classList.toggle('active', settings.overlay === 'wilderness');
+    stratumBtn.textContent = stratum === 'underground' ? 'View: Underground' : 'View: Surface';
+    stratumBtn.classList.toggle('active', stratum === 'underground');
     sizeBtn.textContent = settings.size === 'small' ? 'Size: Small' : 'Size: Medium';
     toggleBtn.textContent = settings.open ? 'Hide' : 'Show';
     body.style.display = settings.open ? 'block' : 'none';
-    subtitle.textContent = MODE_COPY[settings.mode].subtitle;
-    hint.textContent = MODE_COPY[settings.mode].hint;
+    subtitle.textContent = subtitleText();
+    hint.textContent = OVERLAY_COPY[settings.overlay].hint;
     const widthPx = Math.max(SIZE_PRESETS[settings.size] + PANEL_PADDING + 12, MIN_PANEL_WIDTH);
     container.style.width = `${widthPx}px`;
   }
@@ -307,7 +323,7 @@ export function initMinimap(options: MinimapOptions): MinimapController {
     if (!tile) return '#000';
     const templateKind = tile.buildingId !== undefined ? buildingLookup.get(tile.buildingId)?.template?.tileKind : undefined;
 
-    if (settings.mode === 'power') {
+    if (settings.overlay === 'power') {
       if (tile.powerPlantType) return '#81e8ff';
       if (hasOccupant(tile.overhead, Occupant.PowerLine)) {
         return tile.powered ? '#7bf0ff' : '#ff99c2';
@@ -318,7 +334,7 @@ export function initMinimap(options: MinimapOptions): MinimapController {
       return 'rgba(20, 32, 50, 0.9)';
     }
 
-    if (settings.mode === 'water') {
+    if (settings.overlay === 'water') {
       if (tile.terrain === Terrain.Water) return '#1f68d6';
       if (templateKind === TileKind.WaterPump || templateKind === TileKind.WaterTower) {
         return tile.powered ? '#7ad5ff' : '#ffcc70';
@@ -326,7 +342,7 @@ export function initMinimap(options: MinimapOptions): MinimapController {
       return tile.powered ? 'rgba(76, 195, 255, 0.25)' : 'rgba(16, 26, 42, 0.92)';
     }
 
-    if (settings.mode === 'alerts') {
+    if (settings.overlay === 'alerts') {
       const zone = isZone(tile);
       const buildingStatus = tile.buildingId !== undefined ? buildingStatuses.get(tile.buildingId) : undefined;
       let severity = 0;
@@ -344,7 +360,7 @@ export function initMinimap(options: MinimapOptions): MinimapController {
       if (severity === 1) return 'rgba(255, 204, 112, 0.95)';
       return 'rgba(255, 123, 123, 0.95)';
     }
-    if (settings.mode === 'education') {
+    if (settings.overlay === 'education') {
       if (templateKind === TileKind.ElementarySchool || templateKind === TileKind.HighSchool) {
         return '#8f7bff';
       }
@@ -357,7 +373,7 @@ export function initMinimap(options: MinimapOptions): MinimapController {
       return 'rgba(16, 26, 42, 0.9)';
     }
 
-    if (settings.mode === 'wilderness') {
+    if (settings.overlay === 'wilderness') {
       if (tile.terrain === Terrain.Water) return '#1f68d6';
       const delta = (tile.wilderness ?? 0.5) - 0.5;
       if (delta > 0.02) return `rgba(94, 230, 160, ${Math.min(0.3 + delta * 1.4, 0.95).toFixed(2)})`;
@@ -365,7 +381,10 @@ export function initMinimap(options: MinimapOptions): MinimapController {
       return 'rgba(16, 26, 42, 0.9)';
     }
 
-    if (settings.mode === 'underground') {
+    // `overlay === 'base'` beyond this point: the "base look" itself still
+    // depends on the stratum axis — underground has its own base rendering
+    // (pipes as objects), independent of any overlay tint.
+    if (stratum === 'underground') {
       if (hasOccupant(tile.underground, Occupant.Pipe)) return '#4cc3ff';
       if (tile.terrain === Terrain.Water) return '#1f68d6';
       if (tile.watered) return 'rgba(76, 195, 255, 0.55)';
@@ -470,8 +489,13 @@ export function initMinimap(options: MinimapOptions): MinimapController {
     options.onJumpToTile({ x: tileX, y: tileY });
   }
 
-  function update(state: GameState, camera: Camera) {
+  function update(state: GameState, camera: Camera, nextStratum: ViewStratum) {
     latestState = state;
+    if (nextStratum !== stratum) {
+      stratum = nextStratum;
+      dirty = true;
+      syncUi();
+    }
     const sizeChanged = state.width !== lastMapWidth || state.height !== lastMapHeight;
     if (sizeChanged) {
       lastMapWidth = state.width;
@@ -502,7 +526,7 @@ export function initMinimap(options: MinimapOptions): MinimapController {
   return {
     update,
     toggleOpen,
-    setMode,
+    setOverlay,
     setSize,
     markDirty,
     syncSettings

--- a/docs/tile-model.md
+++ b/docs/tile-model.md
@@ -172,7 +172,7 @@ The tile stays a dumb container. `development: Option<BuildingId>` points at an 
 
 ## Bulldoze
 
-The bulldozer works on **what you can see**: surface and overhead together, restoring the tile to its terrain. Underground occupants are only removable from the underground view — which **already exists** (`minimap.ts`, mode `underground`) and is how water pipes are laid today. So this is not a new interaction to design, it is an existing one the model has to keep expressible, and it is expressible only because terrain is a separate field.
+The bulldozer works on **what you can see**: surface and overhead together, restoring the tile to its terrain. Underground occupants are only removable from the underground view — which **already exists** (`main.ts`'s `ViewStratum`, `'underground'`) and is how water pipes are laid today. So this is not a new interaction to design, it is an existing one the model has to keep expressible, and it is expressible only because terrain is a separate field.
 
 ## Scoring becomes a sum
 


### PR DESCRIPTION
## Summary

Part of #197 — this is **PR 1 of 2** from the issue's planned breakdown: split the enum, promote `ViewStratum` to first-class app state. PR 2 (HUD stratum indicator, `toggleStratum` hotkey, and the tool/stratum click-guard) is a follow-on and not included here.

- **Splits `MinimapMode` into two orthogonal types** in `gameState.ts`: `MinimapOverlay` (the six read-only data overlays) and a new `ViewStratum = 'surface' | 'underground'` — the edit-scope axis that changes what tools may touch.
- **`ViewStratum` becomes first-class app state** in `main.ts`, module-level alongside the active tool — not part of `state.settings`, never persisted, always starts at `surface`.
- **Fixes the drift bug in passing**: `clientState.ts`'s sanitiser allow-list was missing `'wilderness'`; both it and `minimap.ts`'s chip set now read one shared `MINIMAP_OVERLAYS` list so they can't drift apart again.
- **`renderer.ts` and `minimap.ts` take `(stratum, overlay)` as two separate params** instead of one `overlayMode` string; the minimap's stratum toggle is now visually split out from the six overlay chips (its own row, not a seventh choice).
- **Tool-implied stratum switching is preserved exactly**, pulled into a new, unit-tested `resolveStratumForTool` (`viewStratum.ts`) instead of living inline in `setTool`.

### Documentation

- Ports the branch-naming conventions from a sibling project's `AGENTS.md`: work the tracking issue number into branch descriptions (`fix/issue-197-view-strata`), enforced by a new opt-in `scripts/hooks/pre-push` hook. Also extends the "add a licence header on touch" rule to `.sh` scripts.

## Test plan

- [x] `bun run lint` (`tsc --noEmit`) passes.
- [x] `bun run test` — 270 tests pass, including new `viewStratum.test.ts` coverage for the tool→stratum resolution.
- [x] Manual check via a running dev server: selecting the Water Pipes tool still auto-switches the minimap to Underground (main map dims correctly, minimap subtitle reads "Base view · Underground", the new stratum toggle chip highlights).
- [x] No behaviour change for the default surface/base combination — confirmed against `e2e/visual.spec.ts`'s pinned `d-minimap.png`, the only screenshot that exercises the minimap, which only covers that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
