### PR TITLE
Put stratum on the wire for every ApplyTool command

### DIFF
--- a/app/src/game/mcpBridge.ts
+++ b/app/src/game/mcpBridge.ts
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: MIT
 
 import type { SimBridge } from './simBridge';
-import type { GameState } from './gameState';
+import type { GameState, ViewStratum } from './gameState';
 import { createInitialState } from './gameState';
 import { Tool } from './toolTypes';
 import { getCalendarPosition } from './time';
@@ -33,6 +33,13 @@ function bresenhamLine(x0: number, y0: number, x1: number, y1: number): [number,
 }
 
 const MCP_WS_PORT = 5174;
+
+// The MCP bridge has no view state of its own — scripted commands default to
+// the surface, with an explicit `stratum: 'underground'` param letting a
+// script lay pipe or bulldoze underground without a client view to read.
+function stratumParam(params: Record<string, unknown>): ViewStratum {
+  return params.stratum === 'underground' ? 'underground' : 'surface';
+}
 
 // Use setTimeout rather than rAF — background/unfocused Chromium tabs throttle
 // rAF to 1 fps, which would stall every MCP command for seconds and freeze the HUD.
@@ -141,7 +148,7 @@ export function initMcpBridge(bridge: SimBridge, state: GameState): void {
           const x = params.x as number;
           const y = params.y as number;
           const moneyBefore = bridge.getState().money;
-          bridge.send({ type: 'ApplyTool', tool, x, y, strokeId: nextStrokeId() });
+          bridge.send({ type: 'ApplyTool', tool, x, y, strokeId: nextStrokeId(), stratum: stratumParam(params) });
           await waitMs(150);
           reply(id, {
             moneyBefore,
@@ -193,8 +200,9 @@ export function initMcpBridge(bridge: SimBridge, state: GameState): void {
           );
           const moneyBefore = bridge.getState().money;
           const lineStroke = nextStrokeId();
+          const stratum = stratumParam(params);
           for (const [px, py] of pts) {
-            bridge.send({ type: 'ApplyTool', tool, x: px, y: py, strokeId: lineStroke });
+            bridge.send({ type: 'ApplyTool', tool, x: px, y: py, strokeId: lineStroke, stratum });
           }
           await waitMs(150);
           reply(id, { placed: pts.length, moneyBefore, moneyAfter: bridge.getState().money, state: simState() });
@@ -209,10 +217,11 @@ export function initMcpBridge(bridge: SimBridge, state: GameState): void {
           const by = Math.max(params.y1 as number, params.y2 as number);
           const moneyBefore = bridge.getState().money;
           const rectStroke = nextStrokeId();
+          const stratum = stratumParam(params);
           let placed = 0;
           for (let ry = ay; ry <= by; ry++) {
             for (let rx = ax; rx <= bx; rx++) {
-              bridge.send({ type: 'ApplyTool', tool, x: rx, y: ry, strokeId: rectStroke });
+              bridge.send({ type: 'ApplyTool', tool, x: rx, y: ry, strokeId: rectStroke, stratum });
               placed++;
             }
           }

--- a/app/src/game/protocol/commands.ts
+++ b/app/src/game/protocol/commands.ts
@@ -7,6 +7,7 @@
  */
 
 import { Tool } from '../toolTypes';
+import type { ViewStratum } from '../gameState';
 
 /**
  * SimCity-style fiscal policy — TS mirror of `BudgetPolicy` in
@@ -107,7 +108,7 @@ export function clampPolicies(policies: Policies): Policies {
 }
 
 export type SimCommand =
-  | { type: 'ApplyTool'; tool: Tool; x: number; y: number; strokeId: number }
+  | { type: 'ApplyTool'; tool: Tool; x: number; y: number; strokeId: number; stratum: ViewStratum }
   | { type: 'SetSpeed'; multiplier: number }
   | { type: 'SetPolicies'; policies: Policies };
 
@@ -120,9 +121,20 @@ export interface CommandResult {
  * `strokeId` groups the many `ApplyTool` commands of one drag-paint gesture
  * into a single undo step — allocate a fresh id per gesture with
  * `nextStrokeId()`, not per painted tile.
+ *
+ * `stratum` names the layer the player is looking at (see `ViewStratum` in
+ * `../gameState`) — every tool but `Tool.Bulldoze` ignores it today, but it
+ * travels on every `ApplyTool` command so it is never a client-only setting
+ * the engine can't see (`docs/features/layer-scoped-bulldozer.md`).
  */
-export function applyToolCmd(tool: Tool, x: number, y: number, strokeId: number): SimCommand {
-  return { type: 'ApplyTool', tool, x, y, strokeId };
+export function applyToolCmd(
+  tool: Tool,
+  x: number,
+  y: number,
+  strokeId: number,
+  stratum: ViewStratum
+): SimCommand {
+  return { type: 'ApplyTool', tool, x, y, strokeId, stratum };
 }
 
 let strokeCounter = 0;

--- a/app/src/game/tauriSimBridge.test.ts
+++ b/app/src/game/tauriSimBridge.test.ts
@@ -30,6 +30,10 @@ const TOOL_ID = {
   Commercial: 18, Industrial: 19, Park: 20, Bulldoze: 21, ParkLarge: 22
 } as const;
 
+// Local mirror of `VIEW_STRATUM_ID` from `tauri-plugin-city-sim`'s guest-js,
+// for the same reason `TOOL_ID` is mirrored above rather than imported.
+const VIEW_STRATUM_ID = { Surface: 0, Underground: 1 } as const;
+
 interface WireBuilding {
   id: number;
   kind: number;
@@ -115,9 +119,22 @@ describe('TauriSimBridge command routing', () => {
     for (const tool of Object.values(Tool)) {
       vi.mocked(plugin.applyTool).mockClear();
       const stroke = nextStrokeId();
-      bridge.send(applyToolCmd(tool, 3, 4, stroke));
-      expect(plugin.applyTool).toHaveBeenCalledWith(TOOL_ID[toolIdKey(tool)], 3, 4, stroke);
+      bridge.send(applyToolCmd(tool, 3, 4, stroke, 'surface'));
+      expect(plugin.applyTool).toHaveBeenCalledWith(TOOL_ID[toolIdKey(tool)], 3, 4, stroke, VIEW_STRATUM_ID.Surface);
     }
+  });
+
+  it('maps an \'underground\' stratum to VIEW_STRATUM_ID.Underground when sending ApplyTool', async () => {
+    const { bridge, plugin } = await makeBridge();
+    const stroke = nextStrokeId();
+    bridge.send(applyToolCmd(Tool.Bulldoze, 3, 4, stroke, 'underground'));
+    expect(plugin.applyTool).toHaveBeenCalledWith(
+      TOOL_ID.Bulldoze,
+      3,
+      4,
+      stroke,
+      VIEW_STRATUM_ID.Underground
+    );
   });
 
   it('delegates SetSpeed and SetPolicies to the plugin', async () => {
@@ -162,7 +179,7 @@ describe('TauriSimBridge command routing', () => {
     const { bridge, plugin, events } = await makeBridge();
     vi.mocked(plugin.applyTool).mockResolvedValueOnce({ success: false, message: 'Not enough funds' });
 
-    bridge.send(applyToolCmd(Tool.Road, 3, 4, nextStrokeId()));
+    bridge.send(applyToolCmd(Tool.Road, 3, 4, nextStrokeId(), 'surface'));
     // send() itself must still answer synchronously and optimistically —
     // the real result arrives later, over the resolved promise.
     await Promise.resolve();

--- a/app/src/game/tauriSimBridge.ts
+++ b/app/src/game/tauriSimBridge.ts
@@ -29,7 +29,7 @@
  * that could disagree with the engine's own.
  */
 
-import type { GameState, Tile } from './gameState';
+import type { GameState, Tile, ViewStratum } from './gameState';
 import { TileKind } from './gameState';
 import { BuildingStatus, createBuildingState } from './buildings/state';
 import { getBuildingTemplate } from './buildings/templates';
@@ -57,6 +57,8 @@ import {
   importLegacy as pluginImportLegacy,
   TOOL_ID,
   type ToolId,
+  VIEW_STRATUM_ID,
+  type ViewStratumId,
   type TickEvent,
 } from 'tauri-plugin-city-sim';
 
@@ -134,6 +136,15 @@ const TOOL_TO_ID: Record<Tool, ToolId> = {
 };
 
 // ---------------------------------------------------------------------------
+// Stratum mapping: TS ViewStratum string union → plugin u8 discriminant
+// ---------------------------------------------------------------------------
+
+const STRATUM_TO_ID: Record<ViewStratum, ViewStratumId> = {
+  surface:     VIEW_STRATUM_ID.Surface,
+  underground: VIEW_STRATUM_ID.Underground,
+};
+
+// ---------------------------------------------------------------------------
 // TauriSimBridge
 // ---------------------------------------------------------------------------
 
@@ -176,7 +187,7 @@ export class TauriSimBridge implements SimBridge {
         // thread over IPC. Forward it once it lands, correlated to this exact
         // call by promise identity ("keyed by stroke" in practice, since each
         // call already carries its own strokeId).
-        void this.plugin.applyTool(id, cmd.x, cmd.y, cmd.strokeId).then((result) => {
+        void this.plugin.applyTool(id, cmd.x, cmd.y, cmd.strokeId, STRATUM_TO_ID[cmd.stratum]).then((result) => {
           this.handler?.({ type: 'CommandResult', success: result.success, message: result.message ?? undefined });
         });
         return { success: true };

--- a/app/src/game/wasmSimBridge.test.ts
+++ b/app/src/game/wasmSimBridge.test.ts
@@ -81,10 +81,21 @@ describe('WasmSimBridge undo/redo', () => {
   it('threads strokeId through apply_tool worker messages', () => {
     const { worker, bridge } = makeBridge();
     const stroke = nextStrokeId();
-    bridge.send(applyToolCmd(Tool.Road, 2, 3, stroke));
+    bridge.send(applyToolCmd(Tool.Road, 2, 3, stroke, 'surface'));
     expect(worker.sent).toHaveLength(1);
     expect(worker.sent[0].type).toBe('apply_tool');
     expect(worker.sent[0].payload).toMatchObject({ x: 2, y: 3, strokeId: stroke });
+  });
+
+  it('encodes the ViewStratum onto the apply_tool payload as a 0/1 discriminant', () => {
+    // The only observable behaviour change in this PR: everything else is
+    // pure plumbing (the engine still ignores stratum until PR 2's bulldoze()
+    // implementation lands), but the wire encoding itself is worth pinning.
+    const { worker, bridge } = makeBridge();
+    const stroke = nextStrokeId();
+    bridge.send(applyToolCmd(Tool.Bulldoze, 4, 5, stroke, 'underground'));
+    expect(worker.sent).toHaveLength(1);
+    expect(worker.sent[0].payload).toMatchObject({ x: 4, y: 5, strokeId: stroke, stratum: 1 });
   });
 
   it('resolves undo with false when the worker reports nothing to undo', async () => {
@@ -97,7 +108,7 @@ describe('WasmSimBridge undo/redo', () => {
   it('undo/redo round-trip resolves true and tracks history flags', async () => {
     const { worker, bridge } = makeBridge();
     const drag = nextStrokeId();
-    bridge.send(applyToolCmd(Tool.Road, 1, 0, drag));
+    bridge.send(applyToolCmd(Tool.Road, 1, 0, drag, 'surface'));
 
     const pendingUndo = bridge.undo();
     worker.emit({
@@ -174,7 +185,7 @@ describe('WasmSimBridge undo/redo', () => {
     const { worker, bridge, events } = makeBridge();
     const historyEvents = () => events.filter(e => e.type === 'HistoryChanged');
     const before = historyEvents().length;
-    bridge.send(applyToolCmd(Tool.Road, 1, 0, nextStrokeId()));
+    bridge.send(applyToolCmd(Tool.Road, 1, 0, nextStrokeId(), 'surface'));
     worker.emit({ type: 'apply_result', success: true, message: null, history: flags(true, false) });
     worker.emit({ type: 'apply_result', success: true, message: null, history: flags(true, false) });
     const after = historyEvents();
@@ -201,7 +212,7 @@ describe('WasmSimBridge undo/redo', () => {
 
   it('forwards a refused apply_result as a CommandResult with the message', () => {
     const { worker, bridge, events } = makeBridge();
-    bridge.send(applyToolCmd(Tool.Road, 1, 0, nextStrokeId()));
+    bridge.send(applyToolCmd(Tool.Road, 1, 0, nextStrokeId(), 'surface'));
     worker.emit({ type: 'apply_result', success: false, message: 'Not enough funds', history: flags(false, false) });
 
     const result = events.find(e => e.type === 'CommandResult');

--- a/app/src/game/wasmSimBridge.ts
+++ b/app/src/game/wasmSimBridge.ts
@@ -11,7 +11,7 @@
 // Tile-buffer transport: transferable ArrayBuffer (one copy per step).
 
 import { recordEngineBuild } from '../buildInfo';
-import type { GameState } from './gameState';
+import type { GameState, ViewStratum } from './gameState';
 import { TileKind } from './gameState';
 import { BuildingStatus, createBuildingState } from './buildings/state';
 import { getBuildingTemplate } from './buildings/templates';
@@ -54,6 +54,16 @@ const TOOL_TO_U8: Record<Tool, number> = {
   [Tool.Park]:             20,
   [Tool.Bulldoze]:         21,
   [Tool.ParkLarge]:        22,
+};
+
+// Mapping from the TS string-valued ViewStratum ('surface' | 'underground',
+// gameState.ts) → the Rust ViewStratum's #[repr(u8)] discriminant
+// (city-sim-protocol/src/commands.rs). Deliberately a distinct concept from
+// tile-internal Stratum — this one describes which layer the *player* is
+// looking at, not a tile occupant bitset — see that enum's doc comment.
+const STRATUM_TO_U8: Record<ViewStratum, number> = {
+  surface: 0,
+  underground: 1,
 };
 
 interface WorkerHistoryFlags {
@@ -250,7 +260,13 @@ export class WasmSimBridge implements SimBridge {
         if (this.ready) {
           this.worker.postMessage({
             type: 'apply_tool',
-            payload: { tool: TOOL_TO_U8[cmd.tool], x: cmd.x, y: cmd.y, strokeId: cmd.strokeId },
+            payload: {
+              tool: TOOL_TO_U8[cmd.tool],
+              x: cmd.x,
+              y: cmd.y,
+              strokeId: cmd.strokeId,
+              stratum: STRATUM_TO_U8[cmd.stratum],
+            },
           });
         }
         break;

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -775,7 +775,7 @@ function applyCurrentTool(tilePos: Position) {
   // engine has actually processed the command — the real result, including
   // any failure message, arrives async as a `CommandResult` FromSim message
   // (see `wireBridge` above), not through this return value.
-  const result = bridge.send(applyToolCmd(activeTool, tilePos.x, tilePos.y, strokeId));
+  const result = bridge.send(applyToolCmd(activeTool, tilePos.x, tilePos.y, strokeId, viewStratum));
   sfx?.playToolResult(activeTool, result.success);
   if (result.success) {
     minimap?.markDirty();

--- a/app/src/workers/wasmSim.worker.ts
+++ b/app/src/workers/wasmSim.worker.ts
@@ -124,7 +124,7 @@ export interface LegacyEngineImport {
 
 type MainToWorker =
   | { type: 'init';          payload: { width: number; height: number; seed: number; terrain?: Uint8Array; policies?: WorkerPolicies } }
-  | { type: 'apply_tool';    payload: { tool: number; x: number; y: number; strokeId: number } }
+  | { type: 'apply_tool';    payload: { tool: number; x: number; y: number; strokeId: number; stratum: number } }
   | { type: 'set_speed';     payload: { multiplier: number } }
   | { type: 'set_policies';  payload: WorkerPolicies }
   | { type: 'undo' }
@@ -359,7 +359,7 @@ self.onmessage = async (e: MessageEvent<MainToWorker>) => {
     }
     case 'apply_tool': {
       if (!host) break;
-      const success = host.apply_tool(msg.payload.tool, msg.payload.x, msg.payload.y, msg.payload.strokeId);
+      const success = host.apply_tool(msg.payload.tool, msg.payload.x, msg.payload.y, msg.payload.strokeId, msg.payload.stratum);
       const message = host.last_apply_message() ?? null;
       // Bump unconditionally (not just on success) — cheap, and keeps this
       // simple; a rejected placement just costs one extra harmless apply on

--- a/crates/city-sim-core/benches/sim_bench.rs
+++ b/crates/city-sim-core/benches/sim_bench.rs
@@ -10,7 +10,7 @@ use city_sim_core::{
     snapshot::{from_bytes, to_bytes},
     state::GameState,
 };
-use city_sim_protocol::commands::Tool;
+use city_sim_protocol::commands::{Tool, ViewStratum};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 // ---------------------------------------------------------------------------
@@ -22,17 +22,41 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 fn make_populated_8x8(seed: u32) -> Simulation {
     let mut sim = Simulation::new(8, 8, seed);
     // Roads
-    apply_tool(&mut sim.state, Tool::Road, 3, 0);
-    apply_tool(&mut sim.state, Tool::Road, 3, 1);
-    apply_tool(&mut sim.state, Tool::Road, 3, 2);
-    apply_tool(&mut sim.state, Tool::Road, 3, 3);
+    apply_tool(&mut sim.state, Tool::Road, 3, 0, ViewStratum::Surface);
+    apply_tool(&mut sim.state, Tool::Road, 3, 1, ViewStratum::Surface);
+    apply_tool(&mut sim.state, Tool::Road, 3, 2, ViewStratum::Surface);
+    apply_tool(&mut sim.state, Tool::Road, 3, 3, ViewStratum::Surface);
     // Zones
-    apply_tool(&mut sim.state, Tool::Residential, 0, 0);
-    apply_tool(&mut sim.state, Tool::Residential, 1, 0);
-    apply_tool(&mut sim.state, Tool::Residential, 0, 1);
-    apply_tool(&mut sim.state, Tool::Residential, 1, 1);
-    apply_tool(&mut sim.state, Tool::Commercial, 0, 2);
-    apply_tool(&mut sim.state, Tool::Industrial, 0, 3);
+    apply_tool(
+        &mut sim.state,
+        Tool::Residential,
+        0,
+        0,
+        ViewStratum::Surface,
+    );
+    apply_tool(
+        &mut sim.state,
+        Tool::Residential,
+        1,
+        0,
+        ViewStratum::Surface,
+    );
+    apply_tool(
+        &mut sim.state,
+        Tool::Residential,
+        0,
+        1,
+        ViewStratum::Surface,
+    );
+    apply_tool(
+        &mut sim.state,
+        Tool::Residential,
+        1,
+        1,
+        ViewStratum::Surface,
+    );
+    apply_tool(&mut sim.state, Tool::Commercial, 0, 2, ViewStratum::Surface);
+    apply_tool(&mut sim.state, Tool::Industrial, 0, 3, ViewStratum::Surface);
     // Prime demand so zone growth fires from tick 1
     sim.state.demand.residential = 80.0;
     sim.state.demand.commercial = 60.0;
@@ -83,7 +107,7 @@ fn tick_1000_64x64(c: &mut Criterion) {
     });
 }
 
-/// Single `apply_tool(Road)` call on a fresh 8×8 state.
+/// Single `apply_tool(Road, ViewStratum::Surface)` call on a fresh 8×8 state.
 ///
 /// Measures the cost of the hottest player-action path: bounds check, fund
 /// deduction, tile mutation, and tile_revision bump.
@@ -92,7 +116,13 @@ fn apply_tool_road(c: &mut Criterion) {
         b.iter_batched(
             || GameState::new(8, 8, 0),
             |mut state| {
-                let result = apply_tool(&mut state, black_box(Tool::Road), 3, 3);
+                let result = apply_tool(
+                    &mut state,
+                    black_box(Tool::Road),
+                    3,
+                    3,
+                    ViewStratum::Surface,
+                );
                 black_box(result)
             },
             criterion::BatchSize::SmallInput,

--- a/crates/city-sim-core/src/adjacency.rs
+++ b/crates/city-sim-core/src/adjacency.rs
@@ -200,7 +200,7 @@ mod tests {
     use crate::commands::apply_tool;
     use crate::migrate::{set_v4, set_v4_kind};
     use crate::occupants::Occupant;
-    use city_sim_protocol::commands::Tool;
+    use city_sim_protocol::commands::{Tool, ViewStratum};
     use city_sim_protocol::legacy_tile_buffer::legacy_flags as flags;
     use city_sim_protocol::tile_kind::TileKind;
 
@@ -310,7 +310,7 @@ mod tests {
         let mut s = g(3, 1);
         s.money = 10_000;
         kind(&mut s, 0, 0, TileKind::Residential);
-        apply_tool(&mut s, Tool::PowerLine, 1, 0);
+        apply_tool(&mut s, Tool::PowerLine, 1, 0, ViewStratum::Surface);
         let line = s.tile_at(1, 0).unwrap();
         assert!(line.has_occupant(Occupant::PowerLine));
         assert!(
@@ -330,8 +330,8 @@ mod tests {
         let mut s = g(3, 1);
         s.money = 10_000;
         kind(&mut s, 0, 0, TileKind::Residential);
-        apply_tool(&mut s, Tool::PowerLine, 1, 0);
-        apply_tool(&mut s, Tool::Road, 1, 0);
+        apply_tool(&mut s, Tool::PowerLine, 1, 0, ViewStratum::Surface);
+        apply_tool(&mut s, Tool::Road, 1, 0, ViewStratum::Surface);
         let t = s.tile_at(1, 0).unwrap();
         assert!(t.has_occupant(Occupant::PowerLine));
         assert!(t.has_occupant(Occupant::Road));
@@ -341,8 +341,8 @@ mod tests {
         let mut s = g(3, 1);
         s.money = 10_000;
         kind(&mut s, 0, 0, TileKind::Residential);
-        apply_tool(&mut s, Tool::Road, 1, 0);
-        apply_tool(&mut s, Tool::PowerLine, 1, 0);
+        apply_tool(&mut s, Tool::Road, 1, 0, ViewStratum::Surface);
+        apply_tool(&mut s, Tool::PowerLine, 1, 0, ViewStratum::Surface);
         assert!(has_road_access(&s, 0, 0), "road-then-line");
     }
 
@@ -438,7 +438,7 @@ mod tests {
                 kind(&mut s, x, y, TileKind::Residential);
             }
         }
-        apply_tool(&mut s, Tool::PowerLine, 3, 1);
+        apply_tool(&mut s, Tool::PowerLine, 3, 1, ViewStratum::Surface);
 
         // (1,1) is the interior tile: every neighbour is a zone, so it is
         // neither a frontier zone nor road-adjacent.
@@ -450,7 +450,7 @@ mod tests {
         );
 
         // Pave the same tile and the chain is a road path again.
-        apply_tool(&mut s, Tool::Road, 3, 1);
+        apply_tool(&mut s, Tool::Road, 3, 1, ViewStratum::Surface);
         assert!(zone_has_road_path(&s, 1, 1));
     }
 

--- a/crates/city-sim-core/src/commands.rs
+++ b/crates/city-sim-core/src/commands.rs
@@ -12,7 +12,7 @@ use crate::occupants::{
 };
 use crate::state::{GameState, Tile, FLAG_ABANDONED};
 use city_sim_protocol::{
-    commands::{CommandResult, Tool},
+    commands::{CommandResult, Tool, ViewStratum},
     tile_kind::TileKind,
 };
 
@@ -123,9 +123,21 @@ fn regrade_refusal(tile: &Tile) -> Option<&'static str> {
 
 /// Apply a player tool at tile (x, y) on `state`.
 ///
+/// `stratum` names the layer the player is looking at, filled from the
+/// client's active view. Every tool but `Tool::Bulldoze` ignores it today —
+/// see `bulldoze` — but it is threaded through every call site so the field
+/// travels on the wire for every command, not just the ones that currently
+/// read it (`docs/features/layer-scoped-bulldozer.md`).
+///
 /// Validates funds and placement rules, modifies state on success, and returns
 /// a `CommandResult` indicating success or a human-readable failure reason.
-pub fn apply_tool(state: &mut GameState, tool: Tool, x: u32, y: u32) -> CommandResult {
+pub fn apply_tool(
+    state: &mut GameState,
+    tool: Tool,
+    x: u32,
+    y: u32,
+    stratum: ViewStratum,
+) -> CommandResult {
     // Bounds check
     if state.tile_index(x, y).is_none() {
         return CommandResult::fail("Out of bounds");
@@ -344,7 +356,7 @@ pub fn apply_tool(state: &mut GameState, tool: Tool, x: u32, y: u32) -> CommandR
         Tool::Park => place_footprint_building(state, TileKind::Park, x, y, cost, 0, 0.0),
         Tool::ParkLarge => place_footprint_building(state, TileKind::ParkLarge, x, y, cost, 0, 0.0),
 
-        Tool::Bulldoze => bulldoze(state, x, y, cost),
+        Tool::Bulldoze => bulldoze(state, x, y, cost, stratum),
     }
 }
 
@@ -551,7 +563,13 @@ fn place_footprint_building(
 /// build one out of a loaded save and `Tile` can hold one.
 ///
 /// [`set_v4`]: crate::migrate::set_v4
-fn bulldoze(state: &mut GameState, x: u32, y: u32, cost: i64) -> CommandResult {
+fn bulldoze(
+    state: &mut GameState,
+    x: u32,
+    y: u32,
+    cost: i64,
+    _stratum: ViewStratum,
+) -> CommandResult {
     state.money -= cost;
     let idx = state.tile_index(x, y).unwrap();
     if let Some(bid) = state.tiles[idx].building_id {
@@ -601,7 +619,7 @@ mod tests {
     #[test]
     fn inspect_always_succeeds() {
         let mut s = gs(4, 4);
-        let r = apply_tool(&mut s, Tool::Inspect, 0, 0);
+        let r = apply_tool(&mut s, Tool::Inspect, 0, 0, ViewStratum::Surface);
         assert!(r.success);
         assert_eq!(s.money, 100_000);
     }
@@ -609,7 +627,7 @@ mod tests {
     #[test]
     fn out_of_bounds_fails() {
         let mut s = gs(4, 4);
-        let r = apply_tool(&mut s, Tool::Road, 10, 10);
+        let r = apply_tool(&mut s, Tool::Road, 10, 10, ViewStratum::Surface);
         assert!(!r.success);
     }
 
@@ -617,7 +635,7 @@ mod tests {
     fn no_funds_fails() {
         let mut s = gs(4, 4);
         s.money = 0;
-        let r = apply_tool(&mut s, Tool::Road, 0, 0);
+        let r = apply_tool(&mut s, Tool::Road, 0, 0, ViewStratum::Surface);
         assert!(!r.success);
         assert_eq!(r.message.as_deref(), Some("Not enough funds"));
     }
@@ -626,7 +644,7 @@ mod tests {
     fn road_places_road_and_charges_money() {
         let mut s = gs(4, 4);
         let before = s.money;
-        let r = apply_tool(&mut s, Tool::Road, 1, 1);
+        let r = apply_tool(&mut s, Tool::Road, 1, 1, ViewStratum::Surface);
         assert!(r.success);
         assert!(s.tile_at(1, 1).unwrap().has_occupant(Occupant::Road));
         assert_eq!(s.money, before - tool_cost(Tool::Road));
@@ -643,7 +661,7 @@ mod tests {
         for order in [[Tool::Rail, Tool::Road], [Tool::Road, Tool::Rail]] {
             let mut s = gs(4, 4);
             for tool in order {
-                assert!(apply_tool(&mut s, tool, 0, 0).success);
+                assert!(apply_tool(&mut s, tool, 0, 0, ViewStratum::Surface).success);
             }
             let t = s.tile_at(0, 0).unwrap();
             assert!(t.has_occupant(Occupant::Road), "{order:?}: the road");
@@ -655,7 +673,7 @@ mod tests {
     fn zone_tool_charges_and_sets_kind() {
         let mut s = gs(4, 4);
         let before = s.money;
-        let r = apply_tool(&mut s, Tool::Residential, 2, 2);
+        let r = apply_tool(&mut s, Tool::Residential, 2, 2, ViewStratum::Surface);
         assert!(r.success);
         assert_eq!(
             s.tile_at(2, 2).unwrap().zone_occupant(),
@@ -668,7 +686,7 @@ mod tests {
     fn zone_over_road_fails() {
         let mut s = gs(4, 4);
         set_v4_kind(s.tile_at_mut(0, 0).unwrap(), TileKind::Road);
-        let r = apply_tool(&mut s, Tool::Residential, 0, 0);
+        let r = apply_tool(&mut s, Tool::Residential, 0, 0, ViewStratum::Surface);
         assert!(!r.success);
         assert!(
             s.tile_at(0, 0).unwrap().has_occupant(Occupant::Road),
@@ -679,7 +697,7 @@ mod tests {
     #[test]
     fn water_pipe_sets_underground() {
         let mut s = gs(4, 4);
-        apply_tool(&mut s, Tool::WaterPipe, 1, 1);
+        apply_tool(&mut s, Tool::WaterPipe, 1, 1, ViewStratum::Surface);
         assert!(s.tile_at(1, 1).unwrap().has_occupant(Occupant::Pipe));
     }
 
@@ -687,7 +705,7 @@ mod tests {
     fn place_1x1_building_stamps_tile_and_charges() {
         let mut s = gs(4, 4);
         let before = s.money;
-        let r = apply_tool(&mut s, Tool::WaterPump, 0, 0);
+        let r = apply_tool(&mut s, Tool::WaterPump, 0, 0, ViewStratum::Surface);
         assert!(r.success);
         assert_eq!(structure_kind_at(&s, 0, 0), Some(TileKind::WaterPump));
         assert!(s.tile_at(0, 0).unwrap().building_id.is_some());
@@ -698,7 +716,7 @@ mod tests {
     #[test]
     fn place_2x2_building_fills_footprint() {
         let mut s = gs(4, 4);
-        let r = apply_tool(&mut s, Tool::WaterTower, 0, 0);
+        let r = apply_tool(&mut s, Tool::WaterTower, 0, 0, ViewStratum::Surface);
         assert!(r.success);
         let bid = s.tile_at(0, 0).unwrap().building_id.unwrap();
         for dy in 0..2 {
@@ -713,7 +731,7 @@ mod tests {
     fn place_building_fails_out_of_bounds() {
         let mut s = gs(3, 3);
         // WaterTower is 2×2; placing at (2,2) would go to (3,3) which is out of bounds
-        let r = apply_tool(&mut s, Tool::WaterTower, 2, 2);
+        let r = apply_tool(&mut s, Tool::WaterTower, 2, 2, ViewStratum::Surface);
         assert!(!r.success);
         assert_eq!(s.tile_at(2, 2).unwrap().occupants(), 0);
     }
@@ -721,8 +739,8 @@ mod tests {
     #[test]
     fn place_building_fails_on_overlap() {
         let mut s = gs(4, 4);
-        apply_tool(&mut s, Tool::WaterPump, 0, 0);
-        let r = apply_tool(&mut s, Tool::WaterPump, 0, 0);
+        apply_tool(&mut s, Tool::WaterPump, 0, 0, ViewStratum::Surface);
+        let r = apply_tool(&mut s, Tool::WaterPump, 0, 0, ViewStratum::Surface);
         assert!(!r.success);
         assert_eq!(s.buildings.len(), 1, "only one building should exist");
     }
@@ -730,8 +748,8 @@ mod tests {
     #[test]
     fn bulldoze_removes_road() {
         let mut s = gs(4, 4);
-        apply_tool(&mut s, Tool::Road, 0, 0);
-        apply_tool(&mut s, Tool::Bulldoze, 0, 0);
+        apply_tool(&mut s, Tool::Road, 0, 0, ViewStratum::Surface);
+        apply_tool(&mut s, Tool::Bulldoze, 0, 0, ViewStratum::Surface);
         assert_eq!(s.tile_at(0, 0).unwrap().occupants(), 0);
     }
 
@@ -758,9 +776,9 @@ mod tests {
     fn the_bulldozer_clears_the_tile_and_leaves_the_ground_alone() {
         // Dry land, built on through the tools.
         let mut s = gs(4, 4);
-        assert!(apply_tool(&mut s, Tool::Road, 1, 1).success);
-        assert!(apply_tool(&mut s, Tool::PowerLine, 1, 1).success);
-        assert!(apply_tool(&mut s, Tool::Bulldoze, 1, 1).success);
+        assert!(apply_tool(&mut s, Tool::Road, 1, 1, ViewStratum::Surface).success);
+        assert!(apply_tool(&mut s, Tool::PowerLine, 1, 1, ViewStratum::Surface).success);
+        assert!(apply_tool(&mut s, Tool::Bulldoze, 1, 1, ViewStratum::Surface).success);
         let t = s.tile_at(1, 1).unwrap();
         assert_eq!(t.terrain(), Terrain::Land, "bulldozing land drowned it");
         assert_eq!(t.occupants(), 0, "something outlived the bulldozer");
@@ -774,7 +792,7 @@ mod tests {
             None,
         );
         assert!(s.tile_at(2, 2).unwrap().has_occupant(Occupant::Road));
-        assert!(apply_tool(&mut s, Tool::Bulldoze, 2, 2).success);
+        assert!(apply_tool(&mut s, Tool::Bulldoze, 2, 2, ViewStratum::Surface).success);
         let t = s.tile_at(2, 2).unwrap();
         assert_eq!(
             t.terrain(),
@@ -802,12 +820,12 @@ mod tests {
     #[test]
     fn bulldozing_open_water_is_not_a_cheap_regrade() {
         let mut s = gs(4, 4);
-        assert!(apply_tool(&mut s, Tool::Water, 1, 1).success);
-        assert!(apply_tool(&mut s, Tool::Bulldoze, 1, 1).success);
+        assert!(apply_tool(&mut s, Tool::Water, 1, 1, ViewStratum::Surface).success);
+        assert!(apply_tool(&mut s, Tool::Bulldoze, 1, 1, ViewStratum::Surface).success);
         assert_eq!(s.tile_at(1, 1).unwrap().terrain(), Terrain::Water);
 
         // …and the brush that *is* priced for it still works.
-        assert!(apply_tool(&mut s, Tool::TerraformRaise, 1, 1).success);
+        assert!(apply_tool(&mut s, Tool::TerraformRaise, 1, 1, ViewStratum::Surface).success);
         assert_eq!(s.tile_at(1, 1).unwrap().terrain(), Terrain::Land);
         assert!(
             tool_cost(Tool::TerraformRaise) > tool_cost(Tool::Bulldoze),
@@ -839,17 +857,17 @@ mod tests {
     #[test]
     fn building_over_water_and_razing_it_is_the_cheapest_regrade() {
         let mut s = gs(4, 4);
-        assert!(apply_tool(&mut s, Tool::Water, 1, 1).success);
+        assert!(apply_tool(&mut s, Tool::Water, 1, 1, ViewStratum::Surface).success);
         assert_eq!(s.tile_at(1, 1).unwrap().terrain(), Terrain::Water);
 
         let before = s.money;
-        assert!(apply_tool(&mut s, Tool::Road, 1, 1).success);
+        assert!(apply_tool(&mut s, Tool::Road, 1, 1, ViewStratum::Surface).success);
         assert_eq!(
             s.tile_at(1, 1).unwrap().terrain(),
             Terrain::Land,
             "the road did not fill the lake in as it crossed it"
         );
-        assert!(apply_tool(&mut s, Tool::Bulldoze, 1, 1).success);
+        assert!(apply_tool(&mut s, Tool::Bulldoze, 1, 1, ViewStratum::Surface).success);
 
         let t = s.tile_at(1, 1).unwrap();
         assert_eq!(
@@ -873,8 +891,8 @@ mod tests {
         // `Pipe` bit and never calls `regrade_at` — and everything else that
         // does regrade costs more than a road.
         let mut pipe = gs(4, 4);
-        assert!(apply_tool(&mut pipe, Tool::Water, 1, 1).success);
-        assert!(apply_tool(&mut pipe, Tool::WaterPipe, 1, 1).success);
+        assert!(apply_tool(&mut pipe, Tool::Water, 1, 1, ViewStratum::Surface).success);
+        assert!(apply_tool(&mut pipe, Tool::WaterPipe, 1, 1, ViewStratum::Surface).success);
         assert_eq!(
             pipe.tile_at(1, 1).unwrap().terrain(),
             Terrain::Water,
@@ -905,8 +923,8 @@ mod tests {
         let mut s = gs(4, 4);
 
         // Overhead: a hydro span, then a lake painted under it.
-        assert!(apply_tool(&mut s, Tool::PowerLine, 2, 2).success);
-        assert!(apply_tool(&mut s, Tool::Water, 2, 2).success);
+        assert!(apply_tool(&mut s, Tool::PowerLine, 2, 2, ViewStratum::Surface).success);
+        assert!(apply_tool(&mut s, Tool::Water, 2, 2, ViewStratum::Surface).success);
         let t = s.tile_at(2, 2).unwrap();
         assert_eq!(t.terrain(), Terrain::Water);
         assert!(
@@ -915,8 +933,8 @@ mod tests {
         );
 
         // Underground: a main, then a lake painted over it.
-        assert!(apply_tool(&mut s, Tool::WaterPipe, 3, 3).success);
-        assert!(apply_tool(&mut s, Tool::Water, 3, 3).success);
+        assert!(apply_tool(&mut s, Tool::WaterPipe, 3, 3, ViewStratum::Surface).success);
+        assert!(apply_tool(&mut s, Tool::Water, 3, 3, ViewStratum::Surface).success);
         let t = s.tile_at(3, 3).unwrap();
         assert_eq!(t.terrain(), Terrain::Water);
         assert!(
@@ -927,12 +945,12 @@ mod tests {
         // And the bulldozer reads correctly on both: what stands goes, the
         // water stays. The pipe takes its own click, because underground is
         // only editable from the underground view.
-        assert!(apply_tool(&mut s, Tool::Bulldoze, 2, 2).success);
+        assert!(apply_tool(&mut s, Tool::Bulldoze, 2, 2, ViewStratum::Surface).success);
         let t = s.tile_at(2, 2).unwrap();
         assert_eq!(t.terrain(), Terrain::Water);
         assert_eq!(t.occupants(), 0);
 
-        assert!(apply_tool(&mut s, Tool::Bulldoze, 3, 3).success);
+        assert!(apply_tool(&mut s, Tool::Bulldoze, 3, 3, ViewStratum::Surface).success);
         let t = s.tile_at(3, 3).unwrap();
         assert_eq!(t.terrain(), Terrain::Water);
         assert_eq!(t.occupants(), 0);
@@ -959,9 +977,9 @@ mod tests {
         use crate::zones::ZoneGrowthSim;
 
         let mut s = gs(4, 4);
-        assert!(apply_tool(&mut s, Tool::Road, 1, 0).success);
-        assert!(apply_tool(&mut s, Tool::Residential, 1, 1).success);
-        assert!(apply_tool(&mut s, Tool::PowerLine, 1, 1).success);
+        assert!(apply_tool(&mut s, Tool::Road, 1, 0, ViewStratum::Surface).success);
+        assert!(apply_tool(&mut s, Tool::Residential, 1, 1, ViewStratum::Surface).success);
+        assert!(apply_tool(&mut s, Tool::PowerLine, 1, 1, ViewStratum::Surface).success);
         s.tile_at_mut(1, 0).unwrap().set_flag(FLAG_POWERED, true);
         s.tile_at_mut(1, 1).unwrap().set_flag(FLAG_POWERED, true);
         s.demand.residential = 100.0;
@@ -983,7 +1001,7 @@ mod tests {
         assert!(t.has_occupant(Occupant::ZoneResidential));
         assert!(t.has_occupant(Occupant::PowerLine));
 
-        assert!(apply_tool(&mut s, Tool::Bulldoze, 1, 1).success);
+        assert!(apply_tool(&mut s, Tool::Bulldoze, 1, 1, ViewStratum::Surface).success);
         let t = s.tile_at(1, 1).unwrap();
         assert!(t.building_id.is_none(), "the house outlived the click");
         assert!(
@@ -1000,16 +1018,16 @@ mod tests {
         );
 
         // The second click is what clears them.
-        assert!(apply_tool(&mut s, Tool::Bulldoze, 1, 1).success);
+        assert!(apply_tool(&mut s, Tool::Bulldoze, 1, 1, ViewStratum::Surface).success);
         assert_eq!(s.tile_at(1, 1).unwrap().occupants(), 0);
     }
 
     #[test]
     fn bulldoze_removes_building_and_clears_tiles() {
         let mut s = gs(4, 4);
-        apply_tool(&mut s, Tool::WaterTower, 0, 0);
+        apply_tool(&mut s, Tool::WaterTower, 0, 0, ViewStratum::Surface);
         assert_eq!(s.buildings.len(), 1);
-        apply_tool(&mut s, Tool::Bulldoze, 0, 0);
+        apply_tool(&mut s, Tool::Bulldoze, 0, 0, ViewStratum::Surface);
         assert!(s.buildings.is_empty());
         for dy in 0..2 {
             for dx in 0..2 {
@@ -1044,13 +1062,16 @@ mod tests {
             (Tool::ElementarySchool, 2, 2),
         ] {
             let mut s = gs(8, 8);
-            assert!(apply_tool(&mut s, tool, 4, 4).success, "{tool:?} refused");
+            assert!(
+                apply_tool(&mut s, tool, 4, 4, ViewStratum::Surface).success,
+                "{tool:?} refused"
+            );
             assert!(
                 s.tile_at(4, 4).unwrap().has_occupant(Occupant::Structure),
                 "{tool:?} not built"
             );
 
-            assert!(apply_tool(&mut s, Tool::Bulldoze, 4, 4).success);
+            assert!(apply_tool(&mut s, Tool::Bulldoze, 4, 4, ViewStratum::Surface).success);
             for dy in 0..h {
                 for dx in 0..w {
                     let (x, y) = (4 + dx, 4 + dy);
@@ -1075,9 +1096,9 @@ mod tests {
     #[test]
     fn bulldoze_removes_underground_pipe() {
         let mut s = gs(4, 4);
-        apply_tool(&mut s, Tool::WaterPipe, 0, 0);
+        apply_tool(&mut s, Tool::WaterPipe, 0, 0, ViewStratum::Surface);
         assert!(s.tile_at(0, 0).unwrap().has_occupant(Occupant::Pipe));
-        apply_tool(&mut s, Tool::Bulldoze, 0, 0);
+        apply_tool(&mut s, Tool::Bulldoze, 0, 0, ViewStratum::Surface);
         assert!(!s.tile_at(0, 0).unwrap().has_occupant(Occupant::Pipe));
     }
 
@@ -1089,8 +1110,8 @@ mod tests {
         // while doing the same two things in the other order gave a crossing.
         for tool in [Tool::Road, Tool::Rail] {
             let mut s = gs(4, 4);
-            apply_tool(&mut s, Tool::PowerLine, 1, 1);
-            apply_tool(&mut s, tool, 1, 1);
+            apply_tool(&mut s, Tool::PowerLine, 1, 1, ViewStratum::Surface);
+            apply_tool(&mut s, tool, 1, 1, ViewStratum::Surface);
 
             let t = s.tile_at(1, 1).unwrap();
             assert!(
@@ -1117,12 +1138,12 @@ mod tests {
             (Tool::Commercial, Tool::PowerLine),
         ] {
             let mut forward = gs(4, 4);
-            apply_tool(&mut forward, first, 1, 1);
-            apply_tool(&mut forward, second, 1, 1);
+            apply_tool(&mut forward, first, 1, 1, ViewStratum::Surface);
+            apply_tool(&mut forward, second, 1, 1, ViewStratum::Surface);
 
             let mut reverse = gs(4, 4);
-            apply_tool(&mut reverse, second, 1, 1);
-            apply_tool(&mut reverse, first, 1, 1);
+            apply_tool(&mut reverse, second, 1, 1, ViewStratum::Surface);
+            apply_tool(&mut reverse, first, 1, 1, ViewStratum::Surface);
 
             assert_eq!(
                 forward.tile_at(1, 1).unwrap().occupants(),
@@ -1138,12 +1159,12 @@ mod tests {
         // power overlay. Bulldozing must clear them, or the tile keeps
         // rendering a road and wires that are no longer there.
         let mut s = gs(4, 4);
-        apply_tool(&mut s, Tool::Road, 1, 1);
-        apply_tool(&mut s, Tool::PowerLine, 1, 1);
+        apply_tool(&mut s, Tool::Road, 1, 1, ViewStratum::Surface);
+        apply_tool(&mut s, Tool::PowerLine, 1, 1, ViewStratum::Surface);
         assert!(s.tile_at(1, 1).unwrap().has_occupant(Occupant::Road));
         assert!(s.tile_at(1, 1).unwrap().has_occupant(Occupant::PowerLine));
 
-        apply_tool(&mut s, Tool::Bulldoze, 1, 1);
+        apply_tool(&mut s, Tool::Bulldoze, 1, 1, ViewStratum::Surface);
         assert_eq!(
             s.tile_at(1, 1).unwrap().visible_occupants(),
             0,
@@ -1154,14 +1175,14 @@ mod tests {
     #[test]
     fn power_line_sets_power_overlay_flag() {
         let mut s = gs(4, 4);
-        apply_tool(&mut s, Tool::PowerLine, 0, 0);
+        apply_tool(&mut s, Tool::PowerLine, 0, 0, ViewStratum::Surface);
         assert!(s.tile_at(0, 0).unwrap().has_occupant(Occupant::PowerLine));
     }
 
     #[test]
     fn place_elementary_school_2x2() {
         let mut s = gs(4, 4);
-        let r = apply_tool(&mut s, Tool::ElementarySchool, 0, 0);
+        let r = apply_tool(&mut s, Tool::ElementarySchool, 0, 0, ViewStratum::Surface);
         assert!(r.success);
         assert_eq!(
             structure_kind_at(&s, 0, 0),
@@ -1175,7 +1196,7 @@ mod tests {
         // Regression: place_footprint_building must propagate water_output from
         // the building template onto the tile so the water BFS sees it as a source.
         let mut s = gs(4, 4);
-        let r = apply_tool(&mut s, Tool::WaterPump, 0, 0);
+        let r = apply_tool(&mut s, Tool::WaterPump, 0, 0, ViewStratum::Surface);
         assert!(r.success);
         assert!(
             s.tile_at(0, 0).unwrap().water_output > 0,
@@ -1189,11 +1210,11 @@ mod tests {
         // The player must Bulldoze first — matches the TS tools.ts guard.
         for tool in [Tool::Road, Tool::Rail, Tool::PowerLine] {
             let mut s = gs(4, 4);
-            apply_tool(&mut s, Tool::WaterPump, 1, 1);
+            apply_tool(&mut s, Tool::WaterPump, 1, 1, ViewStratum::Surface);
             assert!(s.tile_at(1, 1).unwrap().building_id.is_some());
 
             let before_money = s.money;
-            let r = apply_tool(&mut s, tool, 1, 1);
+            let r = apply_tool(&mut s, tool, 1, 1, ViewStratum::Surface);
             assert!(!r.success, "{tool:?} should be rejected over a building");
             assert_eq!(
                 s.money, before_money,
@@ -1209,10 +1230,10 @@ mod tests {
     #[test]
     fn zone_over_building_fails() {
         let mut s = gs(4, 4);
-        apply_tool(&mut s, Tool::WaterPump, 1, 1);
+        apply_tool(&mut s, Tool::WaterPump, 1, 1, ViewStratum::Surface);
         let before_money = s.money;
         for tool in [Tool::Residential, Tool::Commercial, Tool::Industrial] {
-            let r = apply_tool(&mut s, tool, 1, 1);
+            let r = apply_tool(&mut s, tool, 1, 1, ViewStratum::Surface);
             assert!(!r.success, "{tool:?} should be rejected over a building");
             assert_eq!(
                 s.money, before_money,
@@ -1229,9 +1250,9 @@ mod tests {
     #[test]
     fn building_over_road_fails() {
         let mut s = gs(4, 4);
-        apply_tool(&mut s, Tool::Road, 1, 1);
+        apply_tool(&mut s, Tool::Road, 1, 1, ViewStratum::Surface);
         let before_money = s.money;
-        let r = apply_tool(&mut s, Tool::WaterPump, 1, 1);
+        let r = apply_tool(&mut s, Tool::WaterPump, 1, 1, ViewStratum::Surface);
         assert!(!r.success, "building should be rejected over a road");
         assert_eq!(s.money, before_money, "must not charge on rejection");
         assert!(
@@ -1243,9 +1264,9 @@ mod tests {
     #[test]
     fn building_over_powerline_fails() {
         let mut s = gs(4, 4);
-        apply_tool(&mut s, Tool::PowerLine, 1, 1);
+        apply_tool(&mut s, Tool::PowerLine, 1, 1, ViewStratum::Surface);
         let before_money = s.money;
-        let r = apply_tool(&mut s, Tool::WaterPump, 1, 1);
+        let r = apply_tool(&mut s, Tool::WaterPump, 1, 1, ViewStratum::Surface);
         assert!(!r.success, "building should be rejected over a powerline");
         assert_eq!(s.money, before_money, "must not charge on rejection");
     }
@@ -1257,14 +1278,14 @@ mod tests {
         // `kind`-enumerating guard could not see it and let a park land on live
         // conductors — which went on drawing, conducting and billing.
         let mut s = gs(4, 4);
-        apply_tool(&mut s, Tool::Residential, 1, 1);
-        apply_tool(&mut s, Tool::PowerLine, 1, 1);
+        apply_tool(&mut s, Tool::Residential, 1, 1, ViewStratum::Surface);
+        apply_tool(&mut s, Tool::PowerLine, 1, 1, ViewStratum::Surface);
         let t = s.tile_at(1, 1).unwrap();
         assert_eq!(t.zone_occupant(), Some(Occupant::ZoneResidential));
         assert!(t.has_occupant(Occupant::PowerLine));
 
         let before_money = s.money;
-        let r = apply_tool(&mut s, Tool::Park, 1, 1);
+        let r = apply_tool(&mut s, Tool::Park, 1, 1, ViewStratum::Surface);
         assert!(!r.success, "a park was stamped over a live hydro line");
         assert_eq!(s.money, before_money, "must not charge on rejection");
         assert!(s.buildings.is_empty());
@@ -1283,13 +1304,13 @@ mod tests {
         // point of making the strata canonical; the guard reads the occupant
         // set either way.
         let mut s = gs(4, 4);
-        apply_tool(&mut s, Tool::PowerLine, 1, 1);
-        apply_tool(&mut s, Tool::TerraformRaise, 1, 1);
+        apply_tool(&mut s, Tool::PowerLine, 1, 1, ViewStratum::Surface);
+        apply_tool(&mut s, Tool::TerraformRaise, 1, 1, ViewStratum::Surface);
         let t = s.tile_at(1, 1).unwrap();
         assert_eq!(t.occupants_in(Stratum::Surface), 0, "the ground is bare");
         assert!(t.has_occupant(Occupant::PowerLine));
 
-        let r = apply_tool(&mut s, Tool::HydroPlant, 1, 1);
+        let r = apply_tool(&mut s, Tool::HydroPlant, 1, 1, ViewStratum::Surface);
         assert!(!r.success, "a plant was stamped over a terraformed line");
     }
 
@@ -1305,9 +1326,9 @@ mod tests {
             (Tool::TerraformLower, Terrain::Water),
         ] {
             let mut s = gs(4, 4);
-            apply_tool(&mut s, Tool::PowerLine, 1, 1);
-            apply_tool(&mut s, Tool::WaterPipe, 1, 1);
-            apply_tool(&mut s, tool, 1, 1);
+            apply_tool(&mut s, Tool::PowerLine, 1, 1, ViewStratum::Surface);
+            apply_tool(&mut s, Tool::WaterPipe, 1, 1, ViewStratum::Surface);
+            apply_tool(&mut s, tool, 1, 1, ViewStratum::Surface);
 
             let t = s.tile_at(1, 1).unwrap();
             assert_eq!(t.terrain(), expected, "{tool:?} did not regrade the ground");
@@ -1337,11 +1358,11 @@ mod tests {
 
         for tool in [Tool::TerraformRaise, Tool::TerraformLower, Tool::Water] {
             let mut s = gs(8, 8);
-            assert!(apply_tool(&mut s, Tool::CoalPlant, 5, 5).success);
+            assert!(apply_tool(&mut s, Tool::CoalPlant, 5, 5, ViewStratum::Surface).success);
             let before_money = s.money;
             let before_score = compute_wilderness(&s, &WildernessTunables::default()).score;
 
-            let r = apply_tool(&mut s, tool, 5, 5);
+            let r = apply_tool(&mut s, tool, 5, 5, ViewStratum::Surface);
             assert!(
                 !r.success,
                 "{tool:?} regraded the ground under a live plant"
@@ -1377,12 +1398,12 @@ mod tests {
     #[test]
     fn terraforming_refuses_a_developed_zone_lot() {
         let mut s = gs(8, 8);
-        apply_tool(&mut s, Tool::Road, 1, 1);
-        apply_tool(&mut s, Tool::Residential, 2, 1);
+        apply_tool(&mut s, Tool::Road, 1, 1, ViewStratum::Surface);
+        apply_tool(&mut s, Tool::Residential, 2, 1, ViewStratum::Surface);
         crate::zones::place_zone_building(&mut s, 2, 1);
         assert!(s.tile_at(2, 1).unwrap().building_id.is_some(), "lot grew");
 
-        let r = apply_tool(&mut s, Tool::TerraformLower, 2, 1);
+        let r = apply_tool(&mut s, Tool::TerraformLower, 2, 1, ViewStratum::Surface);
         assert!(!r.success, "a regrade drowned a developed lot");
         assert_eq!(
             r.message.as_deref(),
@@ -1410,9 +1431,11 @@ mod tests {
         for surface in [Tool::Road, Tool::Rail] {
             for line_first in [false, true] {
                 let mut s = gs(4, 4);
-                assert!(apply_tool(&mut s, surface, 1, 1).success);
+                assert!(apply_tool(&mut s, surface, 1, 1, ViewStratum::Surface).success);
                 if line_first {
-                    assert!(apply_tool(&mut s, Tool::PowerLine, 1, 1).success);
+                    assert!(
+                        apply_tool(&mut s, Tool::PowerLine, 1, 1, ViewStratum::Surface).success
+                    );
                 }
                 let before = s.tile_at(1, 1).unwrap().clone();
                 assert!(
@@ -1422,7 +1445,7 @@ mod tests {
                 );
                 let before_money = s.money;
 
-                let r = apply_tool(&mut s, Tool::TerraformRaise, 1, 1);
+                let r = apply_tool(&mut s, Tool::TerraformRaise, 1, 1, ViewStratum::Surface);
                 assert!(
                     r.success,
                     "{surface:?} (line_first={line_first}) was refused: {:?}",
@@ -1464,9 +1487,9 @@ mod tests {
     #[test]
     fn a_regrade_wipes_zoned_land_and_still_works_on_open_ground() {
         let mut s = gs(4, 4);
-        apply_tool(&mut s, Tool::Residential, 1, 1);
+        apply_tool(&mut s, Tool::Residential, 1, 1, ViewStratum::Surface);
         let before_money = s.money;
-        let r = apply_tool(&mut s, Tool::TerraformLower, 1, 1);
+        let r = apply_tool(&mut s, Tool::TerraformLower, 1, 1, ViewStratum::Surface);
         assert!(r.success, "a regrade was refused over an undeveloped zone");
         assert_eq!(s.money, before_money - tool_cost(Tool::TerraformLower));
         assert_eq!(s.tile_at(1, 1).unwrap().terrain(), Terrain::Water);
@@ -1482,7 +1505,7 @@ mod tests {
             (Tool::Water, Terrain::Water),
         ] {
             let before_money = s.money;
-            let r = apply_tool(&mut s, tool, 3, 3);
+            let r = apply_tool(&mut s, tool, 3, 3, ViewStratum::Surface);
             assert!(r.success, "{tool:?} refused open ground");
             assert_eq!(s.tile_at(3, 3).unwrap().terrain(), expected);
             assert_eq!(s.money, before_money - tool_cost(tool));
@@ -1503,14 +1526,16 @@ mod tests {
         for surface in [Tool::Road, Tool::Rail] {
             for line_first in [false, true] {
                 let mut s = gs(4, 4);
-                assert!(apply_tool(&mut s, surface, 1, 1).success);
+                assert!(apply_tool(&mut s, surface, 1, 1, ViewStratum::Surface).success);
                 if line_first {
-                    assert!(apply_tool(&mut s, Tool::PowerLine, 1, 1).success);
+                    assert!(
+                        apply_tool(&mut s, Tool::PowerLine, 1, 1, ViewStratum::Surface).success
+                    );
                 }
                 let before = s.tile_at(1, 1).unwrap().clone();
                 let before_money = s.money;
 
-                let r = apply_tool(&mut s, Tool::Tree, 1, 1);
+                let r = apply_tool(&mut s, Tool::Tree, 1, 1, ViewStratum::Surface);
                 assert!(r.success, "{surface:?} (line_first={line_first}) refused");
                 assert_eq!(s.money, before_money - tool_cost(Tool::Tree));
 
@@ -1546,17 +1571,17 @@ mod tests {
     #[test]
     fn planting_refuses_a_tile_carrying_a_live_building() {
         let mut s = gs(8, 8);
-        assert!(apply_tool(&mut s, Tool::CoalPlant, 5, 5).success);
+        assert!(apply_tool(&mut s, Tool::CoalPlant, 5, 5, ViewStratum::Surface).success);
         let before_money = s.money;
 
-        let r = apply_tool(&mut s, Tool::Tree, 5, 5);
+        let r = apply_tool(&mut s, Tool::Tree, 5, 5, ViewStratum::Surface);
         assert!(!r.success, "a canopy was planted over a live plant");
         assert_eq!(s.money, before_money, "charged on rejection");
         assert_eq!(structure_kind_at(&s, 5, 5), Some(TileKind::CoalPlant));
         assert_eq!(s.buildings.len(), 1);
 
         // Open ground still takes a tree.
-        assert!(apply_tool(&mut s, Tool::Tree, 0, 0).success);
+        assert!(apply_tool(&mut s, Tool::Tree, 0, 0, ViewStratum::Surface).success);
         assert!(s.tile_at(0, 0).unwrap().has_occupant(Occupant::Trees));
     }
 
@@ -1573,8 +1598,8 @@ mod tests {
             Tool::Tree,
         ] {
             let mut s = gs(4, 4);
-            assert!(apply_tool(&mut s, tool, 1, 1).success);
-            let r = apply_tool(&mut s, Tool::Park, 1, 1);
+            assert!(apply_tool(&mut s, tool, 1, 1, ViewStratum::Surface).success);
+            let r = apply_tool(&mut s, Tool::Park, 1, 1, ViewStratum::Surface);
             assert!(r.success, "a park was refused over {tool:?}");
             assert_eq!(structure_kind_at(&s, 1, 1), Some(TileKind::Park));
         }
@@ -1590,9 +1615,9 @@ mod tests {
             (Tool::PowerLine, Tool::Residential),
         ] {
             let mut s = gs(4, 4);
-            assert!(apply_tool(&mut s, first, 1, 1).success);
+            assert!(apply_tool(&mut s, first, 1, 1, ViewStratum::Surface).success);
             assert!(
-                apply_tool(&mut s, second, 1, 1).success,
+                apply_tool(&mut s, second, 1, 1, ViewStratum::Surface).success,
                 "{first:?} then {second:?} was refused"
             );
             let t = s.tile_at(1, 1).unwrap();
@@ -1615,8 +1640,8 @@ mod tests {
         // must not need a bulldozer. (The converse — planting a tree *under* a
         // live line — is still the open defect tracked in `occupants.rs`.)
         let mut s = gs(4, 4);
-        apply_tool(&mut s, Tool::Tree, 1, 1);
-        let r = apply_tool(&mut s, Tool::PowerLine, 1, 1);
+        apply_tool(&mut s, Tool::Tree, 1, 1, ViewStratum::Surface);
+        let r = apply_tool(&mut s, Tool::PowerLine, 1, 1, ViewStratum::Surface);
         assert!(r.success, "a line was refused over a tree");
         assert!(s.tile_at(1, 1).unwrap().has_occupant(Occupant::PowerLine));
     }
@@ -1630,13 +1655,13 @@ mod tests {
     fn a_bulldozed_park_leaves_bare_ground() {
         for tool in [Tool::Residential, Tool::Road, Tool::Rail, Tool::PowerLine] {
             let mut s = gs(4, 4);
-            apply_tool(&mut s, Tool::Park, 1, 1);
+            apply_tool(&mut s, Tool::Park, 1, 1, ViewStratum::Surface);
             let bid = s.tile_at(1, 1).unwrap().building_id.unwrap();
             remove_building(&mut s, bid as u32);
             assert_eq!(s.tile_at(1, 1).unwrap().occupants(), 0);
             assert!(s.tile_at(1, 1).unwrap().building_id.is_none());
 
-            let r = apply_tool(&mut s, tool, 1, 1);
+            let r = apply_tool(&mut s, tool, 1, 1, ViewStratum::Surface);
             assert!(r.success, "{tool:?} was refused by a demolished park");
         }
     }
@@ -1656,7 +1681,7 @@ mod tests {
         for (tool, expected_kind, expected_mw) in cases {
             let mut s = gs(6, 6);
             s.money = 200_000;
-            let r = apply_tool(&mut s, tool, 0, 0);
+            let r = apply_tool(&mut s, tool, 0, 0, ViewStratum::Surface);
             assert!(
                 r.success,
                 "{tool:?} placement should succeed: {:?}",

--- a/crates/city-sim-core/src/economy.rs
+++ b/crates/city-sim-core/src/economy.rs
@@ -356,7 +356,7 @@ mod tests {
         // are the whole point: adding a line to a road once took the bill
         // DOWN, from 0.10 to 0.08.
         use crate::commands::apply_tool;
-        use city_sim_protocol::commands::Tool;
+        use city_sim_protocol::commands::{Tool, ViewStratum};
 
         let bill = |build: &dyn Fn(&mut GameState)| {
             let mut s = gs(8, 8);
@@ -368,24 +368,24 @@ mod tests {
         };
 
         let road = bill(&|s| {
-            apply_tool(s, Tool::Road, 1, 1);
+            apply_tool(s, Tool::Road, 1, 1, ViewStratum::Surface);
         });
         let road_line = bill(&|s| {
-            apply_tool(s, Tool::Road, 1, 1);
-            apply_tool(s, Tool::PowerLine, 1, 1);
+            apply_tool(s, Tool::Road, 1, 1, ViewStratum::Surface);
+            apply_tool(s, Tool::PowerLine, 1, 1, ViewStratum::Surface);
         });
         let crossing = bill(&|s| {
-            apply_tool(s, Tool::Road, 1, 1);
-            apply_tool(s, Tool::Rail, 1, 1);
+            apply_tool(s, Tool::Road, 1, 1, ViewStratum::Surface);
+            apply_tool(s, Tool::Rail, 1, 1, ViewStratum::Surface);
         });
         let all_three = bill(&|s| {
-            apply_tool(s, Tool::Road, 1, 1);
-            apply_tool(s, Tool::Rail, 1, 1);
-            apply_tool(s, Tool::PowerLine, 1, 1);
+            apply_tool(s, Tool::Road, 1, 1, ViewStratum::Surface);
+            apply_tool(s, Tool::Rail, 1, 1, ViewStratum::Surface);
+            apply_tool(s, Tool::PowerLine, 1, 1, ViewStratum::Surface);
         });
         let zone_line = bill(&|s| {
-            apply_tool(s, Tool::Commercial, 1, 1);
-            apply_tool(s, Tool::PowerLine, 1, 1);
+            apply_tool(s, Tool::Commercial, 1, 1, ViewStratum::Surface);
+            apply_tool(s, Tool::PowerLine, 1, 1, ViewStratum::Surface);
         });
 
         let near = |got: f32, want: f32, what: &str| {
@@ -417,14 +417,14 @@ mod tests {
     #[test]
     fn a_water_pipe_under_a_road_is_billed_once() {
         use crate::commands::apply_tool;
-        use city_sim_protocol::commands::Tool;
+        use city_sim_protocol::commands::{Tool, ViewStratum};
 
         let mut s = gs(8, 8);
         for t in &mut s.tiles {
             *t = crate::state::Tile::land();
         }
-        apply_tool(&mut s, Tool::Road, 1, 1);
-        apply_tool(&mut s, Tool::WaterPipe, 1, 1);
+        apply_tool(&mut s, Tool::Road, 1, 1, ViewStratum::Surface);
+        apply_tool(&mut s, Tool::WaterPipe, 1, 1, ViewStratum::Surface);
         let b = compute_daily_budget(&s);
         assert!(
             (b.maint_pipes - MAINT_WATER_PIPE).abs() < 1e-4,

--- a/crates/city-sim-core/src/history.rs
+++ b/crates/city-sim-core/src/history.rs
@@ -163,7 +163,7 @@ impl History {
 mod tests {
     use super::*;
     use crate::sim::{state_hash, Simulation};
-    use city_sim_protocol::commands::Tool;
+    use city_sim_protocol::commands::{Tool, ViewStratum};
 
     fn make_sim() -> Simulation {
         let mut sim = Simulation::new(8, 8, 42);
@@ -181,7 +181,7 @@ mod tests {
         y: u32,
     ) -> bool {
         let pending = history.prepare(&sim.state, stroke);
-        let result = crate::commands::apply_tool(&mut sim.state, tool, x, y);
+        let result = crate::commands::apply_tool(&mut sim.state, tool, x, y, ViewStratum::Surface);
         if result.success {
             if let Some(bytes) = pending {
                 history.commit(bytes, stroke);

--- a/crates/city-sim-core/src/import.rs
+++ b/crates/city-sim-core/src/import.rs
@@ -182,7 +182,7 @@ mod tests {
     use crate::occupants::{zone_template_kind, Occupant, StructureLookup};
     use crate::sim::Simulation;
     use crate::state::{Tile, DERIVED_FLAG_MASK};
-    use city_sim_protocol::commands::Tool;
+    use city_sim_protocol::commands::{Tool, ViewStratum};
     use city_sim_protocol::legacy_tile_buffer::legacy_flags;
     use city_sim_protocol::tile_buffer::encode_happiness;
 
@@ -278,12 +278,18 @@ mod tests {
 
     fn build_city() -> Simulation {
         let mut sim = Simulation::new(8, 8, 7);
-        apply_tool(&mut sim.state, Tool::Road, 3, 0);
-        apply_tool(&mut sim.state, Tool::Road, 3, 1);
-        apply_tool(&mut sim.state, Tool::Residential, 2, 0);
-        apply_tool(&mut sim.state, Tool::HydroPlant, 5, 5);
-        apply_tool(&mut sim.state, Tool::WaterPump, 0, 5);
-        apply_tool(&mut sim.state, Tool::WaterPipe, 2, 5);
+        apply_tool(&mut sim.state, Tool::Road, 3, 0, ViewStratum::Surface);
+        apply_tool(&mut sim.state, Tool::Road, 3, 1, ViewStratum::Surface);
+        apply_tool(
+            &mut sim.state,
+            Tool::Residential,
+            2,
+            0,
+            ViewStratum::Surface,
+        );
+        apply_tool(&mut sim.state, Tool::HydroPlant, 5, 5, ViewStratum::Surface);
+        apply_tool(&mut sim.state, Tool::WaterPump, 0, 5, ViewStratum::Surface);
+        apply_tool(&mut sim.state, Tool::WaterPipe, 2, 5, ViewStratum::Surface);
         for _ in 0..60 {
             sim.step(1.0 / 20.0);
         }

--- a/crates/city-sim-core/src/occupants.rs
+++ b/crates/city-sim-core/src/occupants.rs
@@ -1527,7 +1527,7 @@ mod tests {
     use crate::commands::apply_tool;
     use crate::migrate::{set_v4_kind, tile_from_v4};
     use crate::state::{FLAG_ABANDONED, FLAG_POWERED, FLAG_WATERED};
-    use city_sim_protocol::commands::Tool;
+    use city_sim_protocol::commands::{Tool, ViewStratum};
     use city_sim_protocol::legacy_tile_buffer::legacy_flags::{
         POWER_OVERLAY as FLAG_POWER_OVERLAY, RAIL_UNDERLAY as FLAG_RAIL_UNDERLAY,
         ROAD_UNDERLAY as FLAG_ROAD_UNDERLAY,
@@ -2196,8 +2196,8 @@ mod tests {
     #[test]
     fn a_structure_is_refused_over_a_live_hydro_line() {
         let mut s = GameState::new(4, 4, 0);
-        assert!(apply_tool(&mut s, Tool::Residential, 2, 2).success);
-        assert!(apply_tool(&mut s, Tool::PowerLine, 2, 2).success);
+        assert!(apply_tool(&mut s, Tool::Residential, 2, 2, ViewStratum::Surface).success);
+        assert!(apply_tool(&mut s, Tool::PowerLine, 2, 2, ViewStratum::Surface).success);
 
         // After two clicks the tile is a zone carrying a line, recorded the one
         // canonical way: the zone keeps `kind`, the line takes the flag.
@@ -2210,7 +2210,7 @@ mod tests {
         // The third click is refused — the line is in the flag, not in `kind`,
         // and the guard reads the occupant set.
         let money = s.money;
-        let r = apply_tool(&mut s, Tool::Park, 2, 2);
+        let r = apply_tool(&mut s, Tool::Park, 2, 2, ViewStratum::Surface);
         assert!(!r.success, "a park landed on top of live conductors");
         assert_eq!(s.money, money, "a refused placement must not charge");
         assert!(s.buildings.is_empty(), "a refused placement built nothing");
@@ -2223,8 +2223,8 @@ mod tests {
 
         // Bulldozing the line clears the way, so the refusal is a "clear it
         // first", not a tile the player can never build on.
-        assert!(apply_tool(&mut s, Tool::Bulldoze, 2, 2).success);
-        assert!(apply_tool(&mut s, Tool::Park, 2, 2).success);
+        assert!(apply_tool(&mut s, Tool::Bulldoze, 2, 2, ViewStratum::Surface).success);
+        assert!(apply_tool(&mut s, Tool::Park, 2, 2, ViewStratum::Surface).success);
         assert_eq!(
             s.tiles[s.tile_index(2, 2).unwrap()].occupants(),
             B_STRUCTURE
@@ -2236,8 +2236,8 @@ mod tests {
         // standing — correctly, a regrade does not take down a span — after
         // which the old guard saw a bare land tile.
         let mut s = GameState::new(4, 4, 0);
-        assert!(apply_tool(&mut s, Tool::PowerLine, 1, 1).success);
-        assert!(apply_tool(&mut s, Tool::TerraformRaise, 1, 1).success);
+        assert!(apply_tool(&mut s, Tool::PowerLine, 1, 1, ViewStratum::Surface).success);
+        assert!(apply_tool(&mut s, Tool::TerraformRaise, 1, 1, ViewStratum::Surface).success);
         let t = s.tiles[s.tile_index(1, 1).unwrap()].clone();
         assert_eq!(t.terrain(), Terrain::Land);
         assert!(t.has_occupant(Occupant::PowerLine));
@@ -2249,7 +2249,7 @@ mod tests {
         assert!(t.conducts(Network::Power));
         assert!((t.tile_upkeep_unfunded() - MAINT_POWER_LINE).abs() < 1e-6);
         assert!(
-            !apply_tool(&mut s, Tool::HydroPlant, 1, 1).success,
+            !apply_tool(&mut s, Tool::HydroPlant, 1, 1, ViewStratum::Surface).success,
             "a terraformed line is still a line"
         );
 
@@ -2257,10 +2257,10 @@ mod tests {
         // not just its origin: the line here is at (2, 2), the 2×2 plant at
         // (1, 1).
         let mut s = GameState::new(4, 4, 0);
-        assert!(apply_tool(&mut s, Tool::Residential, 2, 2).success);
-        assert!(apply_tool(&mut s, Tool::PowerLine, 2, 2).success);
+        assert!(apply_tool(&mut s, Tool::Residential, 2, 2, ViewStratum::Surface).success);
+        assert!(apply_tool(&mut s, Tool::PowerLine, 2, 2, ViewStratum::Surface).success);
         assert!(
-            !apply_tool(&mut s, Tool::HydroPlant, 1, 1).success,
+            !apply_tool(&mut s, Tool::HydroPlant, 1, 1, ViewStratum::Surface).success,
             "the footprint's far corner sits on a line"
         );
     }
@@ -2286,7 +2286,7 @@ mod tests {
     fn removing_a_building_takes_its_structure_tag_with_it() {
         for tool in [Tool::Residential, Tool::Road, Tool::Rail, Tool::PowerLine] {
             let mut s = GameState::new(4, 4, 0);
-            assert!(apply_tool(&mut s, Tool::Park, 1, 1).success);
+            assert!(apply_tool(&mut s, Tool::Park, 1, 1, ViewStratum::Surface).success);
             let bid = s.tiles[s.tile_index(1, 1).unwrap()].building_id.unwrap();
             crate::commands::remove_building(&mut s, bid as u32);
             let t = s.tiles[s.tile_index(1, 1).unwrap()].clone();
@@ -2296,7 +2296,7 @@ mod tests {
             );
             assert_eq!(t.occupants(), 0, "{tool:?}: bare ground is what is left");
             assert!(
-                apply_tool(&mut s, tool, 1, 1).success,
+                apply_tool(&mut s, tool, 1, 1, ViewStratum::Surface).success,
                 "{tool:?} was refused by a demolished park"
             );
         }
@@ -2307,7 +2307,7 @@ mod tests {
     #[test]
     fn removing_a_zone_lot_leaves_the_zone_standing() {
         let mut s = GameState::new(4, 4, 0);
-        assert!(apply_tool(&mut s, Tool::Residential, 1, 1).success);
+        assert!(apply_tool(&mut s, Tool::Residential, 1, 1, ViewStratum::Surface).success);
         let idx = s.tile_index(1, 1).unwrap();
         s.tiles[idx].building_id = Some(9);
         s.buildings.push(crate::buildings::BuildingInstance::new(
@@ -2355,8 +2355,8 @@ mod tests {
     #[test]
     fn known_defect_trees_are_planted_through_a_live_hydro_line() {
         let mut s = GameState::new(4, 4, 0);
-        assert!(apply_tool(&mut s, Tool::PowerLine, 1, 1).success);
-        let r = apply_tool(&mut s, Tool::Tree, 1, 1);
+        assert!(apply_tool(&mut s, Tool::PowerLine, 1, 1, ViewStratum::Surface).success);
+        let r = apply_tool(&mut s, Tool::Tree, 1, 1, ViewStratum::Surface);
         assert!(
             r.success,
             "step 2 has tightened Tool::Tree — good. Delete this known defect \
@@ -2438,7 +2438,7 @@ mod tests {
         while let Some((s, path)) = frontier.pop_front() {
             for &tool in &tools {
                 let mut next = s.clone();
-                apply_tool(&mut next, tool, 1, 1);
+                apply_tool(&mut next, tool, 1, 1, ViewStratum::Surface);
                 // Funds must never be what makes a state unreachable.
                 next.money = 100_000;
                 if !seen.insert(signature(&next)) {
@@ -2728,7 +2728,7 @@ mod tests {
         fn build(order: &[Tool]) -> OccupantSet {
             let mut s = GameState::new(4, 4, 0);
             for &t in order {
-                apply_tool(&mut s, t, 1, 1);
+                apply_tool(&mut s, t, 1, 1, ViewStratum::Surface);
             }
             s.tiles[s.tile_index(1, 1).unwrap()].occupants()
         }

--- a/crates/city-sim-core/src/sim.rs
+++ b/crates/city-sim-core/src/sim.rs
@@ -441,19 +441,43 @@ mod tests {
 
     fn make_city_sim(seed: u32) -> Simulation {
         use crate::commands::apply_tool;
-        use city_sim_protocol::commands::Tool;
+        use city_sim_protocol::commands::{Tool, ViewStratum};
         let mut sim = Simulation::new(8, 8, seed);
         // Place roads + zones so zone growth fires and RNG is exercised
-        apply_tool(&mut sim.state, Tool::Road, 3, 0);
-        apply_tool(&mut sim.state, Tool::Road, 3, 1);
-        apply_tool(&mut sim.state, Tool::Road, 3, 2);
-        apply_tool(&mut sim.state, Tool::Road, 3, 3);
-        apply_tool(&mut sim.state, Tool::Residential, 0, 0);
-        apply_tool(&mut sim.state, Tool::Residential, 1, 0);
-        apply_tool(&mut sim.state, Tool::Residential, 0, 1);
-        apply_tool(&mut sim.state, Tool::Residential, 1, 1);
-        apply_tool(&mut sim.state, Tool::Commercial, 0, 2);
-        apply_tool(&mut sim.state, Tool::Industrial, 0, 3);
+        apply_tool(&mut sim.state, Tool::Road, 3, 0, ViewStratum::Surface);
+        apply_tool(&mut sim.state, Tool::Road, 3, 1, ViewStratum::Surface);
+        apply_tool(&mut sim.state, Tool::Road, 3, 2, ViewStratum::Surface);
+        apply_tool(&mut sim.state, Tool::Road, 3, 3, ViewStratum::Surface);
+        apply_tool(
+            &mut sim.state,
+            Tool::Residential,
+            0,
+            0,
+            ViewStratum::Surface,
+        );
+        apply_tool(
+            &mut sim.state,
+            Tool::Residential,
+            1,
+            0,
+            ViewStratum::Surface,
+        );
+        apply_tool(
+            &mut sim.state,
+            Tool::Residential,
+            0,
+            1,
+            ViewStratum::Surface,
+        );
+        apply_tool(
+            &mut sim.state,
+            Tool::Residential,
+            1,
+            1,
+            ViewStratum::Surface,
+        );
+        apply_tool(&mut sim.state, Tool::Commercial, 0, 2, ViewStratum::Surface);
+        apply_tool(&mut sim.state, Tool::Industrial, 0, 3, ViewStratum::Surface);
         sim.state.demand.residential = 80.0;
         sim.state.demand.commercial = 60.0;
         sim.state.demand.industrial = 60.0;
@@ -625,17 +649,29 @@ mod tests {
     fn water_requirement_is_opt_in_until_infrastructure_exists() {
         use crate::buildings::BuildingStatus;
         use crate::commands::apply_tool;
-        use city_sim_protocol::commands::Tool;
+        use city_sim_protocol::commands::{Tool, ViewStratum};
         use city_sim_protocol::tile_kind::TileKind;
 
         let mut sim = Simulation::new(16, 16, 42);
         for x in 0..12 {
-            apply_tool(&mut sim.state, Tool::Road, x, 5);
+            apply_tool(&mut sim.state, Tool::Road, x, 5, ViewStratum::Surface);
         }
-        apply_tool(&mut sim.state, Tool::CoalPlant, 0, 3);
+        apply_tool(&mut sim.state, Tool::CoalPlant, 0, 3, ViewStratum::Surface);
         for x in 2..10 {
-            apply_tool(&mut sim.state, Tool::Residential, x, 4);
-            apply_tool(&mut sim.state, Tool::Residential, x, 6);
+            apply_tool(
+                &mut sim.state,
+                Tool::Residential,
+                x,
+                4,
+                ViewStratum::Surface,
+            );
+            apply_tool(
+                &mut sim.state,
+                Tool::Residential,
+                x,
+                6,
+                ViewStratum::Surface,
+            );
         }
         sim.state.demand.residential = 90.0;
         for _ in 0..300 {
@@ -662,7 +698,13 @@ mod tests {
         );
 
         // Opting in: a pump far from the zones activates the requirement.
-        apply_tool(&mut sim.state, Tool::WaterPump, 13, 13);
+        apply_tool(
+            &mut sim.state,
+            Tool::WaterPump,
+            13,
+            13,
+            ViewStratum::Surface,
+        );
         for _ in 0..5 {
             sim.step(1.0 / 20.0);
         }
@@ -930,18 +972,24 @@ mod tests {
     fn step_wires_handle_resource_alerts_into_the_real_tick_path() {
         use crate::commands::apply_tool;
         use crate::zones::place_zone_building;
-        use city_sim_protocol::commands::Tool;
+        use city_sim_protocol::commands::{Tool, ViewStratum};
 
         let mut sim = Simulation::new(16, 16, 42);
         for x in 0..12 {
-            apply_tool(&mut sim.state, Tool::Road, x, 5);
+            apply_tool(&mut sim.state, Tool::Road, x, 5, ViewStratum::Surface);
         }
-        apply_tool(&mut sim.state, Tool::SolarFarm, 0, 3);
+        apply_tool(&mut sim.state, Tool::SolarFarm, 0, 3, ViewStratum::Surface);
         // 5 zoned-and-built residential lots at 1.5 MW each = 7.5 MW,
         // comfortably past the SolarFarm's 5 MW — not the razor-thin 4.5 MW
         // (rounds to 5, exactly tying production) that 3 lots would give.
         for x in 2..7 {
-            apply_tool(&mut sim.state, Tool::Residential, x, 4);
+            apply_tool(
+                &mut sim.state,
+                Tool::Residential,
+                x,
+                4,
+                ViewStratum::Surface,
+            );
             assert!(
                 place_zone_building(&mut sim.state, x, 4),
                 "zone tag must place a building on a tile this test just zoned"

--- a/crates/city-sim-core/src/utilities.rs
+++ b/crates/city-sim-core/src/utilities.rs
@@ -248,7 +248,7 @@ mod tests {
     use crate::migrate::{set_v4_kind, tile_from_v4};
     use crate::occupants::Occupant;
     use crate::state::Tile;
-    use city_sim_protocol::commands::Tool;
+    use city_sim_protocol::commands::{Tool, ViewStratum};
     use city_sim_protocol::legacy_tile_buffer::legacy_flags as flags;
     use city_sim_protocol::tile_kind::TileKind;
 
@@ -454,9 +454,9 @@ mod tests {
             g.tile_at_mut(0, 0).unwrap().power_plant_mw = 60;
             set_v4_kind(g.tile_at_mut(0, 0).unwrap(), TileKind::Road);
             for x in 1..=3 {
-                apply_tool(&mut g, Tool::PowerLine, x, 0);
+                apply_tool(&mut g, Tool::PowerLine, x, 0, ViewStratum::Surface);
             }
-            apply_tool(&mut g, tool, 2, 0);
+            apply_tool(&mut g, tool, 2, 0, ViewStratum::Surface);
 
             let mid = g.tile_at(2, 0).unwrap();
             assert!(

--- a/crates/city-sim-core/src/wilderness.rs
+++ b/crates/city-sim-core/src/wilderness.rs
@@ -529,7 +529,7 @@ mod tests {
     use crate::commands::{apply_tool, tool_cost};
     use crate::migrate::set_v4_kind;
     use crate::occupants::{Occupant, ALL_OCCUPANTS};
-    use city_sim_protocol::commands::Tool;
+    use city_sim_protocol::commands::{Tool, ViewStratum};
 
     fn grid(w: u32, h: u32) -> GameState {
         GameState::new(w, h, 0)
@@ -568,7 +568,7 @@ mod tests {
     fn build_row(state: &mut GameState, tools: &[Tool], y: u32, len: u32) {
         for tool in tools {
             for x in 0..len {
-                let r = apply_tool(state, *tool, x, y);
+                let r = apply_tool(state, *tool, x, y, ViewStratum::Surface);
                 assert!(r.success, "{tool:?} at ({x}, {y}) failed: {:?}", r.message);
             }
         }
@@ -594,14 +594,14 @@ mod tests {
         let (blank_eco, blank_score) = (eco_at(&untouched, 4, 4), score(&untouched));
 
         let mut s = grid(8, 8);
-        assert!(apply_tool(&mut s, Tool::Park, 4, 4).success);
+        assert!(apply_tool(&mut s, Tool::Park, 4, 4, ViewStratum::Surface).success);
         let built_eco = eco_at(&s, 4, 4);
         assert!(
             built_eco > blank_eco,
             "a park must be worth more than the ground it sits on ({built_eco} vs {blank_eco})"
         );
 
-        assert!(apply_tool(&mut s, Tool::Bulldoze, 4, 4).success);
+        assert!(apply_tool(&mut s, Tool::Bulldoze, 4, 4, ViewStratum::Surface).success);
         assert_eq!(
             eco_at(&s, 4, 4),
             blank_eco,
@@ -671,7 +671,7 @@ mod tests {
         build_row(&mut s, &[Tool::Tree], 11, 16);
         for y in 12..16 {
             for x in 0..4 {
-                assert!(apply_tool(&mut s, Tool::Water, x, y).success);
+                assert!(apply_tool(&mut s, Tool::Water, x, y, ViewStratum::Surface).success);
             }
         }
 
@@ -686,7 +686,7 @@ mod tests {
 
         for y in 12..16 {
             for x in 0..4 {
-                assert!(apply_tool(&mut s, Tool::Bulldoze, x, y).success);
+                assert!(apply_tool(&mut s, Tool::Bulldoze, x, y, ViewStratum::Surface).success);
             }
         }
 
@@ -740,7 +740,7 @@ mod tests {
         }
         for y in 8..16 {
             for x in 0..4 {
-                assert!(apply_tool(&mut s, Tool::Water, x, y).success);
+                assert!(apply_tool(&mut s, Tool::Water, x, y, ViewStratum::Surface).success);
             }
         }
         let buildable = |s: &GameState| {
@@ -755,8 +755,8 @@ mod tests {
         let money_before = s.money;
         for y in 8..16 {
             for x in 0..4 {
-                assert!(apply_tool(&mut s, Tool::Road, x, y).success);
-                assert!(apply_tool(&mut s, Tool::Bulldoze, x, y).success);
+                assert!(apply_tool(&mut s, Tool::Road, x, y, ViewStratum::Surface).success);
+                assert!(apply_tool(&mut s, Tool::Bulldoze, x, y, ViewStratum::Surface).success);
             }
         }
 

--- a/crates/city-sim-core/tests/golden_city.rs
+++ b/crates/city-sim-core/tests/golden_city.rs
@@ -68,7 +68,7 @@ use city_sim_core::commands::apply_tool;
 use city_sim_core::occupants::{iter_set, Network, Occupant, StructureLookup, Terrain};
 use city_sim_core::sim::{state_hash, Simulation};
 use city_sim_core::state::{GameState, Tile, FLAG_ABANDONED, FLAG_POWERED, FLAG_WATERED};
-use city_sim_protocol::commands::Tool;
+use city_sim_protocol::commands::{Tool, ViewStratum};
 
 const SCRIPT: &str = include_str!("fixtures/golden_city.script");
 const EXPECTED: &str = include_str!("fixtures/golden_city.expected");
@@ -236,7 +236,7 @@ fn replay(script: &Script) -> Replay {
     for &(line_no, step) in &script.steps {
         match step {
             Step::Apply { tool, x, y } => {
-                let r = apply_tool(&mut sim.state, tool, x, y);
+                let r = apply_tool(&mut sim.state, tool, x, y, ViewStratum::Surface);
                 assert!(
                     r.success,
                     "golden_city.script:{line_no}: `{tool:?} {x} {y}` was refused — {}\n\
@@ -246,7 +246,7 @@ fn replay(script: &Script) -> Replay {
                 );
             }
             Step::Refuse { tool, x, y } => {
-                let r = apply_tool(&mut sim.state, tool, x, y);
+                let r = apply_tool(&mut sim.state, tool, x, y, ViewStratum::Surface);
                 assert!(
                     !r.success,
                     "golden_city.script:{line_no}: `refuse {tool:?} {x} {y}` was ACCEPTED.\n\
@@ -632,7 +632,7 @@ fn footprint_tools() -> Vec<(Tool, (u32, u32))> {
     for tool in (0u8..=u8::MAX).filter_map(|v| Tool::try_from(v).ok()) {
         let mut s = GameState::new(8, 8, 1);
         s.money = 10_000_000;
-        if !apply_tool(&mut s, tool, 2, 2).success {
+        if !apply_tool(&mut s, tool, 2, 2, ViewStratum::Surface).success {
             continue;
         }
         // A zone tool writes a tag and no building; only a footprint stamp does.

--- a/crates/city-sim-core/tests/soak.rs
+++ b/crates/city-sim-core/tests/soak.rs
@@ -238,7 +238,7 @@ use city_sim_core::sim::{state_hash, Simulation};
 use city_sim_core::state::{BudgetStats, DemandStats, EducationStats, GameState};
 use city_sim_core::wilderness::{WildernessBreakdown, WildernessStats};
 use city_sim_core::wire::encode_tile_buffer;
-use city_sim_protocol::commands::Tool;
+use city_sim_protocol::commands::{Tool, ViewStratum};
 
 // ---------------------------------------------------------------------------
 // The counting allocator
@@ -503,7 +503,7 @@ fn build_soak_city() -> Simulation {
     // --- The hinterland ---------------------------------------------------
     for y in 1..5 {
         for x in (OUTPOST_END + 1)..(WIDTH - 1) {
-            apply_tool(s, Tool::Water, x, y);
+            apply_tool(s, Tool::Water, x, y, ViewStratum::Surface);
         }
     }
     for y in 7..(HEIGHT - 1) {
@@ -511,7 +511,7 @@ fn build_soak_city() -> Simulation {
             // Not a solid block — the holes give the fragmentation penalty and
             // the patch bonus something to disagree about.
             if (x + y) % 7 != 0 {
-                apply_tool(s, Tool::Tree, x, y);
+                apply_tool(s, Tool::Tree, x, y, ViewStratum::Surface);
             }
         }
     }
@@ -523,12 +523,12 @@ fn build_soak_city() -> Simulation {
     let grid = |s: &mut GameState, x0: u32, x1: u32| {
         for y in (0..HEIGHT).step_by(4) {
             for x in x0..x1 {
-                apply_tool(s, Tool::Road, x, y);
+                apply_tool(s, Tool::Road, x, y, ViewStratum::Surface);
             }
         }
         for x in (x0..x1).step_by(4) {
             for y in 0..HEIGHT {
-                apply_tool(s, Tool::Road, x, y);
+                apply_tool(s, Tool::Road, x, y, ViewStratum::Surface);
             }
         }
     };
@@ -538,11 +538,11 @@ fn build_soak_city() -> Simulation {
     // --- Services, town only ----------------------------------------------
     // The plant sits on the town grid, so the whole town grid is live; the
     // outpost grid is unreachable across the firebreak.
-    apply_tool(s, Tool::CoalPlant, 1, 1);
-    apply_tool(s, Tool::WaterPump, 2, 2);
-    apply_tool(s, Tool::ElementarySchool, 1, 5);
-    apply_tool(s, Tool::HighSchool, 1, 9);
-    apply_tool(s, Tool::Park, 3, 13);
+    apply_tool(s, Tool::CoalPlant, 1, 1, ViewStratum::Surface);
+    apply_tool(s, Tool::WaterPump, 2, 2, ViewStratum::Surface);
+    apply_tool(s, Tool::ElementarySchool, 1, 5, ViewStratum::Surface);
+    apply_tool(s, Tool::HighSchool, 1, 9, ViewStratum::Surface);
+    apply_tool(s, Tool::Park, 3, 13, ViewStratum::Surface);
 
     // --- Zoning -----------------------------------------------------------
     // The town cycles six parts jobs to one part housing; the outpost is all
@@ -570,7 +570,7 @@ fn build_soak_city() -> Simulation {
                 if s.tiles[idx].occupants() != 0 || s.tiles[idx].building_id.is_some() {
                     continue;
                 }
-                apply_tool(s, zones[*n % zones.len()], x, y);
+                apply_tool(s, zones[*n % zones.len()], x, y, ViewStratum::Surface);
                 *n += 1;
             }
         }

--- a/crates/city-sim-protocol/src/commands.rs
+++ b/crates/city-sim-protocol/src/commands.rs
@@ -138,12 +138,49 @@ impl Policies {
     }
 }
 
+/// Which layer of the tile a layer-scoped tool (currently just
+/// `Tool::Bulldoze`) acts on — filled from the player's active view.
+///
+/// Deliberately distinct from `Stratum` in `city-sim-core`'s `occupants.rs`
+/// (`Underground | Surface | Overhead`, tile-internal): the surface *view*
+/// maps to two tile strata — `Surface` and `Overhead` — at once. `Surface` is
+/// the default so command logs recorded before this field existed, and any
+/// command that doesn't care about layers, decode unchanged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[repr(u8)]
+pub enum ViewStratum {
+    #[default]
+    Surface = 0,
+    Underground = 1,
+}
+
+impl From<u8> for ViewStratum {
+    /// Decodes the `stratum_idx` byte the WASM and Tauri bridges pass across
+    /// their FFI/IPC boundary (mirroring `Tool`'s discriminant convention).
+    /// Infallible rather than `TryFrom` — any value but `1` is `Surface`,
+    /// same as a missing/legacy field decoding through `#[serde(default)]`.
+    fn from(v: u8) -> Self {
+        if v == ViewStratum::Underground as u8 {
+            ViewStratum::Underground
+        } else {
+            ViewStratum::Surface
+        }
+    }
+}
+
 /// A command sent from the UI/bridge into the simulation.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[non_exhaustive]
 pub enum SimCommand {
-    /// Apply a tool at tile coordinates (x, y).
-    ApplyTool { tool: Tool, x: u16, y: u16 },
+    /// Apply a tool at tile coordinates (x, y), scoped to `stratum` for
+    /// tools that honour it (currently just `Tool::Bulldoze`).
+    ApplyTool {
+        tool: Tool,
+        x: u16,
+        y: u16,
+        #[serde(default)]
+        stratum: ViewStratum,
+    },
     /// Adjust simulation speed (multiplier relative to base tick rate).
     SetSpeed { multiplier: f32 },
     /// Replace the full set of player policies (budget, wilderness, ...).
@@ -232,6 +269,7 @@ mod tests {
             tool: Tool::Road,
             x: 5,
             y: 10,
+            stratum: ViewStratum::Underground,
         };
         let bytes = to_allocvec(&cmd).unwrap();
         let back: SimCommand = from_bytes(&bytes).unwrap();
@@ -240,9 +278,18 @@ mod tests {
             SimCommand::ApplyTool {
                 tool: Tool::Road,
                 x: 5,
-                y: 10
+                y: 10,
+                stratum: ViewStratum::Underground,
             }
         ));
+    }
+
+    #[test]
+    fn view_stratum_defaults_to_surface() {
+        // `#[serde(default)]` on `ApplyTool::stratum` falls back to
+        // `ViewStratum::default()` when decoding a command log recorded before
+        // this field existed, so the default must stay `Surface`.
+        assert_eq!(ViewStratum::default(), ViewStratum::Surface);
     }
 
     #[test]

--- a/crates/city-sim-protocol/src/commands.rs
+++ b/crates/city-sim-protocol/src/commands.rs
@@ -293,6 +293,17 @@ mod tests {
     }
 
     #[test]
+    fn view_stratum_from_u8() {
+        // Only `wasm/src/lib.rs` calls this decoder (the FFI boundary for
+        // `stratum_idx`), so it needs its own direct test to be covered by
+        // `cargo test --workspace`.
+        assert_eq!(ViewStratum::from(0u8), ViewStratum::Surface);
+        assert_eq!(ViewStratum::from(1u8), ViewStratum::Underground);
+        assert_eq!(ViewStratum::from(2u8), ViewStratum::Surface);
+        assert_eq!(ViewStratum::from(255u8), ViewStratum::Surface);
+    }
+
+    #[test]
     fn policies_round_trip_postcard() {
         let policies = Policies {
             budget: BudgetPolicy {

--- a/crates/city-sim-wasm/src/lib.rs
+++ b/crates/city-sim-wasm/src/lib.rs
@@ -12,7 +12,7 @@ use city_sim_core::{
     wire::encode_tile_buffer,
 };
 use city_sim_protocol::{
-    commands::{Policies, Tool},
+    commands::{Policies, Tool, ViewStratum},
     tile_buffer::BYTES_PER_TILE,
 };
 use wasm_bindgen::prelude::*;
@@ -282,16 +282,27 @@ impl SimHost {
     /// `tool_idx` is the `Tool` discriminant (0 = Inspect … 21 = Bulldoze),
     /// matching `#[repr(u8)]` in `city-sim-protocol`. `stroke_id` groups the
     /// many calls of one drag-paint gesture into a single undo step — the
-    /// history captures one pre-stroke snapshot per id. Returns `true` on
+    /// history captures one pre-stroke snapshot per id. `stratum_idx` is the
+    /// `ViewStratum` discriminant (0 = Surface, 1 = Underground) — which
+    /// layer the player was looking at when the command was issued, so tools
+    /// like bulldoze can act on only what's visible. Returns `true` on
     /// success; `false` if the tool could not be applied (out-of-bounds,
     /// insufficient funds, invalid placement).
-    pub fn apply_tool(&mut self, tool_idx: u8, x: u32, y: u32, stroke_id: u32) -> bool {
+    pub fn apply_tool(
+        &mut self,
+        tool_idx: u8,
+        x: u32,
+        y: u32,
+        stroke_id: u32,
+        stratum_idx: u8,
+    ) -> bool {
         let Ok(tool) = Tool::try_from(tool_idx) else {
             self.last_apply_message = None;
             return false;
         };
+        let stratum = ViewStratum::from(stratum_idx);
         let pending = self.history.prepare(&self.sim.state, stroke_id as u64);
-        let result = apply_tool(&mut self.sim.state, tool, x, y);
+        let result = apply_tool(&mut self.sim.state, tool, x, y, stratum);
         if result.success {
             if let Some(bytes) = pending {
                 self.history.commit(bytes, stroke_id as u64);

--- a/crates/tauri-plugin-city-sim/guest-js/index.ts
+++ b/crates/tauri-plugin-city-sim/guest-js/index.ts
@@ -118,6 +118,19 @@ export const TOOL_ID = {
 
 export type ToolId = typeof TOOL_ID[keyof typeof TOOL_ID]
 
+/**
+ * ViewStratum u8 discriminant map — mirrors `city_sim_protocol::commands::ViewStratum as u8`.
+ *
+ * Pass one of these as the `stratum` argument to `applyTool`. TauriSimBridge maps
+ * the game's string `ViewStratum` type ('surface' | 'underground') to these IDs.
+ */
+export const VIEW_STRATUM_ID = {
+  Surface:     0,
+  Underground: 1,
+} as const
+
+export type ViewStratumId = typeof VIEW_STRATUM_ID[keyof typeof VIEW_STRATUM_ID]
+
 // ── Plugin commands ───────────────────────────────────────────────────────────
 
 /**
@@ -161,9 +174,18 @@ export interface CommandResult {
  * @param y        Tile row (0-indexed from top).
  * @param strokeId Groups the calls of one drag-paint gesture into a single
  *                 undo step; bump it on every new gesture.
+ * @param stratum  A `VIEW_STRATUM_ID` value — which layer the player was
+ *                 looking at when they clicked, so stratum-aware tools (the
+ *                 bulldozer) know what the player actually meant to clear.
  */
-export async function applyTool(tool: ToolId, x: number, y: number, strokeId: number): Promise<CommandResult> {
-  return await invoke('plugin:city-sim|apply_tool', { tool, x, y, strokeId })
+export async function applyTool(
+  tool: ToolId,
+  x: number,
+  y: number,
+  strokeId: number,
+  stratum: ViewStratumId,
+): Promise<CommandResult> {
+  return await invoke('plugin:city-sim|apply_tool', { tool, x, y, strokeId, stratum })
 }
 
 /**

--- a/crates/tauri-plugin-city-sim/src/commands.rs
+++ b/crates/tauri-plugin-city-sim/src/commands.rs
@@ -14,7 +14,7 @@ use city_sim_core::sim::Simulation;
 use city_sim_core::snapshot;
 use city_sim_core::state::GameState;
 use city_sim_core::wire::encode_tile_buffer;
-use city_sim_protocol::commands::{CommandResult, Policies, Tool};
+use city_sim_protocol::commands::{CommandResult, Policies, Tool, ViewStratum};
 use city_sim_protocol::events::SimAlert;
 use serde::Serialize;
 use tauri::{ipc::Channel, State};
@@ -88,7 +88,14 @@ pub struct WireBuilding {
 // ── Internal command sent from invoke handlers to the sim thread ──────────────
 
 pub enum SimCmd {
-    ApplyTool(Tool, u32, u32, u64, mpsc::SyncSender<CommandResult>),
+    ApplyTool(
+        Tool,
+        u32,
+        u32,
+        u64,
+        ViewStratum,
+        mpsc::SyncSender<CommandResult>,
+    ),
     SetSpeed(f32),
     SetPolicies(Policies),
     SetNaturalTerrain(Vec<u8>),
@@ -236,9 +243,9 @@ pub fn start(
             // Drain all pending commands before ticking
             loop {
                 match rx.try_recv() {
-                    Ok(SimCmd::ApplyTool(tool, x, y, stroke, tx)) => {
+                    Ok(SimCmd::ApplyTool(tool, x, y, stroke, stratum, tx)) => {
                         let pending = history.prepare(&sim.state, stroke);
-                        let result = sim_apply_tool(&mut sim.state, tool, x, y);
+                        let result = sim_apply_tool(&mut sim.state, tool, x, y, stratum);
                         if result.success {
                             if let Some(bytes) = pending {
                                 history.commit(bytes, stroke);
@@ -316,7 +323,11 @@ pub fn start(
 }
 
 /// Apply a player tool at tile (x, y). `tool` is the `Tool` u8 discriminant
-/// (matching `city_sim_protocol::commands::Tool as u8`).
+/// (matching `city_sim_protocol::commands::Tool as u8`). `stratum` is the
+/// `ViewStratum` u8 discriminant (0 = Surface, 1 = Underground) — which layer
+/// the player was looking at when they clicked, so tools that behave
+/// differently per-stratum (currently just the bulldozer) know what the
+/// player actually meant to clear.
 ///
 /// Blocks until the sim thread has actually processed the command (max 2 s,
 /// same budget as `get_snapshot`) and returns its real `CommandResult` —
@@ -330,10 +341,12 @@ pub fn apply_tool(
     x: u32,
     y: u32,
     stroke_id: u32,
+    stratum: u8,
 ) -> Result<CommandResult, Error> {
     let tool = Tool::try_from(tool).map_err(|_| Error::InvalidTool(tool))?;
+    let stratum = ViewStratum::from(stratum);
     let (tx, rx) = mpsc::sync_channel(0);
-    state.send(SimCmd::ApplyTool(tool, x, y, stroke_id as u64, tx))?;
+    state.send(SimCmd::ApplyTool(tool, x, y, stroke_id as u64, stratum, tx))?;
     rx.recv_timeout(Duration::from_secs(2))
         .map_err(|e| match e {
             RecvTimeoutError::Timeout => Error::ApplyToolTimeout,

--- a/crates/tauri-plugin-city-sim/src/lib.rs
+++ b/crates/tauri-plugin-city-sim/src/lib.rs
@@ -8,7 +8,7 @@
 //
 // Commands:
 //   start(width, height, seed, onTick: Channel<TickEvent>)
-//   apply_tool(tool: u8, x: u32, y: u32)
+//   apply_tool(tool: u8, x: u32, y: u32, stroke_id: u32, stratum: u8)
 //   set_speed(multiplier: f32)
 //   set_policies(policies: { budget: {...}, wilderness: {...} })
 //   set_natural_terrain(kinds: Vec<u8>)

--- a/scripts/city-sim-mcp/index.ts
+++ b/scripts/city-sim-mcp/index.ts
@@ -259,8 +259,10 @@ server.tool(
     ]).describe('Tool to apply'),
     x: z.number().int().describe('Tile column'),
     y: z.number().int().describe('Tile row'),
+    stratum: z.enum(['surface', 'underground']).optional()
+      .describe('Which layer to act on — only bulldoze honours this today. Defaults to surface; pass "underground" to clear a buried pipe without a client view.'),
   },
-  async ({ tool, x, y }) => textResult(await callGame('apply_tool', { tool, x, y })),
+  async ({ tool, x, y, stratum }) => textResult(await callGame('apply_tool', { tool, x, y, stratum })),
 );
 
 server.tool(
@@ -294,9 +296,11 @@ server.tool(
     y1: z.number().int().describe('Start tile row'),
     x2: z.number().int().describe('End tile column'),
     y2: z.number().int().describe('End tile row'),
+    stratum: z.enum(['surface', 'underground']).optional()
+      .describe('Which layer to act on — only bulldoze honours this today. Defaults to surface; pass "underground" to clear buried pipe without a client view.'),
   },
-  async ({ tool, x1, y1, x2, y2 }) =>
-    textResult(await callGame('apply_tool_line', { tool, x1, y1, x2, y2 })),
+  async ({ tool, x1, y1, x2, y2, stratum }) =>
+    textResult(await callGame('apply_tool_line', { tool, x1, y1, x2, y2, stratum })),
 );
 
 server.tool(
@@ -311,9 +315,11 @@ server.tool(
     y1: z.number().int().describe('Top row (inclusive)'),
     x2: z.number().int().describe('Right column (inclusive)'),
     y2: z.number().int().describe('Bottom row (inclusive)'),
+    stratum: z.enum(['surface', 'underground']).optional()
+      .describe('Which layer to act on — only bulldoze honours this today. Defaults to surface; pass "underground" to clear buried pipe without a client view.'),
   },
-  async ({ tool, x1, y1, x2, y2 }) =>
-    textResult(await callGame('apply_tool_rect', { tool, x1, y1, x2, y2 })),
+  async ({ tool, x1, y1, x2, y2, stratum }) =>
+    textResult(await callGame('apply_tool_rect', { tool, x1, y1, x2, y2, stratum })),
 );
 
 server.tool(


### PR DESCRIPTION
## Summary

- Part of #198. **PR 1 of 2** (layer-scoped bulldozer) — pure wire plumbing, **no behaviour change**. PR 2 (branch `fix/bulldoze-underground-view`) will make `bulldoze()` actually act on the field.
- Adds `stratum: ViewStratum` (`Surface` default | `Underground`) to `SimCommand::ApplyTool` in `city-sim-protocol`, deliberately distinct from tile-internal `Stratum` (`Underground | Surface | Overhead`) since the surface *view* maps to two tile strata at once.
- Threads it through `city-sim-core::commands::apply_tool` — every match arm ignores it except `Tool::Bulldoze`, which forwards it into `bulldoze()` as an accepted-but-unused `_stratum` param for now.
- Threads it through both transports end to end: WASM (`SimHost::apply_tool` → `wasmSim.worker.ts` → `wasmSimBridge.ts`) and Tauri (`SimCmd::ApplyTool` → `guest-js/index.ts` → `tauriSimBridge.ts`).
- Threads it through the TS mirror (`applyToolCmd`), `main.ts`'s one production call site (the existing `#197` view-stratum click-guard already reads `viewStratum` right there — this just forwards it), and `mcpBridge.ts`'s three `ApplyTool` literals.
- MCP server (`scripts/city-sim-mcp/index.ts`): `apply_tool`/`apply_tool_line`/`apply_tool_rect` tool schemas gain an optional `stratum` param, so scripted underground pipe-laying and bulldozing are possible without a client view.

### Root cause this sets up to fix

The bulldozer's `bulldoze()` today applies a fixed, view-blind precedence (building → underground → surface+overhead) regardless of what the player is looking at, because the active view has always lived in client-side settings and never crossed the wire. This PR is the "any rule that depends on what the player is looking at must travel on the wire" fix — PR 2 makes `bulldoze()` actually use it.

## Test plan

- [x] `cargo test --workspace` — all green, no behaviour change (existing bulldoze tests pass unchanged since `bulldoze()`'s body is untouched this PR)
- [x] `cargo clippy --workspace --exclude city-sim-wasm --all-targets -- -D warnings` (matches CI exactly) — clean
- [x] `cargo clippy -p city-sim-wasm --all-targets -- -D warnings` — clean
- [x] `bun run build:wasm` — succeeds, WASM host's `apply_tool` signature updated
- [x] `cd crates/tauri-plugin-city-sim && bun run build` — succeeds, `dist-js/` rebuilt
- [x] `bun run lint` (`tsc --noEmit`) — clean
- [x] `bun run test` — 280/280 pass, including new tests pinning the wire encoding on both bridges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqGmvrQ659T22NqsCW3d6y
