### PR TITLE
Share City Sim’s browser relay across Codex MCP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ npm run dev
 
 Then open the provided local URL. The service worker caches assets after first load so the game keeps running offline. Use `npm run build` for a production bundle.
 
+### Codex MCP control
+
+Codex can inspect and operate a locally running city through the `city-sim-1000` MCP server. Register it once on the development machine:
+
+```bash
+codex mcp add city-sim-1000 -- bun run --cwd /absolute/path/to/city-sim-1000/scripts/city-sim-mcp start
+```
+
+Start the game with `bun run dev`, then open `http://localhost:5173/?mcp` in a browser. The browser connects to the MCP relay on `localhost:5174`; the Codex server process starts that relay independently after its MCP handshake. Codex may launch more than one MCP process: the first owns the browser relay and later instances proxy their calls through it. Start a new Codex session after registration so it discovers the server. The server reports `No game connected` until that browser tab is open.
+
+Verify the registration with `codex mcp get city-sim-1000`. Remove it later with `codex mcp remove city-sim-1000`.
+
 ### Tests
 
 `bun run test` (TypeScript), `cargo test --workspace` (Rust) and `bun run test:e2e` (Playwright) are the three gates. On top of the unit tests there are three **architecture harnesses** — a golden city, a visual regression over the derived wire bytes, and a long-run soak. `docs/testing.md` describes what each one covers, what it deliberately does not, how to run it, and how to regenerate its baseline.

--- a/scripts/city-sim-mcp/index.ts
+++ b/scripts/city-sim-mcp/index.ts
@@ -7,7 +7,7 @@
 //   1. bun run dev              (start game at http://localhost:5173)
 //   2. bun run mcp              (start this server)
 //   3. Open http://localhost:5173/?mcp in a browser
-//   4. Register this server in Claude Code's MCP config
+//   4. Register this server with Codex (see the README's MCP section)
 //
 // (c) Copyright 2026 Liminal HQ, Scott Morris
 // SPDX-License-Identifier: MIT
@@ -30,43 +30,21 @@ type WsPendingCall = {
 
 const pending = new Map<string, WsPendingCall>();
 let gameSocket: ServerWebSocket<unknown> | null = null;
+let ownsRelay = false;
+let relayStart: Promise<void> | null = null;
 
-Bun.serve({
-  port: MCP_WS_PORT,
-  fetch(req, server) {
-    if (server.upgrade(req)) return undefined;
-    return new Response(
-      'City Sim 1000 MCP relay — open http://localhost:5173/?mcp in a browser',
-      { status: 200, headers: { 'Content-Type': 'text/plain' } },
-    );
-  },
-  websocket: {
-    open(ws) {
-      gameSocket = ws;
-      console.error('[mcp] Browser game connected');
-    },
-    message(_ws, data) {
-      const msg = JSON.parse(data as string) as {
-        id: string;
-        result?: unknown;
-        error?: string;
-      };
-      const call = pending.get(msg.id);
-      if (!call) return;
-      pending.delete(msg.id);
-      if (msg.error) call.reject(new Error(msg.error));
-      else call.resolve(msg.result);
-    },
-    close() {
-      gameSocket = null;
-      console.error('[mcp] Browser game disconnected');
-    },
-  },
-});
+async function existingRelayIsAvailable(): Promise<boolean> {
+  try {
+    const response = await fetch(`http://127.0.0.1:${MCP_WS_PORT}`, {
+      signal: AbortSignal.timeout(500),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
 
-console.error(`[mcp] WebSocket relay listening on ws://localhost:${MCP_WS_PORT}`);
-
-function callGame(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
+function callConnectedGame(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
   if (!gameSocket) {
     throw new Error(
       'No game connected. Open http://localhost:5173/?mcp in a browser first.',
@@ -85,6 +63,85 @@ function callGame(method: string, params: Record<string, unknown> = {}): Promise
     });
     gameSocket!.send(JSON.stringify({ id, method, params }));
   });
+}
+
+async function startRelay(): Promise<void> {
+  if (await existingRelayIsAvailable()) {
+    console.error('[mcp] Reusing an existing City Sim relay');
+    return;
+  }
+
+  Bun.serve({
+    hostname: '127.0.0.1',
+    port: MCP_WS_PORT,
+    async fetch(req, server) {
+      const url = new URL(req.url);
+      if (url.pathname === '/call' && req.method === 'POST') {
+        try {
+          const { method, params } = await req.json() as {
+            method?: unknown;
+            params?: unknown;
+          };
+          if (typeof method !== 'string' || (params != null && typeof params !== 'object')) {
+            return Response.json({ error: 'Invalid relay request' }, { status: 400 });
+          }
+          return Response.json({ result: await callConnectedGame(method, params as Record<string, unknown> ?? {}) });
+        } catch (error) {
+          return Response.json({ error: String(error) }, { status: 500 });
+        }
+      }
+      if (req.method === 'GET' && server.upgrade(req)) return undefined;
+      return new Response(
+        'City Sim 1000 MCP relay — open http://localhost:5173/?mcp in a browser',
+        { status: 200, headers: { 'Content-Type': 'text/plain' } },
+      );
+    },
+    websocket: {
+      open(ws) {
+        gameSocket = ws;
+        console.error('[mcp] Browser game connected');
+      },
+      message(_ws, data) {
+        const msg = JSON.parse(data as string) as {
+          id: string;
+          result?: unknown;
+          error?: string;
+        };
+        const call = pending.get(msg.id);
+        if (!call) return;
+        pending.delete(msg.id);
+        if (msg.error) call.reject(new Error(msg.error));
+        else call.resolve(msg.result);
+      },
+      close() {
+        gameSocket = null;
+        console.error('[mcp] Browser game disconnected');
+      },
+    },
+  });
+  ownsRelay = true;
+  console.error(`[mcp] WebSocket relay listening on ws://localhost:${MCP_WS_PORT}`);
+}
+
+function ensureRelay(): Promise<void> {
+  relayStart ??= startRelay();
+  return relayStart;
+}
+
+async function callGame(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
+  await ensureRelay();
+  if (ownsRelay) return callConnectedGame(method, params);
+
+  const response = await fetch(`http://127.0.0.1:${MCP_WS_PORT}/call`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ method, params }),
+  });
+  const body = await response.json() as { result?: unknown; error?: string };
+  if (!response.ok) {
+    throw new Error(body.error ?? `Relay request for "${method}" failed`);
+  }
+  return body.result;
 }
 
 function textResult(value: unknown) {
@@ -254,3 +311,6 @@ server.tool(
 
 const transport = new StdioServerTransport();
 await server.connect(transport);
+void ensureRelay().catch(error => {
+  console.error(`[mcp] Could not start the browser relay: ${String(error)}`);
+});

--- a/scripts/city-sim-mcp/index.ts
+++ b/scripts/city-sim-mcp/index.ts
@@ -15,9 +15,12 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import type { ServerWebSocket } from 'bun';
+import { closeSync, openSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { z } from 'zod';
 
 const MCP_WS_PORT = 5174;
+const RELAY_LOCK_PATH = `/tmp/city-sim-1000-mcp-${MCP_WS_PORT}.lock`;
+let relayLockToken: string | undefined;
 
 // ---------------------------------------------------------------------------
 // WebSocket relay — browser connects here, MCP tools route through it
@@ -39,6 +42,45 @@ async function existingRelayIsAvailable(): Promise<boolean> {
       signal: AbortSignal.timeout(500),
     });
     return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+function acquireRelayLock(): boolean {
+  try {
+    const fd = openSync(RELAY_LOCK_PATH, 'wx');
+    relayLockToken = `${process.pid}:${crypto.randomUUID()}`;
+    writeFileSync(fd, relayLockToken);
+    closeSync(fd);
+    process.once('exit', () => {
+      try {
+        if (readFileSync(RELAY_LOCK_PATH, 'utf8') === relayLockToken) {
+          unlinkSync(RELAY_LOCK_PATH);
+        }
+      } catch { /* Relay lock already removed. */ }
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function removeStaleRelayLock(): boolean {
+  try {
+    const [pidText] = readFileSync(RELAY_LOCK_PATH, 'utf8').split(':', 1);
+    const pid = Number.parseInt(pidText, 10);
+    if (!Number.isInteger(pid) || pid <= 0) {
+      unlinkSync(RELAY_LOCK_PATH);
+      return true;
+    }
+    try {
+      process.kill(pid, 0);
+      return false;
+    } catch {
+      unlinkSync(RELAY_LOCK_PATH);
+      return true;
+    }
   } catch {
     return false;
   }
@@ -69,6 +111,18 @@ async function startRelay(): Promise<void> {
   if (await existingRelayIsAvailable()) {
     console.error('[mcp] Reusing an existing City Sim relay');
     return;
+  }
+
+  if (!acquireRelayLock()) {
+    for (let attempt = 0; attempt < 20; attempt++) {
+      await new Promise(resolve => setTimeout(resolve, 50));
+      if (await existingRelayIsAvailable()) {
+        console.error('[mcp] Reusing an existing City Sim relay');
+        return;
+      }
+    }
+    if (removeStaleRelayLock()) return startRelay();
+    throw new Error('Another City Sim MCP process is starting the browser relay');
   }
 
   Bun.serve({


### PR DESCRIPTION
## Summary

### Maintainer-facing changes

- **`scripts/city-sim-mcp/index.ts`** — lets one process own the localhost browser relay while later Codex MCP processes proxy their calls through it.
- **`scripts/city-sim-mcp/index.ts`** — connects the stdio MCP transport before the relay starts, so tool discovery is not gated on browser availability.

### Documentation

- **`README.md`** — documents the Codex registration command, browser connection flow, and multi-process relay behaviour.

## Test plan

- [x] `bun run test` — 278 tests passed.
- [x] Started two MCP server processes and verified the second completed `initialize` and relayed `get_state` through the first process.
- [x] Opened `http://localhost:5173/?mcp` through Playwright and used City Sim MCP tools to build and advance a powered, watered starter district.
