### PR TITLE
Wire EducationStats and per-building service load over the bridge protocol

### DIFF
--- a/app/src/game/education.ts
+++ b/app/src/game/education.ts
@@ -1,20 +1,18 @@
-// education.ts — education coverage recompute over school service areas.
+// education.ts — client-side education helpers.
 //
 // (c) Copyright 2026 Liminal HQ, Scott Morris
 // SPDX-License-Identifier: MIT
+//
+// `#228`: education coverage is computed by `city-sim-core`'s
+// `recompute_education` and reaches the client over the wire — see
+// `wasmSimBridge.ts`/`tauriSimBridge.ts`. What remains here is a build-preview
+// helper that has no engine equivalent to call (it previews a school that
+// hasn't been placed yet) plus small readers over `state.education`.
 
-import { BuildingStatus } from './buildings/state';
-import { fundingMultiplier, MAX_FUNDING } from './protocol/commands';
-import { BuildingCategory, getBuildingTemplate } from './buildings/templates';
+import { getBuildingTemplate } from './buildings/templates';
 import type { GameState } from './gameState';
-import { getTile } from './gameState';
 import { ServiceId } from './services';
-import {
-  computeZoneLoads,
-  estimateZoneLoad,
-  getReachableZoneCandidates,
-  DEFAULT_WORKER_SHARE
-} from './serviceDistribution';
+import { getReachableZoneCandidates } from './serviceDistribution';
 
 export interface EducationStats {
   elementaryServed: number;
@@ -28,101 +26,15 @@ export interface EducationStats {
   highCoverage: number;
 }
 
-function clamp(val: number, min: number, max: number) {
-  return Math.max(min, Math.min(max, val));
-}
-export function recomputeEducation(state: GameState): EducationStats {
-  let elementaryLoad = 0;
-  let highLoad = 0;
-  let elementaryServed = 0;
-  let highServed = 0;
-  let elementaryCapacity = 0;
-  let highCapacity = 0;
-  const loads = computeZoneLoads(state, DEFAULT_WORKER_SHARE);
-
-  state.tiles.forEach((tile, idx) => {
-    tile.services.served[ServiceId.EducationElementary] = false;
-    tile.services.served[ServiceId.EducationHigh] = false;
-    tile.services.scores[ServiceId.EducationElementary] = 0;
-    tile.services.scores[ServiceId.EducationHigh] = 0;
-    elementaryLoad += estimateZoneLoad(idx, tile, ServiceId.EducationElementary, loads);
-    highLoad += estimateZoneLoad(idx, tile, ServiceId.EducationHigh, loads);
-  });
-
-  for (const building of state.buildings) {
-    const template = getBuildingTemplate(building.templateId);
-    if (!template?.service) continue;
-    if (
-      template.service.id !== ServiceId.EducationElementary &&
-      template.service.id !== ServiceId.EducationHigh
-    )
-      continue;
-    if (building.state.status !== BuildingStatus.Active) continue;
-    // Underfunded civic departments crowd the schools (mirrors
-    // `recompute_education` in city-sim-core; 100% funding → exact).
-    const capacity =
-      (template.service.capacity ?? 0) *
-      fundingMultiplier(state.policies?.budget.fundCivic ?? MAX_FUNDING);
-    if (capacity <= 0) continue;
-
-    if (template.service.id === ServiceId.EducationElementary) elementaryCapacity += capacity;
-    if (template.service.id === ServiceId.EducationHigh) highCapacity += capacity;
-
-    const candidates = getReachableZoneCandidates(
-      state,
-      building.origin,
-      template.footprint,
-      template.service.coverageRadius
-    );
-    let used = 0;
-
-    for (const [idx] of candidates) {
-      if (used >= capacity) break;
-      const x = idx % state.width;
-      const y = Math.floor(idx / state.width);
-      const tile = getTile(state, x, y);
-      if (!tile) continue;
-      const load = estimateZoneLoad(idx, tile, template.service.id, loads);
-      if (load <= 0) continue;
-      const remaining = Math.max(0, capacity - used);
-      if (remaining <= 0) break;
-      const applied = Math.min(load, remaining);
-      if (applied <= 0) continue;
-      used += applied;
-      tile.services.served[template.service.id] = true;
-      tile.services.scores[template.service.id] = applied / load;
-      if (template.service.id === ServiceId.EducationElementary) {
-        elementaryServed += applied;
-      } else {
-        highServed += applied;
-      }
-    }
-
-    building.state.serviceLoad.slotsUsed[template.service.id] = used;
-  }
-
-  const elementaryCoverage =
-    elementaryLoad > 0 ? clamp(elementaryServed / elementaryLoad, 0, 1) : 1;
-  const highCoverage = highLoad > 0 ? clamp(highServed / highLoad, 0, 1) : 1;
-  const score = clamp(elementaryCoverage * 0.6 + highCoverage * 0.4, 0, 1);
-
-  return {
-    elementaryServed,
-    elementaryCapacity,
-    elementaryLoad,
-    highServed,
-    highCapacity,
-    highLoad,
-    score,
-    elementaryCoverage,
-    highCoverage
-  };
-}
-
 export function getEducationScore(state: GameState): number {
-  return state.education?.score ?? 0;
+  return state.education?.score ?? 1;
 }
 
+/**
+ * Defaults for a city with no schools: no load anywhere means full coverage,
+ * not zero — matches `city_sim_core::state::EducationStats::default()`. Used
+ * before the first wire update lands (initial state, legacy-save back-fill).
+ */
 export function createEmptyEducationStats(): EducationStats {
   return {
     elementaryServed: 0,
@@ -131,9 +43,9 @@ export function createEmptyEducationStats(): EducationStats {
     highServed: 0,
     highCapacity: 0,
     highLoad: 0,
-    score: 0,
-    elementaryCoverage: 0,
-    highCoverage: 0
+    score: 1,
+    elementaryCoverage: 1,
+    highCoverage: 1
   };
 }
 

--- a/app/src/game/gameState.ts
+++ b/app/src/game/gameState.ts
@@ -419,6 +419,8 @@ export function createInitialState(width = 64, height = 64, seed?: number): Game
     buildings: [],
     nextBuildingId: 1,
     services: createServiceSystemState(),
+    // No schools yet → no load anywhere → full coverage, matching
+    // `city_sim_core::state::EducationStats::default()`.
     education: {
       elementaryServed: 0,
       elementaryCapacity: 0,
@@ -426,9 +428,9 @@ export function createInitialState(width = 64, height = 64, seed?: number): Game
       highServed: 0,
       highCapacity: 0,
       highLoad: 0,
-      score: 0,
-      elementaryCoverage: 0,
-      highCoverage: 0
+      score: 1,
+      elementaryCoverage: 1,
+      highCoverage: 1
     },
     bylaws: { ...DEFAULT_BYLAWS },
     policies: createDefaultPolicies(),

--- a/app/src/game/protocol/protocol.test.ts
+++ b/app/src/game/protocol/protocol.test.ts
@@ -1,3 +1,8 @@
+// protocol.test.ts — TileKind/tile-buffer/legacy-tile-buffer parity with the Rust source.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
 /**
  * Protocol parity tests — asserts the TS mirror matches the Rust source.
  *

--- a/app/src/game/protocol/protocol.test.ts
+++ b/app/src/game/protocol/protocol.test.ts
@@ -17,7 +17,10 @@ import {
   tileKindFromU8,
   tileKindToU8,
 } from './tileKind';
-import { BYTES_PER_TILE, STATUS, tileBufferOffsets, decodeHappiness, encodeHappiness, decodeEco, encodeEco, ECO_RANGE } from './tileBuffer';
+import { BYTES_PER_TILE, STATUS, tileBufferOffsets, decodeHappiness, encodeHappiness, decodeEco, encodeEco, ECO_RANGE, decodeScore, decodeTileBuffer } from './tileBuffer';
+import { ServiceId, createTileServiceState } from '../services';
+import { Terrain, ZoneDensity } from './occupants';
+import type { Tile } from '../gameState';
 import { LEGACY_BYTES_PER_TILE, LEGACY_FLAGS, legacyTileBufferOffsets } from './legacyTileBuffer';
 import parityFixture from './tileKindParity.json';
 
@@ -69,7 +72,7 @@ describe('protocol: TileKind ↔ u8 parity with Rust', () => {
 // ---------------------------------------------------------------------------
 
 describe('protocol: tile buffer layout', () => {
-  it('BYTES_PER_TILE is 9', () => expect(BYTES_PER_TILE).toBe(9));
+  it('BYTES_PER_TILE is 11', () => expect(BYTES_PER_TILE).toBe(11));
 
   it('offsets for 64×64 map', () => {
     const n = 64 * 64;
@@ -82,10 +85,19 @@ describe('protocol: tile buffer layout', () => {
     expect(off.elevation).toBe(20480);
     expect(off.buildingId).toBe(24576);
     expect(off.wilderness).toBe(32768);
+    expect(off.elementaryScore).toBe(36864);
+    expect(off.highScore).toBe(40960);
   });
 
   it('STATUS bitmask values (excluding the density field) are unique powers of 2', () => {
-    const vals = [STATUS.POWERED, STATUS.WATERED, STATUS.ABANDONED, STATUS.WATER_TERRAIN];
+    const vals = [
+      STATUS.POWERED,
+      STATUS.WATERED,
+      STATUS.ABANDONED,
+      STATUS.WATER_TERRAIN,
+      STATUS.ELEMENTARY_SERVED,
+      STATUS.HIGH_SERVED
+    ];
     const unique = new Set(vals);
     expect(unique.size).toBe(vals.length);
     for (const v of vals) {
@@ -106,6 +118,45 @@ describe('protocol: tile buffer layout', () => {
     expect(encodeEco(0)).toBe(128);
     expect(encodeEco(999)).toBe(encodeEco(ECO_RANGE));
     expect(encodeEco(-999)).toBe(encodeEco(-ECO_RANGE));
+  });
+
+  it('education score decodes the [0, 1] range from a u8', () => {
+    expect(decodeScore(0)).toBe(0);
+    expect(decodeScore(255)).toBe(1);
+    expect(Math.abs(decodeScore(128) - 0.5)).toBeLessThan(0.01);
+  });
+
+  it('decodeTileBuffer sets per-tile education served/scores from the status bits and score bytes', () => {
+    const n = 2;
+    const makeTile = (): Tile => ({
+      elevation: 0,
+      happiness: 1,
+      powered: false,
+      watered: false,
+      services: createTileServiceState(),
+      terrain: Terrain.Land,
+      underground: 0,
+      surface: 0,
+      overhead: 0,
+      density: ZoneDensity.Low
+    });
+    const tiles = [makeTile(), makeTile()];
+    const o = tileBufferOffsets(n);
+    const bytes = new Array(n * BYTES_PER_TILE).fill(0);
+    bytes[o.status + 0] = STATUS.ELEMENTARY_SERVED;
+    bytes[o.status + 1] = STATUS.HIGH_SERVED;
+    bytes[o.elementaryScore + 0] = 255;
+    bytes[o.highScore + 1] = 128;
+
+    decodeTileBuffer(tiles, bytes);
+
+    expect(tiles[0].services.served[ServiceId.EducationElementary]).toBe(true);
+    expect(tiles[0].services.served[ServiceId.EducationHigh]).toBe(false);
+    expect(tiles[0].services.scores[ServiceId.EducationElementary]).toBe(1);
+
+    expect(tiles[1].services.served[ServiceId.EducationElementary]).toBe(false);
+    expect(tiles[1].services.served[ServiceId.EducationHigh]).toBe(true);
+    expect(Math.abs(tiles[1].services.scores[ServiceId.EducationHigh]! - 0.5)).toBeLessThan(0.01);
   });
 });
 

--- a/app/src/game/protocol/tileBuffer.ts
+++ b/app/src/game/protocol/tileBuffer.ts
@@ -1,4 +1,5 @@
 import type { Tile } from '../gameState';
+import { ServiceId } from '../services';
 import { Terrain, ZoneDensity } from './occupants';
 
 /**
@@ -14,8 +15,10 @@ import { Terrain, ZoneDensity } from './occupants';
  *   elevation[N]   u8   — unsigned elevation (0–255)
  *   building_id[N] u16  — building ID, little-endian (0 = none)
  *   wilderness[N]  u8   — per-tile eco value, quantised (128 = neutral)
+ *   elementary_score[N] u8 — elementary education score, quantised (0.0–1.0)
+ *   high_score[N]  u8   — high-school education score, quantised (0.0–1.0)
  *
- * Total: N × 9 bytes.
+ * Total: N × 11 bytes.
  *
  * `underground`/`surface`/`overhead` are each a dense, rebased slice of one
  * stratum's occupant bits (see `protocol/occupants.ts`): `Occupant`'s
@@ -31,7 +34,7 @@ import { Terrain, ZoneDensity } from './occupants';
  * either representation without either bridge needing its own decoder.
  */
 
-export const BYTES_PER_TILE = 9;
+export const BYTES_PER_TILE = 11;
 
 export function tileBufferOffsets(n: number) {
   return {
@@ -42,7 +45,9 @@ export function tileBufferOffsets(n: number) {
     happiness: n * 4,
     elevation: n * 5,
     buildingId: n * 6, // u16le → occupies n*2 bytes starting here
-    wilderness: n * 8
+    wilderness: n * 8,
+    elementaryScore: n * 9,
+    highScore: n * 10
   } as const;
 }
 
@@ -53,7 +58,9 @@ export const STATUS = {
   ABANDONED: 1 << 2,
   WATER_TERRAIN: 1 << 3,
   DENSITY_SHIFT: 4,
-  DENSITY_MASK: 0b11 << 4
+  DENSITY_MASK: 0b11 << 4,
+  ELEMENTARY_SERVED: 1 << 6,
+  HIGH_SERVED: 1 << 7
 } as const;
 
 /** Rebase a wire `underground` byte back to absolute `Occupant` bits — already absolute, no shift. */
@@ -98,6 +105,11 @@ export function encodeEco(eco: number): number {
   return Math.trunc((clamped / ECO_RANGE) * 127 + 128);
 }
 
+/** Decode a u8 education score byte back to the [0, 1] float range. */
+export function decodeScore(u8: number): number {
+  return u8 / 255;
+}
+
 /**
  * Decode one SoA tile buffer into `tiles`, in place — shared by every bridge
  * that receives this wire (`wasmSimBridge.ts`, `tauriSimBridge.ts`), so a
@@ -125,5 +137,9 @@ export function decodeTileBuffer(tiles: Tile[], bytes: ArrayLike<number>): void 
     tile.buildingId = bid === 0 ? undefined : bid;
     // Normalised 0–1 (0.5 = neutral) for the overlay heatmap.
     tile.wilderness = bytes[o.wilderness + i] / 255;
+    tile.services.served[ServiceId.EducationElementary] = (status & STATUS.ELEMENTARY_SERVED) !== 0;
+    tile.services.served[ServiceId.EducationHigh] = (status & STATUS.HIGH_SERVED) !== 0;
+    tile.services.scores[ServiceId.EducationElementary] = decodeScore(bytes[o.elementaryScore + i]);
+    tile.services.scores[ServiceId.EducationHigh] = decodeScore(bytes[o.highScore + i]);
   }
 }

--- a/app/src/game/protocol/tileBuffer.ts
+++ b/app/src/game/protocol/tileBuffer.ts
@@ -1,3 +1,8 @@
+// tileBuffer.ts — TS decoder for the live SoA tile buffer wire format.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
 import type { Tile } from '../gameState';
 import { ServiceId } from '../services';
 import { Terrain, ZoneDensity } from './occupants';

--- a/app/src/game/tauriSimBridge.test.ts
+++ b/app/src/game/tauriSimBridge.test.ts
@@ -9,6 +9,7 @@ import { applyToolCmd, nextStrokeId } from './protocol/commands';
 import { Occupant, Terrain, ZoneDensity } from './protocol/occupants';
 import { BYTES_PER_TILE, STATUS, encodeHappiness, tileBufferOffsets } from './protocol/tileBuffer';
 import { tileKindToU8 } from './protocol/tileKind';
+import { ServiceId } from './services';
 import type { FromSim } from './protocol/events';
 import { Tool } from './toolTypes';
 import { TauriSimBridge, type TauriPluginBindings } from './tauriSimBridge';
@@ -55,10 +56,22 @@ interface SimAlert {
   sticky: boolean;
 }
 
+interface WireEducationStats {
+  elementaryServed: number; elementaryCapacity: number; elementaryLoad: number;
+  highServed: number; highCapacity: number; highLoad: number;
+  score: number; elementaryCoverage: number; highCoverage: number;
+}
+
+interface WireEducationSeatsUsed {
+  buildingId: number;
+  used: number;
+}
+
 interface TickEvent {
   tick: number; day: number; population: number; jobs: number; money: number;
   power: number; water: number; powerProduced: number; waterProduced: number;
   powerComponents: WireUtilityComponent[]; waterComponents: WireUtilityComponent[];
+  education: WireEducationStats; educationSeatsUsed: WireEducationSeatsUsed[];
   demandResidential: number; demandCommercial: number; demandIndustrial: number;
   wildernessScore: number; wildernessTrend: number;
   width: number; height: number;
@@ -75,6 +88,12 @@ function baseTickEvent(overrides: Partial<TickEvent> = {}): TickEvent {
     tick: 0, day: 0, population: 0, jobs: 0, money: 0,
     power: 0, water: 0, powerProduced: 0, waterProduced: 0,
     powerComponents: [], waterComponents: [],
+    education: {
+      elementaryServed: 0, elementaryCapacity: 0, elementaryLoad: 0,
+      highServed: 0, highCapacity: 0, highLoad: 0,
+      score: 1, elementaryCoverage: 1, highCoverage: 1
+    },
+    educationSeatsUsed: [],
     demandResidential: 0, demandCommercial: 0, demandIndustrial: 0,
     wildernessScore: 0, wildernessTrend: 0,
     width: 8, height: 8,
@@ -263,6 +282,27 @@ describe('TauriSimBridge onTick decode', () => {
     expect(tile.elevation).toBe(200);
     expect(tile.buildingId).toBe(42);
     expect(tile.wilderness).toBeCloseTo(64 / 255, 5);
+  });
+
+  it('adopts event.education verbatim and maps educationSeatsUsed onto the matching building\'s slotsUsed', async () => {
+    const { bridge, emit } = await makeBridge();
+    const education: WireEducationStats = {
+      elementaryServed: 12, elementaryCapacity: 180, elementaryLoad: 20,
+      highServed: 0, highCapacity: 0, highLoad: 0,
+      score: 0.6, elementaryCoverage: 0.6, highCoverage: 1,
+    };
+    const school: WireBuilding = { id: 7, kind: tileKindToU8(TileKind.ElementarySchool), originX: 0, originY: 0 };
+
+    emit(baseTickEvent({
+      education,
+      educationSeatsUsed: [{ buildingId: 7, used: 12 }],
+      buildings: [school],
+    }));
+
+    const s = bridge.getState();
+    expect(s.education).toEqual(education);
+    const building = s.buildings.find((b) => b.id === 7);
+    expect(building?.state.serviceLoad.slotsUsed[ServiceId.EducationElementary]).toBe(12);
   });
 
   it('decodes buildingId directly from the wire, independent of event.buildings, and clears it when the wire says none', async () => {

--- a/app/src/game/tauriSimBridge.ts
+++ b/app/src/game/tauriSimBridge.ts
@@ -33,7 +33,6 @@ import type { GameState, Tile, ViewStratum } from './gameState';
 import { TileKind } from './gameState';
 import { BuildingStatus, createBuildingState } from './buildings/state';
 import { getBuildingTemplate } from './buildings/templates';
-import { recomputeEducation } from './education';
 import type { SimBridge } from './simBridge';
 import type { SimCommand, CommandResult } from './protocol/commands';
 import type { FromSim } from './protocol/events';
@@ -349,6 +348,7 @@ export class TauriSimBridge implements SimBridge {
     for (let i = 0; i < n && !hasWaterSystem; i++) {
       if (hasOccupant(s.tiles[i].underground, Occupant.Pipe)) hasWaterSystem = true;
     }
+    const seatsUsedByBuildingId = new Map(event.educationSeatsUsed.map((e) => [e.buildingId, e.used]));
     s.buildings = event.buildings.map((b) => {
       const kind = tileKindFromU8(b.kind) ?? TileKind.Land;
       // Derive status from the tile flags the status byte already set —
@@ -371,6 +371,12 @@ export class TauriSimBridge implements SimBridge {
       } else if (needsWater && !originTile?.watered) {
         bstate.status = BuildingStatus.InactiveNoWater;
       }
+      // `#228` — seats consumed, from the wire; only schools currently have
+      // an entry (Rust's `ServiceKind` has no other service ported yet).
+      const used = template?.service ? seatsUsedByBuildingId.get(b.id) : undefined;
+      if (template?.service && used !== undefined) {
+        bstate.serviceLoad.slotsUsed[template.service.id] = used;
+      }
       return {
         id: b.id,
         templateId: kind as string,
@@ -379,8 +385,8 @@ export class TauriSimBridge implements SimBridge {
       };
     });
 
-    // Education coverage keys off the rebuilt buildings list.
-    s.education = recomputeEducation(s);
+    // `#228` — Rust-computed, replaces the old client-side recompute.
+    s.education = event.education;
 
     // Forward any deficit/restore alerts raised this tick, plus each one's
     // paired narrative event — same derivation `wasmSimBridge.ts` uses, kept

--- a/app/src/game/wasmSimBridge.test.ts
+++ b/app/src/game/wasmSimBridge.test.ts
@@ -5,8 +5,10 @@
 
 import { describe, expect, it } from 'vitest';
 import { WasmSimBridge } from './wasmSimBridge';
-import { createInitialState } from './gameState';
+import { createInitialState, TileKind } from './gameState';
 import { applyToolCmd, nextStrokeId } from './protocol/commands';
+import { tileKindToU8 } from './protocol/tileKind';
+import { ServiceId } from './services';
 import type { FromSim } from './protocol/events';
 import type { SimStats } from '../workers/wasmSim.worker';
 import { Tool } from './toolTypes';
@@ -260,6 +262,27 @@ describe('WasmSimBridge undo/redo', () => {
       { id: 1, produced: 60, used: 30, sourceCount: 1, utilisation: 0.5 },
     ]);
     expect(state.utilities.waterComponents).toEqual([]);
+  });
+
+  it('decodes educationJson into state.education and educationSeatsUsedJson into a building\'s slotsUsed, on step() flush', () => {
+    const { worker, bridge, state } = makeBridge();
+    const educationStats = {
+      elementaryServed: 12, elementaryCapacity: 180, elementaryLoad: 20,
+      highServed: 0, highCapacity: 0, highLoad: 0,
+      score: 0.6, elementaryCoverage: 0.6, highCoverage: 1,
+    };
+    worker.emit({
+      type: 'step_result', bytes: emptyTileBuffer(), stats: zeroStats(), mutationSeq: 0, alerts: [],
+      buildingsJson: JSON.stringify([{ id: 7, kind: tileKindToU8(TileKind.ElementarySchool), originX: 0, originY: 0 }]),
+      powerComponentsJson: '[]', waterComponentsJson: '[]',
+      educationJson: JSON.stringify(educationStats),
+      educationSeatsUsedJson: JSON.stringify([{ buildingId: 7, used: 12 }]),
+    });
+
+    bridge.step(1 / 20);
+
+    expect(state.education).toEqual(educationStats);
+    expect(state.buildings[0].state.serviceLoad.slotsUsed[ServiceId.EducationElementary]).toBe(12);
   });
 
   it('discards a pending alert when an undo lands before step() flushes it', () => {

--- a/app/src/game/wasmSimBridge.ts
+++ b/app/src/game/wasmSimBridge.ts
@@ -227,7 +227,7 @@ export class WasmSimBridge implements SimBridge {
     // stops. When the posted tick AND mutationSeq both match what's already
     // applied, nothing meaningful could have changed and the buffer is
     // byte-identical to what's already applied, so skip the full tile-array
-    // rebuild + building-list rebuild + recomputeEducation.
+    // rebuild + building-list rebuild + education JSON parse.
     if (
       this.pendingStats !== null &&
       this.pendingStats.tick === this.lastAppliedTick &&

--- a/app/src/game/wasmSimBridge.ts
+++ b/app/src/game/wasmSimBridge.ts
@@ -15,7 +15,6 @@ import type { GameState, UtilityComponentStats, ViewStratum } from './gameState'
 import { TileKind } from './gameState';
 import { BuildingStatus, createBuildingState } from './buildings/state';
 import { getBuildingTemplate } from './buildings/templates';
-import { recomputeEducation } from './education';
 import { createTileServiceState } from './services';
 import type { LegacyEngineImport, SimBridge } from './simBridge';
 import type { BudgetPolicy, SimCommand, CommandResult } from './protocol/commands';
@@ -82,19 +81,19 @@ type WorkerToMain =
   /** Posted only when the WASM's `Last-Modified` changes under a live page. */
   | { type: 'build_update'; build: { lastModified: string | null } }
   | { type: 'init_error';   message: string }
-  | { type: 'step_result';  bytes: Uint8Array; stats: SimStats; buildingsJson: string; powerComponentsJson: string; waterComponentsJson: string; mutationSeq: number; alerts: SimAlertWire[] }
+  | { type: 'step_result';  bytes: Uint8Array; stats: SimStats; buildingsJson: string; powerComponentsJson: string; waterComponentsJson: string; educationJson: string; educationSeatsUsedJson: string; mutationSeq: number; alerts: SimAlertWire[] }
   | { type: 'apply_result'; success: boolean; message: string | null; history: WorkerHistoryFlags }
   | { type: 'undo_result';  happened: false; history: WorkerHistoryFlags }
-  | { type: 'undo_result';  happened: true; bytes: Uint8Array; stats: SimStats; buildingsJson: string; powerComponentsJson: string; waterComponentsJson: string; mutationSeq: number; history: WorkerHistoryFlags }
+  | { type: 'undo_result';  happened: true; bytes: Uint8Array; stats: SimStats; buildingsJson: string; powerComponentsJson: string; waterComponentsJson: string; educationJson: string; educationSeatsUsedJson: string; mutationSeq: number; history: WorkerHistoryFlags }
   | { type: 'redo_result';  happened: false; history: WorkerHistoryFlags }
-  | { type: 'redo_result';  happened: true; bytes: Uint8Array; stats: SimStats; buildingsJson: string; powerComponentsJson: string; waterComponentsJson: string; mutationSeq: number; history: WorkerHistoryFlags }
+  | { type: 'redo_result';  happened: true; bytes: Uint8Array; stats: SimStats; buildingsJson: string; powerComponentsJson: string; waterComponentsJson: string; educationJson: string; educationSeatsUsedJson: string; mutationSeq: number; history: WorkerHistoryFlags }
   | { type: 'snapshot_result'; requestId: number; bytes: Uint8Array }
   | { type: 'load_result'; requestId: number; ok: false; error?: string }
   | {
       type: 'load_result'; requestId: number; ok: true;
       width: number; height: number; seed: number;
       policies: GameState['policies'];
-      bytes: Uint8Array; stats: SimStats; buildingsJson: string; powerComponentsJson: string; waterComponentsJson: string; mutationSeq: number; history: WorkerHistoryFlags;
+      bytes: Uint8Array; stats: SimStats; buildingsJson: string; powerComponentsJson: string; waterComponentsJson: string; educationJson: string; educationSeatsUsedJson: string; mutationSeq: number; history: WorkerHistoryFlags;
     };
 
 /** One entry decoded from a `buildingsJson` payload — see `SimHost::buildings_json` (Rust). */
@@ -103,6 +102,12 @@ interface WireBuilding {
   kind: number;
   originX: number;
   originY: number;
+}
+
+/** One entry decoded from an `educationSeatsUsedJson` payload — see `SimHost::education_seats_used_json` (Rust). */
+interface WireEducationSeatsUsed {
+  buildingId: number;
+  used: number;
 }
 
 export interface WasmSimBridgeConfig {
@@ -124,6 +129,8 @@ export class WasmSimBridge implements SimBridge {
   private pendingBuildingsJson = '';
   private pendingPowerComponentsJson = '';
   private pendingWaterComponentsJson = '';
+  private pendingEducationJson = '';
+  private pendingEducationSeatsUsedJson = '';
   private pendingStats: SimStats | null = null;
   private pendingMutationSeq = 0;
   /**
@@ -237,6 +244,8 @@ export class WasmSimBridge implements SimBridge {
         this.pendingBuildingsJson,
         this.pendingPowerComponentsJson,
         this.pendingWaterComponentsJson,
+        this.pendingEducationJson,
+        this.pendingEducationSeatsUsedJson,
       );
       this.pendingTileBuffer = null;
       this.dirtySinceLastStep = true;
@@ -427,6 +436,8 @@ export class WasmSimBridge implements SimBridge {
         this.pendingBuildingsJson = msg.buildingsJson;
         this.pendingPowerComponentsJson = msg.powerComponentsJson;
         this.pendingWaterComponentsJson = msg.waterComponentsJson;
+        this.pendingEducationJson = msg.educationJson;
+        this.pendingEducationSeatsUsedJson = msg.educationSeatsUsedJson;
         this.pendingStats = msg.stats;
         this.pendingMutationSeq = msg.mutationSeq;
         // Staged, not dispatched here — see pendingAlerts' field doc. Concat
@@ -449,7 +460,7 @@ export class WasmSimBridge implements SimBridge {
         this.pendingStats = null;
         this.pendingAlerts = [];
         if (msg.happened) {
-          this.applyTileBuffer(msg.bytes, msg.buildingsJson, msg.powerComponentsJson, msg.waterComponentsJson);
+          this.applyTileBuffer(msg.bytes, msg.buildingsJson, msg.powerComponentsJson, msg.waterComponentsJson, msg.educationJson, msg.educationSeatsUsedJson);
           this.updateStats(msg.stats);
           this.lastAppliedTick = msg.stats.tick;
           this.lastAppliedMutationSeq = msg.mutationSeq;
@@ -465,7 +476,7 @@ export class WasmSimBridge implements SimBridge {
         this.pendingStats = null;
         this.pendingAlerts = [];
         if (msg.happened) {
-          this.applyTileBuffer(msg.bytes, msg.buildingsJson, msg.powerComponentsJson, msg.waterComponentsJson);
+          this.applyTileBuffer(msg.bytes, msg.buildingsJson, msg.powerComponentsJson, msg.waterComponentsJson, msg.educationJson, msg.educationSeatsUsedJson);
           this.updateStats(msg.stats);
           this.lastAppliedTick = msg.stats.tick;
           this.lastAppliedMutationSeq = msg.mutationSeq;
@@ -495,7 +506,7 @@ export class WasmSimBridge implements SimBridge {
         this.pendingAlerts = [];
         this.adoptDimensions(msg.width, msg.height, msg.seed);
         this.state.policies = msg.policies;
-        this.applyTileBuffer(msg.bytes, msg.buildingsJson, msg.powerComponentsJson, msg.waterComponentsJson);
+        this.applyTileBuffer(msg.bytes, msg.buildingsJson, msg.powerComponentsJson, msg.waterComponentsJson, msg.educationJson, msg.educationSeatsUsedJson);
         this.updateStats(msg.stats);
         this.lastAppliedTick = msg.stats.tick;
         this.lastAppliedMutationSeq = msg.mutationSeq;
@@ -636,6 +647,8 @@ export class WasmSimBridge implements SimBridge {
     buildingsJson: string,
     powerComponentsJson: string,
     waterComponentsJson: string,
+    educationJson: string,
+    educationSeatsUsedJson: string,
   ): void {
     const n = this.state.tiles.length;
 
@@ -651,6 +664,13 @@ export class WasmSimBridge implements SimBridge {
       : [];
     this.state.utilities.waterComponents = waterComponentsJson
       ? (JSON.parse(waterComponentsJson) as UtilityComponentStats[])
+      : [];
+    // `#228` — Rust-computed, replaces the old client-side recompute.
+    if (educationJson) {
+      this.state.education = JSON.parse(educationJson) as GameState['education'];
+    }
+    const seatsUsed: WireEducationSeatsUsed[] = educationSeatsUsedJson
+      ? JSON.parse(educationSeatsUsedJson)
       : [];
 
     decodeTileBuffer(this.state.tiles, bytes);
@@ -668,6 +688,7 @@ export class WasmSimBridge implements SimBridge {
     for (let i = 0; i < n && !hasWaterSystem; i++) {
       if (hasOccupant(this.state.tiles[i].underground, Occupant.Pipe)) hasWaterSystem = true;
     }
+    const seatsUsedByBuildingId = new Map(seatsUsed.map((e) => [e.buildingId, e.used]));
     this.state.buildings = wireBuildings.map((b) => {
       const kind = tileKindFromU8(b.kind) ?? TileKind.Land;
       // Status is derived from the tile flags the Rust buffer already set —
@@ -691,6 +712,12 @@ export class WasmSimBridge implements SimBridge {
       } else if (needsWater && !originTile?.watered) {
         bstate.status = BuildingStatus.InactiveNoWater;
       }
+      // `#228` — seats consumed, from the wire; only schools currently have
+      // an entry (Rust's `ServiceKind` has no other service ported yet).
+      const used = template?.service ? seatsUsedByBuildingId.get(b.id) : undefined;
+      if (template?.service && used !== undefined) {
+        bstate.serviceLoad.slotsUsed[template.service.id] = used;
+      }
       return {
         id: b.id,
         templateId: kind as string,
@@ -698,9 +725,6 @@ export class WasmSimBridge implements SimBridge {
         state: bstate
       };
     });
-
-    // Recompute education coverage so the debug overlay and HUD stay current.
-    this.state.education = recomputeEducation(this.state);
   }
 }
 

--- a/app/src/workers/wasmSim.worker.ts
+++ b/app/src/workers/wasmSim.worker.ts
@@ -198,9 +198,11 @@ function startStepLoop(): void {
     const buildingsJson = host.buildings_json();
     const powerComponentsJson = host.power_components_json();
     const waterComponentsJson = host.water_components_json();
+    const educationJson = host.education_json();
+    const educationSeatsUsedJson = host.education_seats_used_json();
     const alerts: SimAlertWire[] = JSON.parse(host.take_alerts_json() || '[]');
     self.postMessage(
-      { type: 'step_result', bytes, stats, buildingsJson, powerComponentsJson, waterComponentsJson, mutationSeq, alerts },
+      { type: 'step_result', bytes, stats, buildingsJson, powerComponentsJson, waterComponentsJson, educationJson, educationSeatsUsedJson, mutationSeq, alerts },
       { transfer: [bytes.buffer as ArrayBuffer] },
     );
   }, STEP_INTERVAL_MS);
@@ -389,8 +391,10 @@ self.onmessage = async (e: MessageEvent<MainToWorker>) => {
         const buildingsJson = host.buildings_json();
         const powerComponentsJson = host.power_components_json();
         const waterComponentsJson = host.water_components_json();
+        const educationJson = host.education_json();
+        const educationSeatsUsedJson = host.education_seats_used_json();
         self.postMessage(
-          { type: 'undo_result', happened: true, bytes, stats, buildingsJson, powerComponentsJson, waterComponentsJson, mutationSeq, history: historyFlags(host) },
+          { type: 'undo_result', happened: true, bytes, stats, buildingsJson, powerComponentsJson, waterComponentsJson, educationJson, educationSeatsUsedJson, mutationSeq, history: historyFlags(host) },
           { transfer: [bytes.buffer as ArrayBuffer] },
         );
       } else {
@@ -407,8 +411,10 @@ self.onmessage = async (e: MessageEvent<MainToWorker>) => {
         const buildingsJson = host.buildings_json();
         const powerComponentsJson = host.power_components_json();
         const waterComponentsJson = host.water_components_json();
+        const educationJson = host.education_json();
+        const educationSeatsUsedJson = host.education_seats_used_json();
         self.postMessage(
-          { type: 'redo_result', happened: true, bytes, stats, buildingsJson, powerComponentsJson, waterComponentsJson, mutationSeq, history: historyFlags(host) },
+          { type: 'redo_result', happened: true, bytes, stats, buildingsJson, powerComponentsJson, waterComponentsJson, educationJson, educationSeatsUsedJson, mutationSeq, history: historyFlags(host) },
           { transfer: [bytes.buffer as ArrayBuffer] },
         );
       } else {
@@ -480,6 +486,8 @@ function postLoadResult(h: SimHost, requestId: number): void {
       buildingsJson: h.buildings_json(),
       powerComponentsJson: h.power_components_json(),
       waterComponentsJson: h.water_components_json(),
+      educationJson: h.education_json(),
+      educationSeatsUsedJson: h.education_seats_used_json(),
       mutationSeq,
       history: historyFlags(h),
     },

--- a/crates/city-sim-core/src/education.rs
+++ b/crates/city-sim-core/src/education.rs
@@ -223,6 +223,7 @@ pub fn recompute_education(state: &mut GameState) {
         tile.elementary_score = 0.0;
         tile.high_score = 0.0;
     }
+    state.education_seats_used.clear();
 
     let loads = compute_zone_loads(state);
 
@@ -331,6 +332,10 @@ pub fn recompute_education(state: &mut GameState) {
                 high_served_total += applied;
             }
         }
+
+        state
+            .education_seats_used
+            .insert(state.buildings[i].id, used);
     }
 
     let elementary_coverage = if elementary_load > 0.0 {
@@ -424,6 +429,78 @@ mod tests {
             "residential should be served by nearby school"
         );
         assert!(s.education.elementary_coverage > 0.0);
+    }
+
+    #[test]
+    fn active_school_records_seats_used_under_its_building_id() {
+        let mut s = gs(6, 2);
+        let school_id = place_building(&mut s, TileKind::ElementarySchool, 0, 0);
+        set_v4_kind(s.tile_at_mut(2, 0).unwrap(), TileKind::Road);
+        set_v4_kind(s.tile_at_mut(3, 0).unwrap(), TileKind::Residential);
+        s.tile_at_mut(3, 0).unwrap().set_flag(FLAG_POWERED, true);
+        place_building(&mut s, TileKind::Residential, 3, 0);
+        s.population = 14;
+        update_building_states(&mut s, false);
+        recompute_education(&mut s);
+        let used = s
+            .education_seats_used
+            .get(&school_id)
+            .copied()
+            .expect("active school should record a seats-used entry");
+        assert!((used - 14.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn inactive_school_records_no_seats_used() {
+        let mut s = gs(4, 4);
+        let school_id = place_building(&mut s, TileKind::ElementarySchool, 0, 0);
+        for dx in 0..2 {
+            for dy in 0..2 {
+                s.tile_at_mut(dx, dy).unwrap().set_flag(FLAG_POWERED, false);
+            }
+        }
+        update_building_states(&mut s, false);
+        set_v4_kind(s.tile_at_mut(3, 0).unwrap(), TileKind::Residential);
+        place_building(&mut s, TileKind::Residential, 3, 0);
+        s.population = 14;
+        recompute_education(&mut s);
+        assert!(!s.education_seats_used.contains_key(&school_id));
+    }
+
+    #[test]
+    fn seats_used_is_dropped_once_its_school_is_demolished() {
+        let mut s = gs(6, 2);
+        let school_id = place_building(&mut s, TileKind::ElementarySchool, 0, 0);
+        set_v4_kind(s.tile_at_mut(2, 0).unwrap(), TileKind::Road);
+        set_v4_kind(s.tile_at_mut(3, 0).unwrap(), TileKind::Residential);
+        s.tile_at_mut(3, 0).unwrap().set_flag(FLAG_POWERED, true);
+        place_building(&mut s, TileKind::Residential, 3, 0);
+        s.population = 14;
+        update_building_states(&mut s, false);
+        recompute_education(&mut s);
+        assert!(s.education_seats_used.contains_key(&school_id));
+
+        s.buildings.retain(|b| b.id != school_id);
+        recompute_education(&mut s);
+        assert!(!s.education_seats_used.contains_key(&school_id));
+    }
+
+    #[test]
+    fn seats_used_clamps_at_funded_capacity() {
+        // One residential building holds the city's entire (inflated) population
+        // share, so its load (300) exceeds the elementary school's 180-seat
+        // capacity — `used` must clamp at capacity, not the raw load.
+        let mut s = gs(6, 2);
+        let school_id = place_building(&mut s, TileKind::ElementarySchool, 0, 0);
+        set_v4_kind(s.tile_at_mut(2, 0).unwrap(), TileKind::Road);
+        set_v4_kind(s.tile_at_mut(3, 0).unwrap(), TileKind::Residential);
+        s.tile_at_mut(3, 0).unwrap().set_flag(FLAG_POWERED, true);
+        place_building(&mut s, TileKind::Residential, 3, 0);
+        s.population = 300;
+        update_building_states(&mut s, false);
+        recompute_education(&mut s);
+        let used = s.education_seats_used[&school_id];
+        assert!((used - 180.0).abs() < 0.001, "used={used}");
     }
 
     #[test]

--- a/crates/city-sim-core/src/migrate.rs
+++ b/crates/city-sim-core/src/migrate.rs
@@ -232,6 +232,7 @@ pub(crate) fn v4_to_v5(old: v4::GameState) -> GameState {
         next_building_id: old.next_building_id,
         buildings: old.buildings,
         education: old.education,
+        education_seats_used: std::collections::HashMap::new(),
         budget: old.budget,
         budget_history: old.budget_history,
         policies: old.policies,

--- a/crates/city-sim-core/src/state.rs
+++ b/crates/city-sim-core/src/state.rs
@@ -9,7 +9,7 @@ use crate::rng::SeededRng;
 use crate::wilderness::WildernessStats;
 use city_sim_protocol::commands::Policies;
 use city_sim_protocol::tile_kind::TileKind;
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 
 // ---------------------------------------------------------------------------
 // Tile flags
@@ -438,6 +438,15 @@ pub struct GameState {
     pub buildings: Vec<BuildingInstance>,
     /// Education coverage stats, recomputed each tick by `education::recompute_education`.
     pub education: EducationStats,
+    /// Seats consumed per school building (building id → seats used),
+    /// rebuilt from scratch by every `recompute_education` call, same
+    /// lifecycle as `utility_networks`. `#[serde(skip)]` rather than
+    /// persisted: it's fully recomputed from `buildings`/`tiles`, so
+    /// carrying it across a snapshot boundary would buy nothing and cost a
+    /// `VERSION` bump for bytes nothing needs to load. Empty until the first
+    /// recompute after a fresh `GameState` or a snapshot restore.
+    #[serde(skip)]
+    pub education_seats_used: HashMap<u32, f32>,
     /// Last computed daily budget snapshot.
     pub budget: BudgetStats,
     /// Rolling 200-day budget history for the finance panel.
@@ -488,6 +497,7 @@ impl GameState {
             next_building_id: 1,
             buildings: Vec::new(),
             education: EducationStats::default(),
+            education_seats_used: HashMap::new(),
             budget: BudgetStats::default(),
             budget_history: VecDeque::new(),
             policies: Policies::default(),

--- a/crates/city-sim-core/src/wire.rs
+++ b/crates/city-sim-core/src/wire.rs
@@ -15,7 +15,7 @@
 
 use crate::occupants::Terrain;
 use crate::state::{GameState, Tile, DERIVED_FLAG_MASK};
-use city_sim_protocol::tile_buffer::{encode_happiness, status, TileBufferOffsets};
+use city_sim_protocol::tile_buffer::{encode_happiness, encode_score, status, TileBufferOffsets};
 
 /// The `underground` wire byte: bits 0–2, already absolute — no shift needed.
 #[inline]
@@ -36,8 +36,8 @@ pub fn wire_overhead_byte(tile: &Tile) -> u8 {
 }
 
 /// The `status` wire byte: the three derived flags (same bit positions as
-/// `Tile::flags`, copied verbatim), plus terrain and density in the bits the
-/// old flags byte never used.
+/// `Tile::flags`, copied verbatim), plus terrain, density, and education
+/// served flags in the bits the old flags byte never used.
 #[inline]
 pub fn wire_status_byte(tile: &Tile) -> u8 {
     let mut out = tile.flags & DERIVED_FLAG_MASK;
@@ -45,6 +45,12 @@ pub fn wire_status_byte(tile: &Tile) -> u8 {
         out |= status::WATER_TERRAIN;
     }
     out |= (tile.density as u8) << status::DENSITY_SHIFT;
+    if tile.elementary_served {
+        out |= status::ELEMENTARY_SERVED;
+    }
+    if tile.high_served {
+        out |= status::HIGH_SERVED;
+    }
     out
 }
 
@@ -71,6 +77,8 @@ pub fn encode_tile_buffer(state: &GameState) -> Vec<u8> {
         buf[base + 1] = ((bid >> 8) & 0xFF) as u8;
         // 128 = neutral until the first wilderness recompute fills the field.
         buf[o.wilderness + i] = state.wilderness.local_field.get(i).copied().unwrap_or(128);
+        buf[o.elementary_score + i] = encode_score(tile.elementary_score);
+        buf[o.high_score + i] = encode_score(tile.high_score);
     }
     buf
 }
@@ -122,6 +130,10 @@ mod tests {
         s.tiles[1].elevation = 200;
         s.tiles[1].set_building_id(300);
         s.wilderness.local_field = vec![128, 40];
+        s.tiles[1].elementary_served = true;
+        s.tiles[1].elementary_score = 0.5;
+        s.tiles[1].high_served = true;
+        s.tiles[1].high_score = 1.0;
 
         let buf = encode_tile_buffer(&s);
         let o = TileBufferOffsets::for_size(2);
@@ -138,6 +150,11 @@ mod tests {
         assert_eq!(buf[o.overhead + 1], 0b10);
         assert_eq!(buf[o.status], 0);
         assert_eq!(buf[o.status + 1] & status::POWERED, status::POWERED);
+        assert_eq!(
+            buf[o.status + 1] & status::ELEMENTARY_SERVED,
+            status::ELEMENTARY_SERVED
+        );
+        assert_eq!(buf[o.status + 1] & status::HIGH_SERVED, status::HIGH_SERVED);
         assert_eq!(buf[o.happiness], encode_happiness(1.0)); // Tile::default's happiness
         assert_eq!(buf[o.happiness + 1], encode_happiness(2.0));
         assert_eq!(buf[o.elevation], 0);
@@ -154,6 +171,10 @@ mod tests {
         );
         assert_eq!(buf[o.wilderness], 128);
         assert_eq!(buf[o.wilderness + 1], 40);
+        assert_eq!(buf[o.elementary_score], encode_score(0.0));
+        assert_eq!(buf[o.elementary_score + 1], encode_score(0.5));
+        assert_eq!(buf[o.high_score], encode_score(0.0));
+        assert_eq!(buf[o.high_score + 1], encode_score(1.0));
     }
 
     #[test]
@@ -168,5 +189,22 @@ mod tests {
         assert_eq!(byte & status::ABANDONED, status::ABANDONED);
         assert_eq!(byte & status::WATER_TERRAIN, status::WATER_TERRAIN);
         assert_eq!((byte & status::DENSITY_MASK) >> status::DENSITY_SHIFT, 2);
+        assert_eq!(byte & status::ELEMENTARY_SERVED, 0);
+        assert_eq!(byte & status::HIGH_SERVED, 0);
+    }
+
+    #[test]
+    fn status_byte_packs_education_served_flags() {
+        let mut s = GameState::new(1, 1, 0);
+        s.tiles[0].elementary_served = true;
+        let byte = wire_status_byte(&s.tiles[0]);
+        assert_eq!(byte & status::ELEMENTARY_SERVED, status::ELEMENTARY_SERVED);
+        assert_eq!(byte & status::HIGH_SERVED, 0);
+
+        s.tiles[0].elementary_served = false;
+        s.tiles[0].high_served = true;
+        let byte = wire_status_byte(&s.tiles[0]);
+        assert_eq!(byte & status::ELEMENTARY_SERVED, 0);
+        assert_eq!(byte & status::HIGH_SERVED, status::HIGH_SERVED);
     }
 }

--- a/crates/city-sim-protocol/src/tile_buffer.rs
+++ b/crates/city-sim-protocol/src/tile_buffer.rs
@@ -6,11 +6,11 @@
 //! SoA tile buffer layout shared between the sim and the renderer via
 //! SharedArrayBuffer (web) or a Tauri Channel binary payload (desktop).
 //!
-//! For a W×H map the buffer is divided into eight contiguous field arrays:
+//! For a W×H map the buffer is divided into ten contiguous field arrays:
 //!
 //! ```text
-//! | underground[N] u8 | surface[N] u8 | overhead[N] u8 | status[N] u8 | happiness[N] u8 | elevation[N] u8 | building_id[N*2] u16le | wilderness[N] u8 |
-//! |--- N -------------|--- N ---------|--- N -----------|--- N --------|--- N --------------|--- N --------------|--- N*2 ------------------|--- N --------------|
+//! | underground[N] u8 | surface[N] u8 | overhead[N] u8 | status[N] u8 | happiness[N] u8 | elevation[N] u8 | building_id[N*2] u16le | wilderness[N] u8 | elementary_score[N] u8 | high_score[N] u8 |
+//! |--- N -------------|--- N ---------|--- N -----------|--- N --------|--- N --------------|--- N --------------|--- N*2 ------------------|--- N --------------|--- N --------------------|--- N --------------|
 //! ```
 //!
 //! Where N = W × H. All multi-byte values are little-endian.
@@ -26,15 +26,20 @@
 //!
 //! `status` bit layout: bit0=POWERED, bit1=WATERED, bit2=ABANDONED (mirrors
 //! `city_sim_core::state`'s `FLAG_*` positions directly), bit3=WATER_TERRAIN
-//! (0=Land, 1=Water), bits4-5=density (see `status::DENSITY_SHIFT`), bits6-7
-//! spare. See the `status` module below.
+//! (0=Land, 1=Water), bits4-5=density (see `status::DENSITY_SHIFT`),
+//! bit6=ELEMENTARY_SERVED, bit7=HIGH_SERVED (`#228` — mirrors
+//! `Tile::elementary_served`/`high_served`). See the `status` module below.
 //!
 //! `wilderness` is the per-tile eco value quantised via [`encode_eco`] (128 = neutral).
 //!
+//! `elementary_score`/`high_score` (`#228`) are the per-tile education scores
+//! (`applied / load`, 0.0–1.0) quantised via [`encode_score`]; only meaningful
+//! where the matching `status` served bit is set.
+//!
 //! The TS mirror is in `src/game/protocol/tileBuffer.ts`.
 
-/// Number of bytes per tile in the flat buffer (1+1+1+1+1+1+2+1 = 9).
-pub const BYTES_PER_TILE: usize = 9;
+/// Number of bytes per tile in the flat buffer (1+1+1+1+1+1+2+1+1+1 = 11).
+pub const BYTES_PER_TILE: usize = 11;
 
 /// Byte offsets of each field array, as a function of N (number of tiles).
 pub struct TileBufferOffsets {
@@ -54,6 +59,10 @@ pub struct TileBufferOffsets {
     pub building_id: usize,
     /// `wilderness[N]`  — per-tile eco value quantised to u8 (128 = neutral).
     pub wilderness: usize,
+    /// `elementary_score[N]` — elementary education score quantised to u8, see [`encode_score`].
+    pub elementary_score: usize,
+    /// `high_score[N]`       — high-school education score quantised to u8, see [`encode_score`].
+    pub high_score: usize,
 }
 
 impl TileBufferOffsets {
@@ -67,6 +76,8 @@ impl TileBufferOffsets {
             elevation: n * 5,
             building_id: n * 6,
             wilderness: n * 8,
+            elementary_score: n * 9,
+            high_score: n * 10,
         }
     }
 
@@ -90,6 +101,10 @@ pub mod status {
     /// `Tile::density` (`ZoneDensity as u8`, 0-2), packed at bits 4-5.
     pub const DENSITY_SHIFT: u8 = 4;
     pub const DENSITY_MASK: u8 = 0b11 << DENSITY_SHIFT;
+    /// Mirrors `Tile::elementary_served` — same bit, copied verbatim.
+    pub const ELEMENTARY_SERVED: u8 = 1 << 6;
+    /// Mirrors `Tile::high_served` — same bit, copied verbatim.
+    pub const HIGH_SERVED: u8 = 1 << 7;
 }
 
 /// Encode a happiness float (0.0–2.0) to a u8.
@@ -121,6 +136,18 @@ pub fn decode_eco(v: u8) -> f32 {
     (v as f32 - 128.0) / 127.0 * ECO_RANGE
 }
 
+/// Encode a per-tile education score (0.0–1.0, `applied / load`) to a u8.
+#[inline]
+pub fn encode_score(s: f32) -> u8 {
+    (s.clamp(0.0, 1.0) * 255.0) as u8
+}
+
+/// Decode a u8 education score back to f32.
+#[inline]
+pub fn decode_score(s: u8) -> f32 {
+    s as f32 / 255.0
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -137,7 +164,9 @@ mod tests {
         assert_eq!(off.elevation, 20480);
         assert_eq!(off.building_id, 24576);
         assert_eq!(off.wilderness, 32768);
-        assert_eq!(TileBufferOffsets::total_bytes(n), 36864);
+        assert_eq!(off.elementary_score, 36864);
+        assert_eq!(off.high_score, 40960);
+        assert_eq!(TileBufferOffsets::total_bytes(n), 45056);
     }
 
     #[test]
@@ -155,8 +184,19 @@ mod tests {
     #[test]
     fn bytes_per_tile_matches_layout() {
         // underground(1) + surface(1) + overhead(1) + status(1) + happiness(1)
-        //   + elevation(1) + building_id(2) + wilderness(1) = 9
-        assert_eq!(BYTES_PER_TILE, 9);
+        //   + elevation(1) + building_id(2) + wilderness(1) + elementary_score(1)
+        //   + high_score(1) = 11
+        assert_eq!(BYTES_PER_TILE, 11);
+    }
+
+    #[test]
+    fn score_round_trips_within_tolerance() {
+        for v in [0.0f32, 0.25, 0.5, 0.75, 1.0] {
+            let decoded = decode_score(encode_score(v));
+            assert!((decoded - v).abs() < 0.01, "score {v} → {decoded}");
+        }
+        assert_eq!(encode_score(-1.0), encode_score(0.0));
+        assert_eq!(encode_score(2.0), encode_score(1.0));
     }
 
     #[test]
@@ -182,5 +222,11 @@ mod tests {
             0
         );
         assert_eq!(DENSITY_MASK, 0b0011_0000);
+        assert_eq!(ELEMENTARY_SERVED & HIGH_SERVED, 0);
+        assert_eq!(
+            (ELEMENTARY_SERVED | HIGH_SERVED)
+                & (POWERED | WATERED | ABANDONED | WATER_TERRAIN | DENSITY_MASK),
+            0
+        );
     }
 }

--- a/crates/city-sim-wasm/src/lib.rs
+++ b/crates/city-sim-wasm/src/lib.rs
@@ -9,6 +9,7 @@ use city_sim_core::{
     import::{from_tile_buffer, ImportStats},
     sim::Simulation,
     snapshot,
+    state::EducationStats,
     utilities::{UtilityComponent, UtilityKind},
     wire::encode_tile_buffer,
 };
@@ -506,6 +507,28 @@ impl SimHost {
             .collect();
         serde_json::to_string(&wire).unwrap_or_default()
     }
+
+    /// City-wide education coverage snapshot (`#228`) — see `state::EducationStats`.
+    pub fn education_json(&self) -> String {
+        let wire = WireEducationStats::from(&self.sim.state.education);
+        serde_json::to_string(&wire).unwrap_or_default()
+    }
+
+    /// Seats consumed per school building (`#228`), sorted by building id for
+    /// deterministic output. `used` is left unrounded; round for display in
+    /// TS, not here — see `WireUtilityComponent`'s doc comment for the same
+    /// convention.
+    pub fn education_seats_used_json(&self) -> String {
+        let mut wire: Vec<WireEducationSeatsUsed> = self
+            .sim
+            .state
+            .education_seats_used
+            .iter()
+            .map(|(&building_id, &used)| WireEducationSeatsUsed { building_id, used })
+            .collect();
+        wire.sort_by_key(|e| e.building_id);
+        serde_json::to_string(&wire).unwrap_or_default()
+    }
 }
 
 /// One row of [`SimHost::buildings_json`]'s wire shape.
@@ -543,4 +566,46 @@ impl From<&UtilityComponent> for WireUtilityComponent {
             utilisation: c.utilisation(),
         }
     }
+}
+
+/// Wire shape of [`SimHost::education_json`]. Mirrors `state::EducationStats`
+/// field-for-field; kept as a separate type rather than deriving `Serialize`
+/// directly on the engine struct, matching the `WireBuilding`/
+/// `WireUtilityComponent` precedent of wire-agnostic engine types.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WireEducationStats {
+    elementary_served: f32,
+    elementary_capacity: f32,
+    elementary_load: f32,
+    high_served: f32,
+    high_capacity: f32,
+    high_load: f32,
+    score: f32,
+    elementary_coverage: f32,
+    high_coverage: f32,
+}
+
+impl From<&EducationStats> for WireEducationStats {
+    fn from(s: &EducationStats) -> Self {
+        Self {
+            elementary_served: s.elementary_served,
+            elementary_capacity: s.elementary_capacity,
+            elementary_load: s.elementary_load,
+            high_served: s.high_served,
+            high_capacity: s.high_capacity,
+            high_load: s.high_load,
+            score: s.score,
+            elementary_coverage: s.elementary_coverage,
+            high_coverage: s.high_coverage,
+        }
+    }
+}
+
+/// One row of [`SimHost::education_seats_used_json`]'s wire shape.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WireEducationSeatsUsed {
+    building_id: u32,
+    used: f32,
 }

--- a/crates/tauri-plugin-city-sim/guest-js/index.ts
+++ b/crates/tauri-plugin-city-sim/guest-js/index.ts
@@ -40,6 +40,16 @@ export interface TickEvent {
   powerComponents:    WireUtilityComponent[]
   /** Water network connected components — see {@link powerComponents}. */
   waterComponents:    WireUtilityComponent[]
+  /**
+   * City-wide education coverage snapshot — see
+   * `city_sim_core::state::EducationStats`.
+   */
+  education:            WireEducationStats
+  /**
+   * Seats consumed per school building — see
+   * `city_sim_core::state::GameState::education_seats_used`.
+   */
+  educationSeatsUsed:   WireEducationSeatsUsed[]
   demandResidential:  number   // f32 [0, 100]
   demandCommercial:   number   // f32 [0, 100]
   demandIndustrial:   number   // f32 [0, 100]
@@ -50,12 +60,13 @@ export interface TickEvent {
   /**
    * The exact SoA wire buffer `city_sim_protocol::tile_buffer` describes —
    * `underground[N] | surface[N] | overhead[N] | status[N] | happiness[N] |
-   * elevation[N] | building_id[N×2] | wilderness[N]`, produced by
-   * `city_sim_core::wire::encode_tile_buffer`, the same function the WASM
-   * host's `tile_buffer()` calls. Per-tile `building_id` (u16le, 0 = none)
-   * lets the desktop client read `tile.buildingId` straight off the wire,
-   * the same as WASM, instead of deriving tile coverage from `buildings`
-   * below and a template footprint that could disagree with the engine's own.
+   * elevation[N] | building_id[N×2] | wilderness[N] | elementary_score[N] |
+   * high_score[N]`, produced by `city_sim_core::wire::encode_tile_buffer`,
+   * the same function the WASM host's `tile_buffer()` calls. Per-tile
+   * `building_id` (u16le, 0 = none) lets the desktop client read
+   * `tile.buildingId` straight off the wire, the same as WASM, instead of
+   * deriving tile coverage from `buildings` below and a template footprint
+   * that could disagree with the engine's own.
    */
   tiles:              number[]
   /**
@@ -101,6 +112,26 @@ export interface WireUtilityComponent {
   sourceCount:  number   // u16
   /** `used / produced`, clamped to `[0, 1]`. */
   utilisation:  number   // f32
+}
+
+/** {@link TickEvent.education} — mirrors `city_sim_core::state::EducationStats`. */
+export interface WireEducationStats {
+  elementaryServed:     number   // f32
+  elementaryCapacity:   number   // f32
+  elementaryLoad:       number   // f32
+  highServed:           number   // f32
+  highCapacity:         number   // f32
+  highLoad:             number   // f32
+  /** Combined coverage score in [0, 1]: elementary × 0.6 + high × 0.4. */
+  score:                number   // f32
+  elementaryCoverage:   number   // f32
+  highCoverage:         number   // f32
+}
+
+/** One entry in {@link TickEvent.educationSeatsUsed}, unrounded — round for display in TS. */
+export interface WireEducationSeatsUsed {
+  buildingId:  number   // u32
+  used:        number   // f32, unrounded
 }
 
 /**

--- a/crates/tauri-plugin-city-sim/src/commands.rs
+++ b/crates/tauri-plugin-city-sim/src/commands.rs
@@ -12,7 +12,7 @@ use city_sim_core::history::{History, HistoryConfig};
 use city_sim_core::import::{from_tile_buffer, ImportStats};
 use city_sim_core::sim::Simulation;
 use city_sim_core::snapshot;
-use city_sim_core::state::GameState;
+use city_sim_core::state::{EducationStats, GameState};
 use city_sim_core::utilities::{UtilityComponent, UtilityKind};
 use city_sim_core::wire::encode_tile_buffer;
 use city_sim_protocol::commands::{CommandResult, Policies, Tool, ViewStratum};
@@ -46,6 +46,12 @@ pub struct TickEvent {
     pub power_components: Vec<WireUtilityComponent>,
     /// Water network connected components — see `power_components`.
     pub water_components: Vec<WireUtilityComponent>,
+    /// City-wide education coverage snapshot (`#228`) — see
+    /// `city_sim_core::state::EducationStats`.
+    pub education: WireEducationStats,
+    /// Seats consumed per school building (`#228`) — see
+    /// `city_sim_core::state::GameState::education_seats_used`.
+    pub education_seats_used: Vec<WireEducationSeatsUsed>,
     pub demand_residential: f32,
     pub demand_commercial: f32,
     pub demand_industrial: f32,
@@ -118,6 +124,48 @@ impl From<&UtilityComponent> for WireUtilityComponent {
             utilisation: c.utilisation(),
         }
     }
+}
+
+/// Wire shape of [`TickEvent::education`]. Mirrors `state::EducationStats`
+/// field-for-field; mirrors `SimHost::education_json` on the WASM path, sent
+/// as real values here since Tauri IPC serialises the whole `TickEvent`
+/// natively.
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WireEducationStats {
+    pub elementary_served: f32,
+    pub elementary_capacity: f32,
+    pub elementary_load: f32,
+    pub high_served: f32,
+    pub high_capacity: f32,
+    pub high_load: f32,
+    pub score: f32,
+    pub elementary_coverage: f32,
+    pub high_coverage: f32,
+}
+
+impl From<&EducationStats> for WireEducationStats {
+    fn from(s: &EducationStats) -> Self {
+        Self {
+            elementary_served: s.elementary_served,
+            elementary_capacity: s.elementary_capacity,
+            elementary_load: s.elementary_load,
+            high_served: s.high_served,
+            high_capacity: s.high_capacity,
+            high_load: s.high_load,
+            score: s.score,
+            elementary_coverage: s.elementary_coverage,
+            high_coverage: s.high_coverage,
+        }
+    }
+}
+
+/// One entry in [`TickEvent::education_seats_used`].
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WireEducationSeatsUsed {
+    pub building_id: u32,
+    pub used: f32,
 }
 
 // ── Internal command sent from invoke handlers to the sim thread ──────────────
@@ -221,6 +269,16 @@ fn build_tick_event(sim: &Simulation, history: &History, alerts: Vec<SimAlert>) 
             .iter()
             .map(WireUtilityComponent::from)
             .collect(),
+        education: WireEducationStats::from(&s.education),
+        education_seats_used: {
+            let mut v: Vec<WireEducationSeatsUsed> = s
+                .education_seats_used
+                .iter()
+                .map(|(&building_id, &used)| WireEducationSeatsUsed { building_id, used })
+                .collect();
+            v.sort_by_key(|e| e.building_id);
+            v
+        },
         demand_residential: s.demand.residential,
         demand_commercial: s.demand.commercial,
         demand_industrial: s.demand.industrial,

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -6,6 +6,8 @@ One document per feature: what it is, why it exists, what the code actually does
 
 - [City Narrative](city-narrative.md) — the toggleable storytelling layer over simulation events.
 - [Wilderness Score](wilderness-score.md) — the ecosystem-preservation metric and its consequences.
+- [Utility Network Connected Components](utility-network-components.md) — per-segment power/water stats instead of one pooled city-wide total.
+- [Education Stats and Service Load Over the Wire](education-over-the-wire.md) — the client stops re-deriving school coverage; it reads Rust's answer.
 
 ## Recovery docs (2026-07 migration audit)
 

--- a/docs/features/education-over-the-wire.md
+++ b/docs/features/education-over-the-wire.md
@@ -1,0 +1,25 @@
+# Education Stats and Service Load Over the Wire
+
+**Status:** engine wiring landed (`#228`). `city_sim_core::education::recompute_education` already computed the right numbers every tick; they simply never reached the client. Both bindings now carry `EducationStats` and per-building seats-used, and the TS client reads them instead of independently re-deriving the whole subsystem.
+
+## Purpose
+
+`recompute_education` runs every tick and produces two things: a city-wide `EducationStats` snapshot, and — per active school — how many seats it filled. Neither crossed the wire. `app/src/game/education.ts`'s `recomputeEducation` re-ran the same BFS/greedy-fill algorithm client-side, in both bridges, to populate `state.education`, each building's `serviceLoad.slotsUsed`, and each tile's `services.served`/`scores`. Two implementations of the same algorithm can (and did) disagree — `#226` was a tie-break mismatch between the TS and Rust BFS when a school at capacity had several zone tiles tied at the same distance. Fixing the tie-break alone would have been a stopgap; the next algorithmic drift would reopen the same class of bug. The real fix is for Rust to send its own answer and for TS to stop computing one.
+
+## What shipped
+
+* `GameState::education_seats_used: HashMap<u32, f32>` (`crates/city-sim-core/src/state.rs`) — building id → seats consumed, populated inside `recompute_education`'s existing per-building loop (`crates/city-sim-core/src/education.rs`) instead of discarding `used` after folding it into the city-wide total. `#[serde(skip)]`, same lifecycle as `utility_networks` (`#230`): fully re-derived every tick, no snapshot `VERSION` bump.
+* Per-tile `elementary_served`/`high_served`/`elementary_score`/`high_score` — already computed by `recompute_education`, now carried on the live SoA tile buffer (`crates/city-sim-protocol/src/tile_buffer.rs`): the two previously-spare `status` bits (6–7) for the served flags, plus two new quantised `elementary_score`/`high_score` u8 arrays. `BYTES_PER_TILE` grows 9 → 11 — additive only; the frozen 8-byte `legacy_tile_buffer` used by old `.citysim` imports is untouched, and every reader keys off `TileBufferOffsets` rather than a hardcoded stride.
+* Wire exposure, mirroring `#230`'s `power_components_json`/`water_components_json` pattern: `SimHost::education_json`/`education_seats_used_json` (WASM, `crates/city-sim-wasm/src/lib.rs`) and `TickEvent::education`/`education_seats_used` (Tauri, `crates/tauri-plugin-city-sim/src/commands.rs`), each a local `WireEducationStats`/`WireEducationSeatsUsed` — no shared `city_sim_protocol` type, matching the existing `WireBuilding`/`WireUtilityComponent` duplication.
+* `app/src/game/wasmSimBridge.ts`/`tauriSimBridge.ts` read `state.education` and each school's `serviceLoad.slotsUsed` straight from the wire; `app/src/game/protocol/tileBuffer.ts`'s `decodeTileBuffer` writes `tile.services.served`/`scores` from the new status bits and score bytes. The Education map overlay, the minimap overlay, and the tile inspector's coverage percentage are unchanged in behaviour — they read the same `tile.services` shape, now populated from Rust instead of a client recompute.
+* `app/src/game/education.ts`'s `recomputeEducation` is deleted. `getEducationScore` and `computeEducationReach` (the school-placement preview helper — no engine equivalent, since it previews a building that hasn't been placed yet) stay. `createEmptyEducationStats`'s and `createInitialState`'s defaults now match `EducationStats::default()` (`score`/coverages = `1.0`, not `0`) — a city with no schools has no load anywhere, which is full coverage, not zero.
+
+## Non-goals (this issue)
+
+* Police/fire/health service-load wiring — Rust's `ServiceKind` only has `EducationElementary`/`EducationHigh` today; those services aren't ported to the engine yet.
+* New UI surfacing per-school seats-used beyond what the inspector already showed (`#233`/`#234` track dedicated panels).
+* `#226`'s narrow tie-break fix — superseded: once TS stops computing its own served set, there is no second implementation left to disagree with Rust's.
+
+## See also
+
+`docs/features/utility-network-components.md` — the `#230` precedent this wiring follows (per-tick wire exposure of an already-computed engine value, local per-binding wire structs, `#[serde(skip)]` for fully-derived `GameState` fields).

--- a/docs/features/utility-network-components.md
+++ b/docs/features/utility-network-components.md
@@ -24,3 +24,7 @@
 * Snapshot format changes (none needed — see above).
 
 These are exactly the follow-ups #230 was filed to unblock, not part of it.
+
+## See also
+
+`docs/features/education-over-the-wire.md` (`#228`) follows this same pattern — per-tick wire exposure of an already-computed engine value, local per-binding wire structs, `#[serde(skip)]` for the fully-derived `GameState` field.


### PR DESCRIPTION
## Summary

- **Stops the client from re-deriving school coverage.** `city_sim_core::education::recompute_education` already computes `EducationStats` and per-building seats-used every tick; neither reached the client, so `app/src/game/education.ts`'s `recomputeEducation` independently re-ran the same BFS/greedy-fill algorithm in both bridges. Two implementations of the same algorithm can disagree — that's the root cause of #226's tie-break mismatch. `recomputeEducation` is deleted; both bridges now read Rust's answer straight off the wire.
- **Adds per-building seats-used**, previously computed and thrown away: `GameState::education_seats_used` (a `#[serde(skip)]` map, same lifecycle as `#230`'s `utility_networks`), exposed over both bindings and mapped onto each school's `serviceLoad.slotsUsed` client-side.
- **Extends the live SoA tile buffer** (`BYTES_PER_TILE` 9 → 11) to carry per-tile education served/score, since the Education map overlay, minimap overlay, and tile inspector's coverage percentage all read that data and would otherwise silently break once the client stopped computing it itself. Purely additive — the frozen 8-byte legacy tile buffer used by old `.citysim` imports is untouched.

### User-facing changes

None intended — the Education overlay, minimap overlay, and inspector coverage percentage behave identically, now sourced from the engine instead of a client recompute. `createEmptyEducationStats()`'s defaults (and the initial-state literal) changed from `0` to `1.0` for `score`/coverages, matching `EducationStats::default()` — this only affects the one frame before the first tick lands (or an old legacy save briefly on load), and fixes what would otherwise be a "0% education" flash for a city the engine actually scores at full coverage.

### Maintainer-facing changes

- `crates/city-sim-core`: `education_seats_used` map, populated in `recompute_education`'s existing per-building loop.
- `crates/city-sim-protocol`: tile buffer gains `ELEMENTARY_SERVED`/`HIGH_SERVED` status bits and two quantised score arrays.
- `crates/city-sim-wasm` / `crates/tauri-plugin-city-sim`: `education_json`/`education_seats_used_json` (WASM) and `TickEvent.education`/`educationSeatsUsed` (Tauri), mirroring `#230`'s `power_components_json`/`water_components_json` pattern.
- `app/src/game/protocol/tileBuffer.ts`: decodes the new status bits/score bytes into `tile.services.served`/`scores`.
- `app/src/game/wasmSimBridge.ts` / `tauriSimBridge.ts`: read the wire values instead of calling `recomputeEducation`.
- #226 is already closed upstream (its own body says "closeable as superseded by #228") — will leave a confirming comment once this merges.

### Documentation

- New `docs/features/education-over-the-wire.md`, cross-linked with `docs/features/utility-network-components.md` and added to the feature-docs index.

## Test plan

- [x] `cargo test --workspace` (336 core + 25 protocol + golden-city + soak tests, all green)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `bun run build:wasm` (regenerated after the `#[wasm_bindgen]` additions and the tile-buffer layout change)
- [x] `cd app && bun run test` (291 tests, including new coverage for the wire-adoption path in both bridges and the tile-buffer decode)
- [x] `cd app && bun run lint` (`tsc --noEmit`)
- [ ] Manual: place a school at capacity with tied-distance zone candidates, confirm the inspector's seats-used and the Education overlay's served set match Rust's `(distance, idx)` tie-break order — covered by the Rust-side `(distance, idx)` sort test and the new decode tests, not re-verified by hand in a running browser session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5fXiVGoMk6C1RrVYjXFoV