### PR TITLE
Wire budget_history over the bridge protocol

### DIFF
--- a/app/src/game/economy.test.ts
+++ b/app/src/game/economy.test.ts
@@ -1,3 +1,8 @@
+// economy.test.ts — budget-history bucketing and runway estimation.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
 import { describe, expect, it } from 'vitest';
 import { createInitialState } from './gameState';
 import { computeRunwayDays, getQuarterSummary, getRecentMonths, type BudgetHistoryEntry } from './economy';

--- a/app/src/game/economy.test.ts
+++ b/app/src/game/economy.test.ts
@@ -1,40 +1,24 @@
 import { describe, expect, it } from 'vitest';
 import { createInitialState } from './gameState';
-import {
-  computeRunwayDays,
-  ensureBudgetHistory,
-  getQuarterSummary,
-  getRecentMonths,
-  recordDailyBudget
-} from './economy';
+import { computeRunwayDays, getQuarterSummary, getRecentMonths, type BudgetHistoryEntry } from './economy';
+
+// `#229`: the daily-recording/200-day-cap logic this file used to test
+// (`recordDailyBudget`/`ensureBudgetHistory`) moved to Rust
+// (`economy::record_daily_budget` in `city-sim-core`, covered there) — the
+// client now just reads whatever `state.budgetHistory` array the wire
+// supplies. These tests build that array by hand instead of driving it
+// through a day-by-day client-side recompute.
+
+function entry(day: number, revenue: number, expenses: number): BudgetHistoryEntry {
+  return { day, revenue, expenses, net: revenue - expenses };
+}
 
 describe('budget helpers', () => {
-  it('records one entry per day and trims history', () => {
+  it('summarises last quarter and recent months from a wire-sourced budgetHistory array', () => {
     const state = createInitialState();
-    ensureBudgetHistory(state);
-    state.budget.revenue = 100;
-    state.budget.expenses = 50;
-    state.budget.net = 50;
-    for (let d = 1; d <= 5; d++) {
-      state.day = d;
-      recordDailyBudget(state);
-    }
-    expect(state.budgetHistory.daily.length).toBe(5);
-    expect(state.budgetHistory.lastRecordedDay).toBe(5);
-    const last = state.budgetHistory.daily[state.budgetHistory.daily.length - 1];
-    expect(last.day).toBe(5);
-    expect(last.net).toBe(50);
-  });
-
-  it('summarises last quarter and recent months', () => {
-    const state = createInitialState();
-    ensureBudgetHistory(state);
+    state.budgetHistory = [];
     for (let d = 1; d <= 120; d++) {
-      state.day = d;
-      state.budget.revenue = 100 + d;
-      state.budget.expenses = 50;
-      state.budget.net = state.budget.revenue - state.budget.expenses;
-      recordDailyBudget(state);
+      state.budgetHistory.push(entry(d, 100 + d, 50));
     }
     state.day = 120;
     const quarter = getQuarterSummary(state);
@@ -42,6 +26,15 @@ describe('budget helpers', () => {
     const months = getRecentMonths(state);
     expect(months.length).toBeGreaterThan(0);
     expect(months[0].label.startsWith('Month')).toBe(true);
+  });
+
+  it('treats a missing budgetHistory as empty rather than throwing', () => {
+    const state = createInitialState();
+    // @ts-expect-error — exercising the `?? []` guard against an absent field
+    delete state.budgetHistory;
+    state.day = 10;
+    expect(getQuarterSummary(state).net).toBe(0);
+    expect(getRecentMonths(state).every((m) => m.net === 0 && m.revenue === 0)).toBe(true);
   });
 
   it('computes runway only when burn is negative', () => {

--- a/app/src/game/economy.ts
+++ b/app/src/game/economy.ts
@@ -1,9 +1,15 @@
 import { GameState } from './gameState';
 import { getCalendarPosition, DAYS_PER_MONTH } from './time';
 
-export const BUDGET_HISTORY_LENGTH = 200;
 export const MONTHS_PER_QUARTER = 3;
 
+/**
+ * `#229`: mirrors `city_sim_core::state::BudgetHistoryEntry` exactly. Rust
+ * is the sole source now — the ring buffer, its 200-day cap, and the
+ * day-boundary dedup this used to need client-side all live in
+ * `economy::record_daily_budget`; the wire's `budgetHistory` array is
+ * adopted verbatim by both bridges, see `wasmSimBridge.ts`/`tauriSimBridge.ts`.
+ */
 export interface BudgetHistoryEntry {
   day: number;
   revenue: number;
@@ -11,43 +17,11 @@ export interface BudgetHistoryEntry {
   net: number;
 }
 
-export interface BudgetHistory {
-  daily: BudgetHistoryEntry[];
-  lastRecordedDay: number;
-}
-
 export interface BudgetBucket {
   label: string;
   revenue: number;
   expenses: number;
   net: number;
-}
-
-export function ensureBudgetHistory(state: GameState): BudgetHistory {
-  if (!state.budgetHistory) {
-    state.budgetHistory = { daily: [], lastRecordedDay: 0 };
-  } else {
-    state.budgetHistory.daily = state.budgetHistory.daily ?? [];
-    state.budgetHistory.lastRecordedDay = state.budgetHistory.lastRecordedDay ?? 0;
-  }
-  return state.budgetHistory;
-}
-
-export function recordDailyBudget(state: GameState) {
-  const history = ensureBudgetHistory(state);
-  const currentDay = Math.floor(state.day);
-  if (currentDay <= history.lastRecordedDay) return;
-  const entry: BudgetHistoryEntry = {
-    day: currentDay,
-    revenue: state.budget.revenue,
-    expenses: state.budget.expenses,
-    net: state.budget.net
-  };
-  history.daily.push(entry);
-  while (history.daily.length > BUDGET_HISTORY_LENGTH) {
-    history.daily.shift();
-  }
-  history.lastRecordedDay = currentDay;
 }
 
 function sumBucket(entries: BudgetHistoryEntry[], startDay: number, endDay: number): BudgetBucket {
@@ -60,7 +34,7 @@ function sumBucket(entries: BudgetHistoryEntry[], startDay: number, endDay: numb
 }
 
 export function getRecentMonths(state: GameState): BudgetBucket[] {
-  const history = ensureBudgetHistory(state);
+  const daily = state.budgetHistory ?? [];
   const currentMonth = getCalendarPosition(state.day).month;
   const months: BudgetBucket[] = [];
   for (let i = 0; i < MONTHS_PER_QUARTER; i++) {
@@ -68,7 +42,7 @@ export function getRecentMonths(state: GameState): BudgetBucket[] {
     if (monthNumber < 1) break;
     const startDay = (monthNumber - 1) * DAYS_PER_MONTH + 1;
     const endDay = monthNumber * DAYS_PER_MONTH;
-    const bucket = sumBucket(history.daily, startDay, endDay);
+    const bucket = sumBucket(daily, startDay, endDay);
     const label = `Month ${monthNumber}`;
     months.push({ ...bucket, label });
   }
@@ -76,10 +50,10 @@ export function getRecentMonths(state: GameState): BudgetBucket[] {
 }
 
 export function getQuarterSummary(state: GameState): BudgetBucket {
-  const history = ensureBudgetHistory(state);
+  const daily = state.budgetHistory ?? [];
   const endDay = Math.floor(state.day);
   const startDay = Math.max(1, endDay - DAYS_PER_MONTH * MONTHS_PER_QUARTER + 1);
-  const bucket = sumBucket(history.daily, startDay, endDay);
+  const bucket = sumBucket(daily, startDay, endDay);
   return { ...bucket, label: `Last ${MONTHS_PER_QUARTER} months` };
 }
 

--- a/app/src/game/economy.ts
+++ b/app/src/game/economy.ts
@@ -1,3 +1,8 @@
+// economy.ts — budget-history bucketing (recent months, quarter summary) and runway estimation.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
 import { GameState } from './gameState';
 import { getCalendarPosition, DAYS_PER_MONTH } from './time';
 

--- a/app/src/game/gameState.ts
+++ b/app/src/game/gameState.ts
@@ -9,7 +9,7 @@ import { createDefaultPolicies, type Policies } from './protocol/commands';
 import { defaultHotkeys, type HotkeyBindings } from '../ui/hotkeys';
 import { createDefaultSfxOverrides, type SfxOverrides } from './sfxOverrides';
 import { Occupant, Terrain, ZoneDensity, withOccupant } from './protocol/occupants';
-import type { BudgetHistory } from './economy';
+import type { BudgetHistoryEntry } from './economy';
 import type { EducationStats } from './education';
 import type { BuildingInstance } from './buildings/state';
 import type { ServiceSystemState, TileServiceState } from './services';
@@ -257,7 +257,8 @@ export interface GameState {
   utilities: UtilityStats;
   demand: DemandStats;
   budget: BudgetStats;
-  budgetHistory: BudgetHistory;
+  /** `#229` — Rust-computed, wire-sourced; see `economy.ts`'s doc comment. */
+  budgetHistory: BudgetHistoryEntry[];
   buildings: BuildingInstance[];
   nextBuildingId: number;
   services: ServiceSystemState;
@@ -414,7 +415,7 @@ export function createInitialState(width = 64, height = 64, seed?: number): Game
         }
       }
     },
-    budgetHistory: { daily: [], lastRecordedDay: 0 },
+    budgetHistory: [],
     demand: { residential: 30, commercial: 30, industrial: 30 },
     buildings: [],
     nextBuildingId: 1,

--- a/app/src/game/persistence.test.ts
+++ b/app/src/game/persistence.test.ts
@@ -203,9 +203,16 @@ describe('scalar and structural back-fill', () => {
       delete parsed.education;
       delete parsed.bylaws;
     });
-    expect(state.budgetHistory).toEqual({ daily: [], lastRecordedDay: 0 });
+    expect(state.budgetHistory).toEqual([]);
     expect(state.education).toEqual(createEmptyEducationStats());
     expect(state.bylaws).toEqual(DEFAULT_BYLAWS);
+  });
+
+  it('reads a legacy {daily, lastRecordedDay}-shaped budgetHistory as its bare daily array', () => {
+    const state = degrade((parsed) => {
+      parsed.budgetHistory = { daily: [{ day: 3, revenue: 10, expenses: 5, net: 5 }], lastRecordedDay: 3 };
+    });
+    expect(state.budgetHistory).toEqual([{ day: 3, revenue: 10, expenses: 5, net: 5 }]);
   });
 
   it('back-fills a missing bylaws section without clobbering the rest', () => {

--- a/app/src/game/persistence.test.ts
+++ b/app/src/game/persistence.test.ts
@@ -1,3 +1,8 @@
+// persistence.test.ts — save/load: serialize/deserialize round trips and legacy back-fill.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect } from 'vitest';
 import { serialize, deserialize, copyState } from './persistence';
 import {

--- a/app/src/game/persistence.ts
+++ b/app/src/game/persistence.ts
@@ -1,3 +1,8 @@
+// persistence.ts — save/load: IndexedDB CSAV containers, legacy JSON back-fill, and downloads.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
 import { LOCAL_STORAGE_KEY } from './constants';
 import { DEFAULT_BYLAWS } from './bylaws';
 import {

--- a/app/src/game/persistence.ts
+++ b/app/src/game/persistence.ts
@@ -166,9 +166,15 @@ export function deserialize(payload: string): GameState {
       zonesByType: parsed.budget.breakdown.details.buildings?.zonesByType ?? {}
     };
   }
-  parsed.budgetHistory = parsed.budgetHistory ?? { daily: [], lastRecordedDay: 0 };
-  parsed.budgetHistory.daily = parsed.budgetHistory.daily ?? [];
-  parsed.budgetHistory.lastRecordedDay = parsed.budgetHistory.lastRecordedDay ?? 0;
+  // `#229`: budgetHistory used to be a `{daily, lastRecordedDay}` wrapper —
+  // the wrapper only existed to gate the client's own now-deleted daily
+  // recompute, so a save carrying the old shape reads its `.daily` array
+  // straight through; a save with neither shape starts empty (nothing to
+  // reconstruct once the client-side recompute is gone — the wire overwrites
+  // this on the first tick regardless).
+  parsed.budgetHistory = Array.isArray(parsed.budgetHistory)
+    ? parsed.budgetHistory
+    : (parsed.budgetHistory?.daily ?? []);
   // Fold policies into the grouped `policies` shape. Legacy saves carry flat
   // `budgetPolicy`/`wildernessPolicy` keys; saves from before those features
   // get the neutral defaults.

--- a/app/src/game/tauriSimBridge.test.ts
+++ b/app/src/game/tauriSimBridge.test.ts
@@ -67,11 +67,19 @@ interface WireEducationSeatsUsed {
   used: number;
 }
 
+interface WireBudgetHistoryEntry {
+  day: number;
+  revenue: number;
+  expenses: number;
+  net: number;
+}
+
 interface TickEvent {
   tick: number; day: number; population: number; jobs: number; money: number;
   power: number; water: number; powerProduced: number; waterProduced: number;
   powerComponents: WireUtilityComponent[]; waterComponents: WireUtilityComponent[];
   education: WireEducationStats; educationSeatsUsed: WireEducationSeatsUsed[];
+  budgetHistory: WireBudgetHistoryEntry[];
   demandResidential: number; demandCommercial: number; demandIndustrial: number;
   wildernessScore: number; wildernessTrend: number;
   width: number; height: number;
@@ -94,6 +102,7 @@ function baseTickEvent(overrides: Partial<TickEvent> = {}): TickEvent {
       score: 1, elementaryCoverage: 1, highCoverage: 1
     },
     educationSeatsUsed: [],
+    budgetHistory: [],
     demandResidential: 0, demandCommercial: 0, demandIndustrial: 0,
     wildernessScore: 0, wildernessTrend: 0,
     width: 8, height: 8,
@@ -247,6 +256,19 @@ describe('TauriSimBridge onTick decode', () => {
     expect(s.demand.industrial).toBe(10);
     expect(s.wilderness.score).toBe(33);
     expect(s.wilderness.trend).toBe(-1.5);
+  });
+
+  it('adopts event.budgetHistory verbatim, replacing whatever the mirror held before', async () => {
+    const { bridge, emit } = await makeBridge();
+
+    emit(baseTickEvent({ budgetHistory: [{ day: 1, revenue: 100, expenses: 40, net: 60 }] }));
+    expect(bridge.getState().budgetHistory).toEqual([{ day: 1, revenue: 100, expenses: 40, net: 60 }]);
+
+    emit(baseTickEvent({ budgetHistory: [{ day: 1, revenue: 100, expenses: 40, net: 60 }, { day: 2, revenue: 110, expenses: 45, net: 65 }] }));
+    expect(bridge.getState().budgetHistory).toEqual([
+      { day: 1, revenue: 100, expenses: 40, net: 60 },
+      { day: 2, revenue: 110, expenses: 45, net: 65 },
+    ]);
   });
 
   it('decodes every field from its SoA wire offset, matching the WASM path exactly', async () => {

--- a/app/src/game/tauriSimBridge.ts
+++ b/app/src/game/tauriSimBridge.ts
@@ -298,6 +298,9 @@ export class TauriSimBridge implements SimBridge {
     s.utilities.waterUsed = event.waterProduced - event.water;
     s.utilities.powerComponents = event.powerComponents;
     s.utilities.waterComponents = event.waterComponents;
+    // `#229` — Rust-computed, replaces the old client-side reconstruction;
+    // this bridge never had one (no `recordDailyBudget` call existed here).
+    s.budgetHistory = event.budgetHistory;
 
     // Demand
     s.demand.residential = event.demandResidential;

--- a/app/src/game/wasmSimBridge.test.ts
+++ b/app/src/game/wasmSimBridge.test.ts
@@ -285,6 +285,18 @@ describe('WasmSimBridge undo/redo', () => {
     expect(state.buildings[0].state.serviceLoad.slotsUsed[ServiceId.EducationElementary]).toBe(12);
   });
 
+  it('decodes budgetHistoryJson into state.budgetHistory on step() flush', () => {
+    const { worker, bridge, state } = makeBridge();
+    worker.emit({
+      type: 'step_result', bytes: emptyTileBuffer(), stats: zeroStats(), mutationSeq: 0, alerts: [],
+      budgetHistoryJson: JSON.stringify([{ day: 3, revenue: 100, expenses: 40, net: 60 }]),
+    });
+
+    bridge.step(1 / 20);
+
+    expect(state.budgetHistory).toEqual([{ day: 3, revenue: 100, expenses: 40, net: 60 }]);
+  });
+
   it('discards a pending alert when an undo lands before step() flushes it', () => {
     const { worker, bridge, events } = makeBridge();
     worker.emit({

--- a/app/src/game/wasmSimBridge.ts
+++ b/app/src/game/wasmSimBridge.ts
@@ -18,7 +18,7 @@ import { getBuildingTemplate } from './buildings/templates';
 import { createTileServiceState } from './services';
 import type { LegacyEngineImport, SimBridge } from './simBridge';
 import type { BudgetPolicy, SimCommand, CommandResult } from './protocol/commands';
-import { recordDailyBudget } from './economy';
+import type { BudgetHistoryEntry } from './economy';
 import type { FromSim } from './protocol/events';
 import type { SimStats, SimAlertWire } from '../workers/wasmSim.worker';
 import { deriveNarrativeEventFromAlert } from './protocol/deficitNarrative';
@@ -81,19 +81,19 @@ type WorkerToMain =
   /** Posted only when the WASM's `Last-Modified` changes under a live page. */
   | { type: 'build_update'; build: { lastModified: string | null } }
   | { type: 'init_error';   message: string }
-  | { type: 'step_result';  bytes: Uint8Array; stats: SimStats; buildingsJson: string; powerComponentsJson: string; waterComponentsJson: string; educationJson: string; educationSeatsUsedJson: string; mutationSeq: number; alerts: SimAlertWire[] }
+  | { type: 'step_result';  bytes: Uint8Array; stats: SimStats; buildingsJson: string; powerComponentsJson: string; waterComponentsJson: string; educationJson: string; educationSeatsUsedJson: string; budgetHistoryJson: string; mutationSeq: number; alerts: SimAlertWire[] }
   | { type: 'apply_result'; success: boolean; message: string | null; history: WorkerHistoryFlags }
   | { type: 'undo_result';  happened: false; history: WorkerHistoryFlags }
-  | { type: 'undo_result';  happened: true; bytes: Uint8Array; stats: SimStats; buildingsJson: string; powerComponentsJson: string; waterComponentsJson: string; educationJson: string; educationSeatsUsedJson: string; mutationSeq: number; history: WorkerHistoryFlags }
+  | { type: 'undo_result';  happened: true; bytes: Uint8Array; stats: SimStats; buildingsJson: string; powerComponentsJson: string; waterComponentsJson: string; educationJson: string; educationSeatsUsedJson: string; budgetHistoryJson: string; mutationSeq: number; history: WorkerHistoryFlags }
   | { type: 'redo_result';  happened: false; history: WorkerHistoryFlags }
-  | { type: 'redo_result';  happened: true; bytes: Uint8Array; stats: SimStats; buildingsJson: string; powerComponentsJson: string; waterComponentsJson: string; educationJson: string; educationSeatsUsedJson: string; mutationSeq: number; history: WorkerHistoryFlags }
+  | { type: 'redo_result';  happened: true; bytes: Uint8Array; stats: SimStats; buildingsJson: string; powerComponentsJson: string; waterComponentsJson: string; educationJson: string; educationSeatsUsedJson: string; budgetHistoryJson: string; mutationSeq: number; history: WorkerHistoryFlags }
   | { type: 'snapshot_result'; requestId: number; bytes: Uint8Array }
   | { type: 'load_result'; requestId: number; ok: false; error?: string }
   | {
       type: 'load_result'; requestId: number; ok: true;
       width: number; height: number; seed: number;
       policies: GameState['policies'];
-      bytes: Uint8Array; stats: SimStats; buildingsJson: string; powerComponentsJson: string; waterComponentsJson: string; educationJson: string; educationSeatsUsedJson: string; mutationSeq: number; history: WorkerHistoryFlags;
+      bytes: Uint8Array; stats: SimStats; buildingsJson: string; powerComponentsJson: string; waterComponentsJson: string; educationJson: string; educationSeatsUsedJson: string; budgetHistoryJson: string; mutationSeq: number; history: WorkerHistoryFlags;
     };
 
 /** One entry decoded from a `buildingsJson` payload — see `SimHost::buildings_json` (Rust). */
@@ -131,6 +131,7 @@ export class WasmSimBridge implements SimBridge {
   private pendingWaterComponentsJson = '';
   private pendingEducationJson = '';
   private pendingEducationSeatsUsedJson = '';
+  private pendingBudgetHistoryJson = '';
   private pendingStats: SimStats | null = null;
   private pendingMutationSeq = 0;
   /**
@@ -246,6 +247,7 @@ export class WasmSimBridge implements SimBridge {
         this.pendingWaterComponentsJson,
         this.pendingEducationJson,
         this.pendingEducationSeatsUsedJson,
+        this.pendingBudgetHistoryJson,
       );
       this.pendingTileBuffer = null;
       this.dirtySinceLastStep = true;
@@ -438,6 +440,7 @@ export class WasmSimBridge implements SimBridge {
         this.pendingWaterComponentsJson = msg.waterComponentsJson;
         this.pendingEducationJson = msg.educationJson;
         this.pendingEducationSeatsUsedJson = msg.educationSeatsUsedJson;
+        this.pendingBudgetHistoryJson = msg.budgetHistoryJson;
         this.pendingStats = msg.stats;
         this.pendingMutationSeq = msg.mutationSeq;
         // Staged, not dispatched here — see pendingAlerts' field doc. Concat
@@ -460,7 +463,7 @@ export class WasmSimBridge implements SimBridge {
         this.pendingStats = null;
         this.pendingAlerts = [];
         if (msg.happened) {
-          this.applyTileBuffer(msg.bytes, msg.buildingsJson, msg.powerComponentsJson, msg.waterComponentsJson, msg.educationJson, msg.educationSeatsUsedJson);
+          this.applyTileBuffer(msg.bytes, msg.buildingsJson, msg.powerComponentsJson, msg.waterComponentsJson, msg.educationJson, msg.educationSeatsUsedJson, msg.budgetHistoryJson);
           this.updateStats(msg.stats);
           this.lastAppliedTick = msg.stats.tick;
           this.lastAppliedMutationSeq = msg.mutationSeq;
@@ -476,7 +479,7 @@ export class WasmSimBridge implements SimBridge {
         this.pendingStats = null;
         this.pendingAlerts = [];
         if (msg.happened) {
-          this.applyTileBuffer(msg.bytes, msg.buildingsJson, msg.powerComponentsJson, msg.waterComponentsJson, msg.educationJson, msg.educationSeatsUsedJson);
+          this.applyTileBuffer(msg.bytes, msg.buildingsJson, msg.powerComponentsJson, msg.waterComponentsJson, msg.educationJson, msg.educationSeatsUsedJson, msg.budgetHistoryJson);
           this.updateStats(msg.stats);
           this.lastAppliedTick = msg.stats.tick;
           this.lastAppliedMutationSeq = msg.mutationSeq;
@@ -506,7 +509,7 @@ export class WasmSimBridge implements SimBridge {
         this.pendingAlerts = [];
         this.adoptDimensions(msg.width, msg.height, msg.seed);
         this.state.policies = msg.policies;
-        this.applyTileBuffer(msg.bytes, msg.buildingsJson, msg.powerComponentsJson, msg.waterComponentsJson, msg.educationJson, msg.educationSeatsUsedJson);
+        this.applyTileBuffer(msg.bytes, msg.buildingsJson, msg.powerComponentsJson, msg.waterComponentsJson, msg.educationJson, msg.educationSeatsUsedJson, msg.budgetHistoryJson);
         this.updateStats(msg.stats);
         this.lastAppliedTick = msg.stats.tick;
         this.lastAppliedMutationSeq = msg.mutationSeq;
@@ -624,10 +627,6 @@ export class WasmSimBridge implements SimBridge {
     wild.breakdown.transport     = stats.wildernessTransport;
     wild.breakdown.power         = stats.wildernessPower;
     wild.breakdown.civic         = stats.wildernessCivic;
-    // Record the daily budget history TS-side so the quarterly panel works
-    // on the WASM path (the Rust sim keeps its own history internally but it
-    // isn't carried over the stats wire).
-    recordDailyBudget(this.state);
     this.handler?.({
       type: 'TickStats',
       data: {
@@ -649,6 +648,7 @@ export class WasmSimBridge implements SimBridge {
     waterComponentsJson: string,
     educationJson: string,
     educationSeatsUsedJson: string,
+    budgetHistoryJson: string,
   ): void {
     const n = this.state.tiles.length;
 
@@ -672,6 +672,10 @@ export class WasmSimBridge implements SimBridge {
     const seatsUsed: WireEducationSeatsUsed[] = educationSeatsUsedJson
       ? JSON.parse(educationSeatsUsedJson)
       : [];
+    // `#229` — Rust-computed, replaces the old client-side reconstruction.
+    if (budgetHistoryJson) {
+      this.state.budgetHistory = JSON.parse(budgetHistoryJson) as BudgetHistoryEntry[];
+    }
 
     decodeTileBuffer(this.state.tiles, bytes);
 

--- a/app/src/workers/wasmSim.worker.ts
+++ b/app/src/workers/wasmSim.worker.ts
@@ -200,9 +200,10 @@ function startStepLoop(): void {
     const waterComponentsJson = host.water_components_json();
     const educationJson = host.education_json();
     const educationSeatsUsedJson = host.education_seats_used_json();
+    const budgetHistoryJson = host.budget_history_json();
     const alerts: SimAlertWire[] = JSON.parse(host.take_alerts_json() || '[]');
     self.postMessage(
-      { type: 'step_result', bytes, stats, buildingsJson, powerComponentsJson, waterComponentsJson, educationJson, educationSeatsUsedJson, mutationSeq, alerts },
+      { type: 'step_result', bytes, stats, buildingsJson, powerComponentsJson, waterComponentsJson, educationJson, educationSeatsUsedJson, budgetHistoryJson, mutationSeq, alerts },
       { transfer: [bytes.buffer as ArrayBuffer] },
     );
   }, STEP_INTERVAL_MS);
@@ -393,8 +394,9 @@ self.onmessage = async (e: MessageEvent<MainToWorker>) => {
         const waterComponentsJson = host.water_components_json();
         const educationJson = host.education_json();
         const educationSeatsUsedJson = host.education_seats_used_json();
+        const budgetHistoryJson = host.budget_history_json();
         self.postMessage(
-          { type: 'undo_result', happened: true, bytes, stats, buildingsJson, powerComponentsJson, waterComponentsJson, educationJson, educationSeatsUsedJson, mutationSeq, history: historyFlags(host) },
+          { type: 'undo_result', happened: true, bytes, stats, buildingsJson, powerComponentsJson, waterComponentsJson, educationJson, educationSeatsUsedJson, budgetHistoryJson, mutationSeq, history: historyFlags(host) },
           { transfer: [bytes.buffer as ArrayBuffer] },
         );
       } else {
@@ -413,8 +415,9 @@ self.onmessage = async (e: MessageEvent<MainToWorker>) => {
         const waterComponentsJson = host.water_components_json();
         const educationJson = host.education_json();
         const educationSeatsUsedJson = host.education_seats_used_json();
+        const budgetHistoryJson = host.budget_history_json();
         self.postMessage(
-          { type: 'redo_result', happened: true, bytes, stats, buildingsJson, powerComponentsJson, waterComponentsJson, educationJson, educationSeatsUsedJson, mutationSeq, history: historyFlags(host) },
+          { type: 'redo_result', happened: true, bytes, stats, buildingsJson, powerComponentsJson, waterComponentsJson, educationJson, educationSeatsUsedJson, budgetHistoryJson, mutationSeq, history: historyFlags(host) },
           { transfer: [bytes.buffer as ArrayBuffer] },
         );
       } else {
@@ -488,6 +491,7 @@ function postLoadResult(h: SimHost, requestId: number): void {
       waterComponentsJson: h.water_components_json(),
       educationJson: h.education_json(),
       educationSeatsUsedJson: h.education_seats_used_json(),
+      budgetHistoryJson: h.budget_history_json(),
       mutationSeq,
       history: historyFlags(h),
     },

--- a/crates/city-sim-wasm/src/lib.rs
+++ b/crates/city-sim-wasm/src/lib.rs
@@ -9,7 +9,7 @@ use city_sim_core::{
     import::{from_tile_buffer, ImportStats},
     sim::Simulation,
     snapshot,
-    state::EducationStats,
+    state::{BudgetHistoryEntry, EducationStats},
     utilities::{UtilityComponent, UtilityKind},
     wire::encode_tile_buffer,
 };
@@ -529,6 +529,18 @@ impl SimHost {
         wire.sort_by_key(|e| e.building_id);
         serde_json::to_string(&wire).unwrap_or_default()
     }
+
+    /// Rolling 200-day budget history (`#229`) — see `state::BudgetHistoryEntry`.
+    pub fn budget_history_json(&self) -> String {
+        let wire: Vec<WireBudgetHistoryEntry> = self
+            .sim
+            .state
+            .budget_history
+            .iter()
+            .map(WireBudgetHistoryEntry::from)
+            .collect();
+        serde_json::to_string(&wire).unwrap_or_default()
+    }
 }
 
 /// One row of [`SimHost::buildings_json`]'s wire shape.
@@ -608,4 +620,28 @@ impl From<&EducationStats> for WireEducationStats {
 struct WireEducationSeatsUsed {
     building_id: u32,
     used: f32,
+}
+
+/// One row of [`SimHost::budget_history_json`]'s wire shape. A local
+/// duplicate rather than deriving `Serialize` directly on the engine's
+/// `BudgetHistoryEntry`, matching the `WireBuilding`/`WireUtilityComponent`
+/// precedent of wire-agnostic engine types.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WireBudgetHistoryEntry {
+    day: u32,
+    revenue: f32,
+    expenses: f32,
+    net: f32,
+}
+
+impl From<&BudgetHistoryEntry> for WireBudgetHistoryEntry {
+    fn from(e: &BudgetHistoryEntry) -> Self {
+        Self {
+            day: e.day,
+            revenue: e.revenue,
+            expenses: e.expenses,
+            net: e.net,
+        }
+    }
 }

--- a/crates/tauri-plugin-city-sim/guest-js/index.ts
+++ b/crates/tauri-plugin-city-sim/guest-js/index.ts
@@ -50,6 +50,14 @@ export interface TickEvent {
    * `city_sim_core::state::GameState::education_seats_used`.
    */
   educationSeatsUsed:   WireEducationSeatsUsed[]
+  /**
+   * Rolling 200-day budget history — see
+   * `city_sim_core::state::BudgetHistoryEntry`. Note this `TickEvent` carries
+   * no headline `revenue`/`expenses`/`net` fields at all yet — the desktop
+   * budget modal's ledger becomes real once this is adopted, but its
+   * top-line numbers are a separate, pre-existing gap.
+   */
+  budgetHistory:      WireBudgetHistoryEntry[]
   demandResidential:  number   // f32 [0, 100]
   demandCommercial:   number   // f32 [0, 100]
   demandIndustrial:   number   // f32 [0, 100]
@@ -132,6 +140,14 @@ export interface WireEducationStats {
 export interface WireEducationSeatsUsed {
   buildingId:  number   // u32
   used:        number   // f32, unrounded
+}
+
+/** One entry in {@link TickEvent.budgetHistory}. */
+export interface WireBudgetHistoryEntry {
+  day:       number   // u32
+  revenue:   number   // f32
+  expenses:  number   // f32
+  net:       number   // f32
 }
 
 /**

--- a/crates/tauri-plugin-city-sim/src/commands.rs
+++ b/crates/tauri-plugin-city-sim/src/commands.rs
@@ -12,7 +12,7 @@ use city_sim_core::history::{History, HistoryConfig};
 use city_sim_core::import::{from_tile_buffer, ImportStats};
 use city_sim_core::sim::Simulation;
 use city_sim_core::snapshot;
-use city_sim_core::state::{EducationStats, GameState};
+use city_sim_core::state::{BudgetHistoryEntry, EducationStats, GameState};
 use city_sim_core::utilities::{UtilityComponent, UtilityKind};
 use city_sim_core::wire::encode_tile_buffer;
 use city_sim_protocol::commands::{CommandResult, Policies, Tool, ViewStratum};
@@ -52,6 +52,12 @@ pub struct TickEvent {
     /// Seats consumed per school building (`#228`) — see
     /// `city_sim_core::state::GameState::education_seats_used`.
     pub education_seats_used: Vec<WireEducationSeatsUsed>,
+    /// Rolling 200-day budget history (`#229`) — see
+    /// `city_sim_core::state::BudgetHistoryEntry`. Note this `TickEvent`
+    /// carries no headline `BudgetStats` fields (`revenue`/`expenses`/`net`)
+    /// at all yet — the desktop budget modal's ledger becomes real once this
+    /// ships, but its top-line numbers are a separate, pre-existing gap.
+    pub budget_history: Vec<WireBudgetHistoryEntry>,
     pub demand_residential: f32,
     pub demand_commercial: f32,
     pub demand_industrial: f32,
@@ -168,6 +174,29 @@ pub struct WireEducationSeatsUsed {
     pub used: f32,
 }
 
+/// One entry in [`TickEvent::budget_history`]. Mirrors
+/// `SimHost::budget_history_json` on the WASM path, sent as real values here
+/// since Tauri IPC serialises the whole `TickEvent` natively.
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WireBudgetHistoryEntry {
+    pub day: u32,
+    pub revenue: f32,
+    pub expenses: f32,
+    pub net: f32,
+}
+
+impl From<&BudgetHistoryEntry> for WireBudgetHistoryEntry {
+    fn from(e: &BudgetHistoryEntry) -> Self {
+        Self {
+            day: e.day,
+            revenue: e.revenue,
+            expenses: e.expenses,
+            net: e.net,
+        }
+    }
+}
+
 // ── Internal command sent from invoke handlers to the sim thread ──────────────
 
 pub enum SimCmd {
@@ -279,6 +308,11 @@ fn build_tick_event(sim: &Simulation, history: &History, alerts: Vec<SimAlert>) 
             v.sort_by_key(|e| e.building_id);
             v
         },
+        budget_history: s
+            .budget_history
+            .iter()
+            .map(WireBudgetHistoryEntry::from)
+            .collect(),
         demand_residential: s.demand.residential,
         demand_commercial: s.demand.commercial,
         demand_industrial: s.demand.industrial,


### PR DESCRIPTION
## Summary

- **Stops the client from reconstructing its own budget ledger.** Rust already maintains `state.budget_history: VecDeque<BudgetHistoryEntry>` (capped at 200 days, round-trips through CSIM snapshots), but it never crossed the wire — `app/src/game/economy.ts`'s `recordDailyBudget` independently rebuilt the same 200-day ledger client-side by sampling `state.budget` once per day-tick. If the client missed a tick boundary (backgrounded tab, a speed-multiplier edge case, a reload mid-day), its reconstructed series could silently desync from Rust's real history with no way to cross-check. Both bridges now read the wire value directly.
- **Simplifies `GameState.budgetHistory`** from a `{daily, lastRecordedDay}` wrapper to a bare `BudgetHistoryEntry[]` — the wrapper only existed to gate the client's own day-boundary dedup, which is deleted along with the 200-entry cap (`BUDGET_HISTORY_LENGTH`) now that both live solely in `economy::record_daily_budget` on the Rust side.

Much smaller than #251 (#228) — no new engine computation, purely wire exposure of an already-computed, already-persisted field.

### User-facing changes

None intended — the budget modal's quarterly ledger (`getRecentMonths`/`getQuarterSummary`, unchanged) reads the same shape, now sourced from the engine instead of a client recompute that could drift from it.

### Maintainer-facing changes

- `crates/city-sim-wasm`: `SimHost::budget_history_json()`, serialising a local `WireBudgetHistoryEntry` (duplicate-per-binding, matching the `WireBuilding`/`WireUtilityComponent` precedent rather than reusing the persisted engine type directly).
- `crates/tauri-plugin-city-sim`: `TickEvent.budgetHistory`, same wire struct, mirrored in `guest-js/index.ts`.
- **Side-finding, flagged but out of scope:** Tauri's `TickEvent` carries no headline `revenue`/`expenses`/`net` fields at all — the desktop budget modal's top-line numbers are zero today regardless of this PR. Worth its own follow-up issue; noted in the `TickEvent.budgetHistory` field doc comment rather than folded in here.
- `app/src/game/economy.ts`: `recordDailyBudget`/`ensureBudgetHistory`/`BUDGET_HISTORY_LENGTH` deleted; `getRecentMonths`/`getQuarterSummary`/`computeRunwayDays` kept, reading `state.budgetHistory` directly.
- `app/src/game/persistence.ts`: back-fill accepts either the old `{daily: [...]}` shape or a missing field; no reconstruction attempted for legacy JSON imports — there's no trustworthy source once the client-side recompute is gone, and the wire overwrites the mirror on the first tick regardless.

## Test plan

- [x] `cargo test --workspace` (331 core + 24 protocol tests, golden-city, soak — all green)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `bun run build:wasm` (regenerated after the `#[wasm_bindgen]` addition)
- [x] `cd app && bun run test` (290 tests, including new coverage for the wire-adoption path in both bridges, a legacy-save-shape back-fill test, and updated `economy.test.ts` fixtures built by hand instead of driven through the deleted client recompute)
- [x] `cd app && bun run lint` (`tsc --noEmit`)
- [ ] Manual: background the tab for several in-game days, foreground, confirm the budget modal's ledger matches Rust's `budget_history` with no gaps/duplicates — covered by the automated wire-adoption tests, not re-verified by hand in a running browser session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5fXiVGoMk6C1RrVYjXFoV