### PR TITLE
Fix reset() orphaning the render mirror in WasmSimBridge

### DIFF
--- a/app/src/game/wasmSimBridge.test.ts
+++ b/app/src/game/wasmSimBridge.test.ts
@@ -183,6 +183,33 @@ describe('WasmSimBridge undo/redo', () => {
     expect(state.tiles).toHaveLength(before);
   });
 
+  it('newCity mutates the existing mirror in place instead of orphaning main.ts\'s reference', async () => {
+    // Regression test: newCity() used to do `this.state = fresh`, rebinding
+    // the bridge's mirror to a new object. main.ts holds the object handed
+    // to the constructor (`state` here) for the lifetime of the page and
+    // never re-reads it from `bridge.getState()`, so that rebind orphaned
+    // main.ts's reference on the pre-reset city forever — the renderer/HUD
+    // kept redrawing stale data while `getState()`/MCP tools correctly saw
+    // the new one. Found via an MCP playtest calling the `reset` tool.
+    const { worker, state, bridge } = makeBridge();
+    const fresh = createInitialState(4, 4, 99);
+    const pending = bridge.newCity(fresh);
+    await Promise.resolve(); // let the readyPromise chain post the message
+    const sent = worker.sent.find(m => m.type === 'new_city');
+    expect(sent).toBeDefined();
+    const requestId = (sent!.payload as { requestId: number }).requestId;
+    worker.emit({
+      type: 'load_result', requestId, ok: true,
+      width: 4, height: 4, seed: 99, policies: fresh.policies,
+      bytes: new Uint8Array(4 * 4 * 8), stats: { ...zeroStats(), money: fresh.money },
+      history: flags(false, false)
+    });
+    await pending;
+    expect(bridge.getState()).toBe(state);
+    expect(state.width).toBe(4);
+    expect(state.seed).toBe(99);
+  });
+
   it('emits HistoryChanged only on flag transitions', () => {
     const { worker, bridge, events } = makeBridge();
     const historyEvents = () => events.filter(e => e.type === 'HistoryChanged');

--- a/app/src/game/wasmSimBridge.ts
+++ b/app/src/game/wasmSimBridge.ts
@@ -343,7 +343,11 @@ export class WasmSimBridge implements SimBridge {
   /** Start a fresh city from a newly generated mirror state. */
   async newCity(fresh: GameState): Promise<void> {
     await this.readyPromise;
-    this.state = fresh;
+    // Copy fresh's fields onto the existing state object rather than
+    // rebinding `this.state` — main.ts holds the same reference for
+    // rendering/HUD (see constructor), and rebinding here would orphan
+    // that reference on the pre-reset city forever.
+    Object.assign(this.state, fresh);
     return this.requestLoad(requestId => {
       this.worker.postMessage({
         type: 'new_city',


### PR DESCRIPTION
## Summary
- **Fixes a bug found while MCP-playtesting `#253`** (the `v0.4.0` release-prep branch): calling the MCP `reset` tool left the canvas and HUD frozen on the previous city forever, even though `get_state`/`get_tile`/`apply_tool` all correctly operated on the new one.
- **Root cause:** `main.ts` holds one `GameState` object for the page's lifetime and passes it into `WasmSimBridge` by reference; every normal mutator (`updateStats`, `applyTileBuffer`, `loadSnapshot`'s `load_result` handler) writes onto that object in place so the renderer/HUD stay in sync. `newCity()` was the one path that broke this contract with `this.state = fresh`, rebinding the bridge's mirror to a brand-new object and orphaning `main.ts`'s reference on the pre-reset city.
- **Fix:** `newCity()` now does `Object.assign(this.state, fresh)`, mutating the shared object in place like every other mutator, instead of rebinding it.

### Why this went unnoticed
`bridge.newCity()` is currently called from exactly one place in the whole app — `mcpBridge.ts`'s `reset` handler. There's no in-game "New Game" button wired up yet, so ordinary play never exercised this path; only MCP-driven scripts (like this playtest) do.

### Known follow-up (not fixed here)
`TauriSimBridge`'s constructor already does `this.state = structuredClone(state)` at construction time — a separate, pre-existing identity break unrelated to `newCity()`. I can't verify its real-world impact without a Tauri runtime in this environment, so it's intentionally left untouched. Worth its own follow-up issue if it turns out to matter for the desktop build.

### Test coverage
Added a regression test (`wasmSimBridge.test.ts`) pinning `bridge.getState()`'s object identity across `newCity()`, mirroring the existing `loadSnapshot` mirror test that already covers this invariant for that path.

## Test plan
- [x] `bun run test` — 295/295 passing (includes the new regression test)
- [x] `bun run lint` (`tsc --noEmit`) — clean
- [x] Manually verified via the MCP `city-sim` tools: `reset` → `screenshot` now shows the fresh city immediately, and the HUD money/day match the new city instead of the stale pre-reset one