### PR TITLE
MCP server tidy-up: real command results, per-stratum tile detail, fresh-worktree fix

### DIFF
--- a/app/src/game/mcpBridge.test.ts
+++ b/app/src/game/mcpBridge.test.ts
@@ -4,8 +4,10 @@
 // SPDX-License-Identifier: MIT
 
 import { describe, it, expect } from 'vitest';
-import { stratumParam, createCommandResultQueue, summarizeApplyResults } from './mcpBridge';
+import { stratumParam, createCommandResultQueue, summarizeApplyResults, tileMatchesKind } from './mcpBridge';
 import { Tool } from './toolTypes';
+import { createInitialState, getTile, setTile, TileKind } from './gameState';
+import { Occupant, Terrain, setTileOccupant } from './protocol/occupants';
 
 describe('stratumParam', () => {
   it('defaults to surface when the param is absent', () => {
@@ -89,5 +91,38 @@ describe('summarizeApplyResults', () => {
 
   it('handles an empty batch', () => {
     expect(summarizeApplyResults([])).toEqual({ placed: 0, attempted: 0, firstFailureMessage: null });
+  });
+});
+
+describe('tileMatchesKind', () => {
+  it('without anyStratum, matches only the dominant (display) label — a road under a power line does not match "road"', () => {
+    const state = createInitialState(3, 3);
+    setTile(state, 1, 1, TileKind.Road);
+    const tile = getTile(state, 1, 1)!;
+    setTileOccupant(tile, Occupant.PowerLine, true);
+
+    expect(tileMatchesKind(state, tile, TileKind.PowerLine, false)).toBe(true);
+    expect(tileMatchesKind(state, tile, TileKind.Road, false)).toBe(false); // hidden behind the power line
+  });
+
+  it('with anyStratum, matches a kind present in any stratum, not just the dominant one', () => {
+    const state = createInitialState(3, 3);
+    setTile(state, 1, 1, TileKind.Road);
+    const tile = getTile(state, 1, 1)!;
+    setTileOccupant(tile, Occupant.PowerLine, true);
+    setTileOccupant(tile, Occupant.Pipe, true);
+
+    expect(tileMatchesKind(state, tile, TileKind.PowerLine, true)).toBe(true);
+    expect(tileMatchesKind(state, tile, TileKind.Road, true)).toBe(true); // no longer hidden
+    expect(tileMatchesKind(state, tile, TileKind.WaterPipe, true)).toBe(true);
+    expect(tileMatchesKind(state, tile, TileKind.Rail, true)).toBe(false);
+  });
+
+  it('anyStratum does not change the result for a tile with only one occupant', () => {
+    const state = createInitialState(3, 3);
+    const tile = getTile(state, 1, 1)!;
+    tile.terrain = Terrain.Land; // procedural generation may have placed water here
+    expect(tileMatchesKind(state, tile, TileKind.Land, false)).toBe(true);
+    expect(tileMatchesKind(state, tile, TileKind.Land, true)).toBe(false); // "land" is the absence of occupants, not an occupant itself
   });
 });

--- a/app/src/game/mcpBridge.test.ts
+++ b/app/src/game/mcpBridge.test.ts
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 import { describe, it, expect } from 'vitest';
-import { stratumParam } from './mcpBridge';
+import { stratumParam, createCommandResultQueue, summarizeApplyResults } from './mcpBridge';
 import { Tool } from './toolTypes';
 
 describe('stratumParam', () => {
@@ -28,5 +28,66 @@ describe('stratumParam', () => {
 
   it('still honours an explicit "surface" override on water_pipe (the engine will refuse it)', () => {
     expect(stratumParam({ tool: Tool.WaterPipe, stratum: 'surface' })).toBe('surface');
+  });
+});
+
+describe('createCommandResultQueue', () => {
+  it('resolves pending entries in FIFO order, matching send order to arrival order', async () => {
+    const queue = createCommandResultQueue();
+    const first = queue.expectNext().promise;
+    const second = queue.expectNext().promise;
+    const third = queue.expectNext().promise;
+    // Arrival order mirrors send order (the worker is single-threaded and
+    // processes ApplyTool messages in the order it received them) — the
+    // queue doesn't need to see any id to match these correctly.
+    queue.resolveNext({ success: true });
+    queue.resolveNext({ success: false, message: 'no funds' });
+    queue.resolveNext({ success: true });
+    await expect(first).resolves.toEqual({ success: true });
+    await expect(second).resolves.toEqual({ success: false, message: 'no funds' });
+    await expect(third).resolves.toEqual({ success: true });
+  });
+
+  it('cancel() drops the entry so a later result skips it, not misattributes to it', async () => {
+    const queue = createCommandResultQueue();
+    const { promise: dropped, cancel } = queue.expectNext();
+    const next = queue.expectNext().promise;
+    cancel();
+    // Only one real result arrives (as if `dropped`'s send timed out and was
+    // cancelled) — it must resolve `next`, not the already-abandoned `dropped`.
+    queue.resolveNext({ success: true });
+    await expect(next).resolves.toEqual({ success: true });
+    // `dropped` never resolves — proven indirectly: if resolveNext had
+    // matched it instead of `next`, the assertion above would have failed
+    // (there would be nothing left to resolve `next`).
+    void dropped;
+  });
+
+  it('resolveNext with nothing pending is a no-op, not a throw', () => {
+    const queue = createCommandResultQueue();
+    expect(() => queue.resolveNext({ success: true })).not.toThrow();
+  });
+});
+
+describe('summarizeApplyResults', () => {
+  it('counts an all-success batch as fully placed, with no failure message', () => {
+    expect(summarizeApplyResults([{ success: true }, { success: true }])).toEqual({
+      placed: 2, attempted: 2, firstFailureMessage: null,
+    });
+  });
+
+  it('counts failures out of the placed total and surfaces the first failure message', () => {
+    const results = [
+      { success: true },
+      { success: false, message: 'wrong stratum' },
+      { success: false, message: 'insufficient funds' },
+    ];
+    expect(summarizeApplyResults(results)).toEqual({
+      placed: 1, attempted: 3, firstFailureMessage: 'wrong stratum',
+    });
+  });
+
+  it('handles an empty batch', () => {
+    expect(summarizeApplyResults([])).toEqual({ placed: 0, attempted: 0, firstFailureMessage: null });
   });
 });

--- a/app/src/game/mcpBridge.ts
+++ b/app/src/game/mcpBridge.ts
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: MIT
 
 import type { SimBridge } from './simBridge';
-import type { GameState, ViewStratum } from './gameState';
+import type { GameState, Tile, ViewStratum } from './gameState';
 import { createInitialState } from './gameState';
 import { Tool } from './toolTypes';
 import { getCalendarPosition } from './time';
@@ -104,6 +104,21 @@ export function summarizeApplyResults(results: CommandResultLike[]) {
     attempted: results.length,
     firstFailureMessage: failures[0]?.message ?? null,
   };
+}
+
+/**
+ * `get_tiles_where`'s matcher. By default matches `dominantOccupantLabel`
+ * only — the same single collapsed label `get_tile`'s `kind` returns — so a
+ * road hidden under a power line won't match `kind: "road"`. `anyStratum`
+ * widens the check to `occupantsByStratum`'s full per-layer breakdown, so
+ * a script can find every tile carrying a kind regardless of what's winning
+ * the display slot. Exported (only) so it's unit-testable — see
+ * `stratumParam`'s doc comment.
+ */
+export function tileMatchesKind(state: GameState, tile: Tile, kind: string, anyStratum: boolean): boolean {
+  if (!anyStratum) return dominantOccupantLabel(state, tile) === kind;
+  const occupants = occupantsByStratum(state, tile);
+  return occupants.underground.includes(kind) || occupants.surface.includes(kind) || occupants.overhead.includes(kind);
 }
 
 // Use setTimeout rather than rAF — background/unfocused Chromium tabs throttle
@@ -230,10 +245,9 @@ export function initMcpBridge(
         case 'get_tiles_where': {
           const s = bridge.getState();
           const kind = params.kind as string;
+          const anyStratum = params.anyStratum === true;
           const hits = s.tiles.flatMap((t, i) =>
-            dominantOccupantLabel(s, t) === kind
-              ? [{ x: i % s.width, y: Math.floor(i / s.width) }]
-              : [],
+            tileMatchesKind(s, t, kind, anyStratum) ? [{ x: i % s.width, y: Math.floor(i / s.width) }] : [],
           );
           reply(id, hits);
           break;

--- a/app/src/game/mcpBridge.ts
+++ b/app/src/game/mcpBridge.ts
@@ -13,6 +13,7 @@ import { createInitialState } from './gameState';
 import { Tool } from './toolTypes';
 import { getCalendarPosition } from './time';
 import { nextStrokeId } from './protocol/commands';
+import type { FromSim } from './protocol/events';
 import { dominantOccupantLabel } from './protocol/tileLabel';
 
 // Bresenham's line — returns all integer (x,y) pairs from (x0,y0) to (x1,y1).
@@ -38,11 +39,7 @@ const MCP_WS_PORT = 5174;
 // the surface, with an explicit `stratum` param letting a script override it.
 // `Tool.WaterPipe` defaults to underground instead: the engine refuses it
 // outright from any other stratum (`#198`), same as the real UI auto-switches
-// the view the moment the tool is selected (`SPEC.md`'s Water Pipe entry) —
-// without this, every `apply_tool_line`/`apply_tool_rect` water-pipe script
-// that doesn't pass `stratum: 'underground'` explicitly would place nothing
-// while still reporting a `placed` count, since those two handlers fire
-// commands without checking each one's `CommandResult`.
+// the view the moment the tool is selected (`SPEC.md`'s Water Pipe entry).
 // Exported (only) so it's unit-testable — everything else here needs a live
 // WebSocket connection to exercise.
 export function stratumParam(params: Record<string, unknown>): ViewStratum {
@@ -52,13 +49,74 @@ export function stratumParam(params: Record<string, unknown>): ViewStratum {
   return params.tool === Tool.WaterPipe ? 'underground' : 'surface';
 }
 
+/** The bits of `CommandResult` a caller needs — kept separate from `FromSim`
+ * so this file stays testable without importing the full protocol union. */
+export interface CommandResultLike {
+  success: boolean;
+  message?: string;
+}
+
+/**
+ * Correlates `ApplyTool` sends to the `CommandResult`s the worker reports
+ * back for them. The wire message carries no id (`{ type: 'CommandResult',
+ * success, message }` — see `protocol/events.ts`), but the worker posts
+ * exactly one `apply_result` per `apply_tool` message it receives, in the
+ * order received (`wasmSim.worker.ts`'s `case 'apply_tool'`), so matching
+ * each pending send to the oldest still-unresolved entry is reliable *as
+ * long as MCP mode is the only source of `ApplyTool` commands* — true for
+ * scripted play, not for a human clicking the same tab at the same time.
+ * Exported (only) so it's unit-testable — see `stratumParam`'s doc comment.
+ */
+export function createCommandResultQueue() {
+  const pending: Array<(result: CommandResultLike) => void> = [];
+  return {
+    /**
+     * Call once per `ApplyTool` send, in send order. `cancel` drops the
+     * entry without resolving it — callers that give up waiting (a timeout)
+     * must call it, or a later, unrelated `CommandResult` would shift into
+     * this slot and resolve the wrong send.
+     */
+    expectNext(): { promise: Promise<CommandResultLike>; cancel: () => void } {
+      let resolve!: (result: CommandResultLike) => void;
+      const promise = new Promise<CommandResultLike>(res => { resolve = res; });
+      pending.push(resolve);
+      return { promise, cancel: () => {
+        const i = pending.indexOf(resolve);
+        if (i !== -1) pending.splice(i, 1);
+      } };
+    },
+    /** Call once per `CommandResult` message received, in arrival order. */
+    resolveNext(result: CommandResultLike): void {
+      pending.shift()?.(result);
+    },
+  };
+}
+
+/** Reduces a batch of `ApplyTool` results (`apply_tool_line`/`_rect`) down
+ * to a placed/attempted count plus one representative failure message —
+ * enough to tell a script "some of this didn't land" without a result per
+ * tile. Exported (only) so it's unit-testable — see `stratumParam`'s doc
+ * comment. */
+export function summarizeApplyResults(results: CommandResultLike[]) {
+  const failures = results.filter(r => !r.success);
+  return {
+    placed: results.length - failures.length,
+    attempted: results.length,
+    firstFailureMessage: failures[0]?.message ?? null,
+  };
+}
+
 // Use setTimeout rather than rAF — background/unfocused Chromium tabs throttle
 // rAF to 1 fps, which would stall every MCP command for seconds and freeze the HUD.
 function waitMs(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export function initMcpBridge(bridge: SimBridge, state: GameState): void {
+export function initMcpBridge(
+  bridge: SimBridge,
+  state: GameState,
+  tapSimMessages: (tap: (msg: FromSim) => void) => void,
+): void {
   if (!new URLSearchParams(location.search).has('mcp')) return;
 
   console.info('[MCP] MCP mode active — connecting to ws://localhost:5174');
@@ -66,6 +124,25 @@ export function initMcpBridge(bridge: SimBridge, state: GameState): void {
   let ws: WebSocket | null = null;
   let currentSpeed = 1;
   const replyOverrides = new Map<string, (result: unknown, error?: string) => void>();
+  const commandResults = createCommandResultQueue();
+  tapSimMessages(msg => {
+    if (msg.type === 'CommandResult') commandResults.resolveNext(msg);
+  });
+
+  // Fire an ApplyTool command and resolve once its CommandResult arrives —
+  // or after 2s with an assumed success, so a dropped/never-sent result
+  // (e.g. a bridge implementation that doesn't emit CommandResult) can't
+  // hang an MCP call forever.
+  function sendApplyTool(
+    tool: Tool, x: number, y: number, strokeId: number, stratum: ViewStratum,
+  ): Promise<CommandResultLike> {
+    const { promise, cancel } = commandResults.expectNext();
+    bridge.send({ type: 'ApplyTool', tool, x, y, strokeId, stratum });
+    return Promise.race([
+      promise,
+      new Promise<CommandResultLike>(resolve => setTimeout(() => { cancel(); resolve({ success: true }); }, 2000)),
+    ]);
+  }
 
   function connect(): void {
     const sock = new WebSocket(`ws://localhost:${MCP_WS_PORT}`);
@@ -159,13 +236,16 @@ export function initMcpBridge(bridge: SimBridge, state: GameState): void {
           const x = params.x as number;
           const y = params.y as number;
           const moneyBefore = bridge.getState().money;
-          bridge.send({ type: 'ApplyTool', tool, x, y, strokeId: nextStrokeId(), stratum: stratumParam(params) });
+          const pendingResult = sendApplyTool(tool, x, y, nextStrokeId(), stratumParam(params));
           await waitMs(150);
+          const result = await pendingResult;
           reply(id, {
             moneyBefore,
             moneyAfter: bridge.getState().money,
             tile: tileAt(x, y),
             state: simState(),
+            success: result.success,
+            message: result.message ?? null,
           });
           break;
         }
@@ -212,11 +292,10 @@ export function initMcpBridge(bridge: SimBridge, state: GameState): void {
           const moneyBefore = bridge.getState().money;
           const lineStroke = nextStrokeId();
           const stratum = stratumParam(params);
-          for (const [px, py] of pts) {
-            bridge.send({ type: 'ApplyTool', tool, x: px, y: py, strokeId: lineStroke, stratum });
-          }
+          const pending = pts.map(([px, py]) => sendApplyTool(tool, px, py, lineStroke, stratum));
           await waitMs(150);
-          reply(id, { placed: pts.length, moneyBefore, moneyAfter: bridge.getState().money, state: simState() });
+          const summary = summarizeApplyResults(await Promise.all(pending));
+          reply(id, { ...summary, moneyBefore, moneyAfter: bridge.getState().money, state: simState() });
           break;
         }
 
@@ -229,15 +308,15 @@ export function initMcpBridge(bridge: SimBridge, state: GameState): void {
           const moneyBefore = bridge.getState().money;
           const rectStroke = nextStrokeId();
           const stratum = stratumParam(params);
-          let placed = 0;
+          const pending: Promise<CommandResultLike>[] = [];
           for (let ry = ay; ry <= by; ry++) {
             for (let rx = ax; rx <= bx; rx++) {
-              bridge.send({ type: 'ApplyTool', tool, x: rx, y: ry, strokeId: rectStroke, stratum });
-              placed++;
+              pending.push(sendApplyTool(tool, rx, ry, rectStroke, stratum));
             }
           }
           await waitMs(150);
-          reply(id, { placed, moneyBefore, moneyAfter: bridge.getState().money, state: simState() });
+          const summary = summarizeApplyResults(await Promise.all(pending));
+          reply(id, { ...summary, moneyBefore, moneyAfter: bridge.getState().money, state: simState() });
           break;
         }
 

--- a/app/src/game/mcpBridge.ts
+++ b/app/src/game/mcpBridge.ts
@@ -14,7 +14,7 @@ import { Tool } from './toolTypes';
 import { getCalendarPosition } from './time';
 import { nextStrokeId } from './protocol/commands';
 import type { FromSim } from './protocol/events';
-import { dominantOccupantLabel } from './protocol/tileLabel';
+import { dominantOccupantLabel, occupantsByStratum } from './protocol/tileLabel';
 
 // Bresenham's line — returns all integer (x,y) pairs from (x0,y0) to (x1,y1).
 function bresenhamLine(x0: number, y0: number, x1: number, y1: number): [number, number][] {
@@ -195,6 +195,14 @@ export function initMcpBridge(
     if (!t) return null;
     return {
       kind: dominantOccupantLabel(s, t),
+      // `kind` collapses to one label per the legacy display precedence
+      // (structure > zone > trees > power line > rail > road) — a tile can
+      // carry a road on the surface *and* a power line overhead *and* a
+      // pipe underground all at once. `occupants` is the same information
+      // without the collapse, so a script can tell "there's a road here,
+      // just hidden behind a power line" from "no road here" — e.g. to
+      // confirm a `water_pipe` placement actually landed underneath a road.
+      occupants: occupantsByStratum(s, t),
       powered: t.powered,
       watered: t.watered,
       abandoned: t.abandoned ?? false,

--- a/app/src/game/protocol/tileLabel.test.ts
+++ b/app/src/game/protocol/tileLabel.test.ts
@@ -1,0 +1,67 @@
+// tileLabel.test.ts — dominantOccupantLabel/occupantsByStratum against layered strata.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect } from 'vitest';
+import { createInitialState, getTile, setTile, TileKind } from '../gameState';
+import { Occupant, Terrain, setTileOccupant } from './occupants';
+import { createBuildingState } from '../buildings/state';
+import { dominantOccupantLabel, occupantsByStratum } from './tileLabel';
+
+describe('occupantsByStratum', () => {
+  it('reports an empty tile as empty in every stratum', () => {
+    const state = createInitialState(3, 3);
+    const tile = getTile(state, 1, 1)!;
+    tile.terrain = Terrain.Land; // procedural generation may have placed water here
+    expect(occupantsByStratum(state, tile)).toEqual({ underground: [], surface: [], overhead: [] });
+    expect(dominantOccupantLabel(state, tile)).toBe(TileKind.Land);
+  });
+
+  it('lists a single surface occupant under "surface", nowhere else', () => {
+    const state = createInitialState(3, 3);
+    setTile(state, 1, 1, TileKind.Road);
+    const tile = getTile(state, 1, 1)!;
+    expect(occupantsByStratum(state, tile)).toEqual({ underground: [], surface: [TileKind.Road], overhead: [] });
+  });
+
+  it('keeps a road, a power line, and a pipe all visible on the same tile — what dominantOccupantLabel collapses away', () => {
+    const state = createInitialState(3, 3);
+    setTile(state, 1, 1, TileKind.Road);
+    const tile = getTile(state, 1, 1)!;
+    setTileOccupant(tile, Occupant.PowerLine, true);
+    setTileOccupant(tile, Occupant.Pipe, true);
+
+    expect(occupantsByStratum(state, tile)).toEqual({
+      underground: [TileKind.WaterPipe],
+      surface: [TileKind.Road],
+      overhead: [TileKind.PowerLine],
+    });
+    // The power line wins the single-label display slot — the road is still
+    // there (proven above), just not visible through `dominantOccupantLabel`.
+    expect(dominantOccupantLabel(state, tile)).toBe(TileKind.PowerLine);
+  });
+
+  it('resolves a Structure occupant through the building instance, same as dominantOccupantLabel', () => {
+    const state = createInitialState(3, 3);
+    const tile = getTile(state, 1, 1)!;
+    tile.terrain = Terrain.Land; // procedural generation may have placed water here
+    setTileOccupant(tile, Occupant.Structure, true);
+    tile.buildingId = 7;
+    state.buildings.push({
+      id: 7, templateId: TileKind.WaterPump, origin: { x: 1, y: 1 }, state: createBuildingState(),
+    });
+
+    expect(occupantsByStratum(state, tile)).toEqual({ underground: [], surface: [TileKind.WaterPump], overhead: [] });
+    expect(dominantOccupantLabel(state, tile)).toBe(TileKind.WaterPump);
+  });
+
+  it('omits a Structure occupant whose building instance is missing (no TileKind to report)', () => {
+    const state = createInitialState(3, 3);
+    const tile = getTile(state, 1, 1)!;
+    setTileOccupant(tile, Occupant.Structure, true);
+    tile.buildingId = 404; // no matching entry in state.buildings
+
+    expect(occupantsByStratum(state, tile)).toEqual({ underground: [], surface: [], overhead: [] });
+  });
+});

--- a/app/src/game/protocol/tileLabel.ts
+++ b/app/src/game/protocol/tileLabel.ts
@@ -3,9 +3,17 @@
 // (c) Copyright 2026 Liminal HQ, Scott Morris
 // SPDX-License-Identifier: MIT
 
+import { TileKind } from '../gameState';
 import type { GameState, Tile } from '../gameState';
 import { getBuildingTemplate } from '../buildings/templates';
 import { legacyKind } from './legacyProjection';
+import { Occupant, iterSet } from './occupants';
+
+function structureKindOf(state: GameState, buildingId: number | undefined): TileKind | undefined {
+  if (buildingId === undefined) return undefined;
+  const instance = state.buildings.find((b) => b.id === buildingId);
+  return instance ? getBuildingTemplate(instance.templateId)?.tileKind : undefined;
+}
 
 /**
  * The tile's dominant occupant, as a display/query string — used by the HUD
@@ -22,9 +30,53 @@ export function dominantOccupantLabel(state: GameState, tile: Tile): string {
     surface: tile.surface,
     overhead: tile.overhead,
     buildingId: tile.buildingId,
-    structureKindOf: (buildingId) => {
-      const instance = state.buildings.find((b) => b.id === buildingId);
-      return instance ? getBuildingTemplate(instance.templateId)?.tileKind : undefined;
-    }
+    structureKindOf: (buildingId) => structureKindOf(state, buildingId)
   });
+}
+
+/** One occupant's label — same `TileKind` vocabulary `dominantOccupantLabel` uses, so a
+ * script filtering on either agrees on spelling. `Structure` resolves through the building
+ * instance the same way `dominantOccupantLabel` does; `undefined` covers the two reserved
+ * occupants (`Subway`/`Fibre`) with no `TileKind` yet — see `occupants.ts`. */
+function occupantLabel(state: GameState, tile: Tile, occupant: Occupant): string | undefined {
+  switch (occupant) {
+    case Occupant.Pipe: return TileKind.WaterPipe;
+    case Occupant.Road: return TileKind.Road;
+    case Occupant.Rail: return TileKind.Rail;
+    case Occupant.ZoneResidential: return TileKind.Residential;
+    case Occupant.ZoneCommercial: return TileKind.Commercial;
+    case Occupant.ZoneIndustrial: return TileKind.Industrial;
+    case Occupant.Structure: return structureKindOf(state, tile.buildingId);
+    case Occupant.PowerLine: return TileKind.PowerLine;
+    case Occupant.Trees: return TileKind.Tree;
+    case Occupant.Subway:
+    case Occupant.Fibre:
+      return undefined;
+  }
+}
+
+/**
+ * Every occupant on `tile`, grouped by stratum and labelled — the detail
+ * `dominantOccupantLabel` deliberately collapses away by design (it picks
+ * one winner per the legacy display precedence: structure > zone > trees >
+ * power line > rail > road). A tile can carry a road on the surface *and* a
+ * power line overhead *and* a pipe underground at once; a caller that only
+ * reads `dominantOccupantLabel`'s single string can't tell the difference
+ * between "no road here" and "there's a road, but a power line is winning
+ * the display slot" — this is what `get_tile` needs to answer that.
+ */
+export function occupantsByStratum(state: GameState, tile: Tile): Record<'underground' | 'surface' | 'overhead', string[]> {
+  // Each field already only ever carries its own stratum's bits — see
+  // `Tile.underground`/`.surface`/`.overhead`'s doc comments and
+  // `setTileOccupant`, the sole write path, which routes by the occupant's
+  // own declared stratum rather than trusting the caller.
+  const labelsIn = (bits: number) =>
+    iterSet(bits)
+      .map(o => occupantLabel(state, tile, o))
+      .filter((label): label is string => label !== undefined);
+  return {
+    underground: labelsIn(tile.underground),
+    surface: labelsIn(tile.surface),
+    overhead: labelsIn(tile.overhead),
+  };
 }

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -440,8 +440,16 @@ function stopBootErrorWatch(): void {
   window.removeEventListener('unhandledrejection', onBootRejection);
 }
 
+// `SimBridge.onMessage` is single-subscriber (see its doc comment) — this
+// tap lets `initMcpBridge` observe every `FromSim` message (e.g.
+// `CommandResult`) without stealing the one slot `wireBridge` already holds
+// for alerts/toasts/narrative/history. Set once, below, before any message
+// can actually arrive (both calls happen synchronously during boot).
+let mcpMessageTap: ((msg: FromSim) => void) | null = null;
+
 function wireBridge(b: SimBridge): void {
   b.onMessage((msg: FromSim) => {
+    mcpMessageTap?.(msg);
     if (msg.type === 'Ready') {
       stopBootErrorWatch();
       loadingScreen.complete();
@@ -625,7 +633,7 @@ function startAutosave(): void {
 }
 
 wireBridge(bridge);
-initMcpBridge(bridge, state);
+initMcpBridge(bridge, state, tap => { mcpMessageTap = tap; });
 void bootLoadSave().finally(startAutosave);
 
 let debugOverlay: ReturnType<typeof initDebugOverlay> | null = null;

--- a/crates/tauri-plugin-city-sim/package.json
+++ b/crates/tauri-plugin-city-sim/package.json
@@ -15,7 +15,8 @@
     "default": "./dist-js/index.js"
   },
   "scripts": {
-    "build": "rollup -c"
+    "build": "rollup -c",
+    "postinstall": "rollup -c"
   },
   "files": [
     "dist-js",

--- a/scripts/city-sim-mcp/index.ts
+++ b/scripts/city-sim-mcp/index.ts
@@ -244,7 +244,7 @@ server.tool(
 
 server.tool(
   'apply_tool',
-  'Apply a build or demolish action at tile (x, y). Returns money before/after, the resulting tile state, and a sim state snapshot.',
+  'Apply a build or demolish action at tile (x, y). Returns money before/after, the resulting tile state, a sim state snapshot, and `success`/`message` reporting whether the engine actually accepted the command (e.g. wrong stratum, insufficient funds, no road access) — check `success` rather than assuming the placement landed.',
   {
     tool: z.enum([
       'inspect',
@@ -285,7 +285,7 @@ server.tool(
 
 server.tool(
   'apply_tool_line',
-  'Apply a build tool along a straight line from (x1,y1) to (x2,y2) using Bresenham\'s algorithm. Ideal for roads, power lines, or pipes. Returns number of tiles placed and money delta.',
+  'Apply a build tool along a straight line from (x1,y1) to (x2,y2) using Bresenham\'s algorithm. Ideal for roads, power lines, or pipes. Returns `placed` (tiles the engine actually accepted), `attempted` (total tiles on the line), and `firstFailureMessage` (the engine\'s reason for the first rejected tile, if `placed` < `attempted`) alongside the money delta.',
   {
     tool: z.enum([
       'road', 'rail', 'powerline',
@@ -305,7 +305,7 @@ server.tool(
 
 server.tool(
   'apply_tool_rect',
-  'Fill a rectangular region with a tool — useful for zoning large areas in one call. Returns number of tiles placed and money delta.',
+  'Fill a rectangular region with a tool — useful for zoning large areas in one call. Returns `placed` (tiles the engine actually accepted), `attempted` (total tiles in the rectangle), and `firstFailureMessage` (the engine\'s reason for the first rejected tile, if `placed` < `attempted`) alongside the money delta.',
   {
     tool: z.enum([
       'residential', 'commercial', 'industrial', 'park', 'park_large',

--- a/scripts/city-sim-mcp/index.ts
+++ b/scripts/city-sim-mcp/index.ts
@@ -227,19 +227,22 @@ server.tool(
 
 server.tool(
   'get_tiles_where',
-  'Return all (x, y) positions matching a given tile kind. Useful for finding existing roads, zones, utilities, etc.',
+  'Return all (x, y) positions matching a given tile kind. Useful for finding existing roads, zones, utilities, etc. By default this only matches each tile\'s single dominant kind (picked by display precedence: structure > zone > trees > power line > rail > road) — a road hidden under a power line won\'t match `kind: "road"` unless `anyStratum` is set, since the power line is winning the display slot. Set `anyStratum: true` to match any tile that has the given kind present in ANY stratum (underground/surface/overhead), regardless of which one wins the display precedence — see `get_tile`\'s `occupants` field for the same distinction on a single tile.',
   {
     kind: z.enum([
       'land', 'water', 'tree',
       'road', 'rail',
       'residential', 'commercial', 'industrial',
-      'powerline', 'hydro',
+      'powerline',
+      'hydro', 'coal', 'wind', 'solar',
       'pump', 'water_tower', 'water_pipe',
       'elementary_school', 'high_school',
       'park', 'park_large',
-    ]).describe('Tile kind string. Note: all power plant types (coal/wind/solar/hydro) share the kind "hydro"'),
+    ]).describe('Tile kind string. Each power plant type has its own distinct kind (hydro/coal/wind/solar), not a shared one.'),
+    anyStratum: z.boolean().optional()
+      .describe('When true, match a tile if `kind` appears in any of its strata, not just the one dominant/display kind. Default false. Has no effect for `kind: "land"` or `"water"` — those describe the terrain itself, not an occupant, so they never appear in any stratum and `anyStratum: true` will find nothing for them; leave it false (the default) to find land/water tiles.'),
   },
-  async ({ kind }) => textResult(await callGame('get_tiles_where', { kind })),
+  async ({ kind, anyStratum }) => textResult(await callGame('get_tiles_where', { kind, anyStratum })),
 );
 
 server.tool(

--- a/scripts/city-sim-mcp/index.ts
+++ b/scripts/city-sim-mcp/index.ts
@@ -217,7 +217,7 @@ server.tool(
 
 server.tool(
   'get_tile',
-  'Get the state of a single tile: kind, powered, watered, abandoned, happiness, elevation, buildingId.',
+  'Get the state of a single tile: kind, powered, watered, abandoned, happiness, elevation, buildingId. `kind` is one dominant label picked by display precedence (structure > zone > trees > power line > rail > road) — a tile can carry a road on the surface, a power line overhead, and a pipe underground all at once, and `kind` only ever shows the winner. `occupants` gives the full picture as `{ underground: string[], surface: string[], overhead: string[] }`, e.g. to confirm a `water_pipe` placement actually landed underneath a road rather than being masked by it.',
   {
     x: z.number().int().describe('Tile column (0 = left edge)'),
     y: z.number().int().describe('Tile row (0 = top edge)'),


### PR DESCRIPTION
## Summary

Follow-up to `#254` from the same `#253` MCP playtest, plus a targeted codebase sweep for other legacy-format leakage into live MCP tools — four focused fixes, each its own commit:

- **`apply_tool`/`apply_tool_line`/`apply_tool_rect` now report real success/failure.** They used to fire the command and reply after a fixed wait, never checking the engine's actual `CommandResult` — a rejected placement (wrong stratum, overlapping a building, insufficient funds) was reported identically to a success. Bit me directly: an `elementary_school` placed on an occupied tile silently no-op'd, and only cross-checking `get_buildings` revealed nothing had landed. Fixed with a FIFO queue correlating each `ApplyTool` send to the `CommandResult` the worker posts back for it (reliable since the worker always responds in send order — see the commit for the full reasoning, including a timeout/cancellation edge case I caught while writing it). `apply_tool` gains `success`/`message`; `apply_tool_line`/`apply_tool_rect` redefine `placed` to mean tiles actually accepted (it previously always equaled the attempted count) and add `attempted`/`firstFailureMessage`.
- **`get_tile` exposes per-stratum occupants, not just one collapsed label.** `kind` picks one winner via legacy display precedence (structure > zone > trees > power line > rail > road) — a holdover from the frozen v4 save format where a tile really could only be one thing. Since the strata rewrite, a tile can carry a road on the surface *and* a power line overhead *and* a pipe underground at once, and `kind` alone can't show that. Also bit me directly during the playtest: `kind: "powerline"` after building a power line over a road left me unsure whether the road survived. New `occupants: { underground, surface, overhead }` field answers that directly.
- **`get_tiles_where` had the same collapsed-label blind spot, plus a stale/wrong enum.** Its `kind` enum only listed `hydro` among power plants (comment claimed coal/wind/solar "share the kind hydro" — no longer true once `Structure` occupants started resolving through the building template). Coal, wind, and solar plants were unfindable via this tool. Fixed the enum to all 19 `TileKind` values, and added `anyStratum` (default false, matching existing behaviour) to search the full per-layer breakdown instead of just the dominant label.
- **`crates/tauri-plugin-city-sim`'s gitignored `dist-js/` now rebuilds via `postinstall`.** Hit the "failed to resolve entry for package tauri-plugin-city-sim" fresh-worktree trap twice in one session doing unrelated MCP work; the fix was already documented in CLAUDE.md but easy to forget since it's unrelated to whatever prompted the fresh checkout.

### Maintainer-facing changes
- `app/src/main.ts` — a small message tap (`mcpMessageTap`) lets `mcpBridge.ts` observe every `FromSim` message without stealing `SimBridge.onMessage`'s single subscriber slot from `wireBridge`.
- `app/src/game/mcpBridge.ts` — `createCommandResultQueue`, `summarizeApplyResults`, `occupantsByStratum`, `tileMatchesKind` wiring; all exported (only) for unit testing, matching `stratumParam`'s existing pattern.
- `app/src/game/protocol/tileLabel.ts` — new `occupantsByStratum`, plus a shared `structureKindOf` helper factored out of `dominantOccupantLabel`.
- `scripts/city-sim-mcp/index.ts` — tool descriptions/schemas updated to document the new response fields and the corrected `kind` enum.

## Test plan
- [x] `bun run test` — 308/308 (app) + 2/2 (mcp server), includes 14 new tests across `mcpBridge.test.ts` and `tileLabel.test.ts`
- [x] `bun run lint` (`tsc --noEmit`) — clean
- [x] Manually verified against a running MCP session (fresh worktree, `bun run dev` + `?mcp`, using the `__mcpTest` browser hook where the long-running MCP stdio process itself was too stale to hot-reload the new schema):
  - placing a `high_school` on an occupied tile → `{ success: false, message: "Cannot overlap another building. Bulldoze first." }`
  - a 4-tile `apply_tool_rect` straddling that building → `{ placed: 2, attempted: 4, firstFailureMessage: "Cannot zone over a building. Bulldoze first." }`
  - building `road` then `powerline` on the same tile → `kind: "powerline"` but `occupants: { surface: ["road"], overhead: ["powerline"], underground: [] }`, proving the road survived
  - `get_tiles_where({kind: 'coal'})` now finds a coal plant's full 2×2 footprint (previously schema-rejected)
  - a road built under a power line is invisible to `get_tiles_where({kind: 'road'})` by default but found with `anyStratum: true`
  - deleting `dist-js/` and re-running `bun install` regenerates it even when bun reports no lockfile changes

## Known limitations
- The `CommandResult` FIFO correlation assumes MCP mode is the only source of `ApplyTool` commands in the tab — true for scripted play, not if a human is also clicking the same session at the same time. Documented in `createCommandResultQueue`'s doc comment.
- `anyStratum: true` has no effect for `kind: "land"`/`"water"` — those describe terrain, not an occupant, so they never appear in any stratum. Documented on the param.