### PR TITLE
BuildingKind lands in Rust — TileKind retires to the import boundary

### DIFF
--- a/app/src/game/buildings/templates.ts
+++ b/app/src/game/buildings/templates.ts
@@ -7,7 +7,15 @@ import { BUILD_COST, POWER_PLANT_CONFIGS, PowerPlantType } from '../constants';
 import { Tool } from '../toolTypes';
 import { ServiceId } from '../services';
 
-export enum BuildingCategory {
+/**
+ * The coarse power/civic/zone bucket a template's upkeep lands in — the same
+ * trio the engine's budget ledger reports (`economy.rs`'s maintenance
+ * breakdown) and the debug/bylaw UI groups by. Distinct from Rust's
+ * `BuildingCategory` (`city-sim-protocol`'s `building_kind.rs`), the precise
+ * seven-member domain taxonomy carried in a `BuildingKind`'s high nibble —
+ * `Water`/`Education`/`Recreation` all land in `Civic` here.
+ */
+export enum LedgerGroup {
   Power = 'power',
   Civic = 'civic',
   Zone = 'zone'
@@ -42,7 +50,7 @@ export enum BuildingKind {
 export interface BuildingTemplate {
   id: string;
   name: string;
-  category: BuildingCategory;
+  category: LedgerGroup;
   footprint: { width: number; height: number };
   cost: number;
   maintenance: number;
@@ -75,7 +83,7 @@ export const POWER_PLANT_TEMPLATES: Record<PowerPlantType, BuildingTemplate> = {
   [PowerPlantType.Hydro]: {
     id: PowerPlantType.Hydro,
     name: POWER_PLANT_CONFIGS[PowerPlantType.Hydro].name,
-    category: BuildingCategory.Power,
+    category: LedgerGroup.Power,
     footprint: POWER_PLANT_CONFIGS[PowerPlantType.Hydro].footprint,
     cost: POWER_PLANT_CONFIGS[PowerPlantType.Hydro].buildCost,
     maintenance: POWER_PLANT_CONFIGS[PowerPlantType.Hydro].maintenancePerDay,
@@ -87,7 +95,7 @@ export const POWER_PLANT_TEMPLATES: Record<PowerPlantType, BuildingTemplate> = {
   [PowerPlantType.Coal]: {
     id: PowerPlantType.Coal,
     name: POWER_PLANT_CONFIGS[PowerPlantType.Coal].name,
-    category: BuildingCategory.Power,
+    category: LedgerGroup.Power,
     footprint: POWER_PLANT_CONFIGS[PowerPlantType.Coal].footprint,
     cost: POWER_PLANT_CONFIGS[PowerPlantType.Coal].buildCost,
     maintenance: POWER_PLANT_CONFIGS[PowerPlantType.Coal].maintenancePerDay,
@@ -99,7 +107,7 @@ export const POWER_PLANT_TEMPLATES: Record<PowerPlantType, BuildingTemplate> = {
   [PowerPlantType.Wind]: {
     id: PowerPlantType.Wind,
     name: POWER_PLANT_CONFIGS[PowerPlantType.Wind].name,
-    category: BuildingCategory.Power,
+    category: LedgerGroup.Power,
     footprint: POWER_PLANT_CONFIGS[PowerPlantType.Wind].footprint,
     cost: POWER_PLANT_CONFIGS[PowerPlantType.Wind].buildCost,
     maintenance: POWER_PLANT_CONFIGS[PowerPlantType.Wind].maintenancePerDay,
@@ -111,7 +119,7 @@ export const POWER_PLANT_TEMPLATES: Record<PowerPlantType, BuildingTemplate> = {
   [PowerPlantType.Solar]: {
     id: PowerPlantType.Solar,
     name: POWER_PLANT_CONFIGS[PowerPlantType.Solar].name,
-    category: BuildingCategory.Power,
+    category: LedgerGroup.Power,
     footprint: POWER_PLANT_CONFIGS[PowerPlantType.Solar].footprint,
     cost: POWER_PLANT_CONFIGS[PowerPlantType.Solar].buildCost,
     maintenance: POWER_PLANT_CONFIGS[PowerPlantType.Solar].maintenancePerDay,
@@ -126,7 +134,7 @@ export const CIVIC_BUILDING_TEMPLATES: Record<string, BuildingTemplate> = {
   [BuildingKind.WaterPump]: {
     id: BuildingKind.WaterPump,
     name: 'Water Pump',
-    category: BuildingCategory.Civic,
+    category: LedgerGroup.Civic,
     footprint: { width: 1, height: 1 },
     cost: BUILD_COST[Tool.WaterPump],
     maintenance: 5,
@@ -138,7 +146,7 @@ export const CIVIC_BUILDING_TEMPLATES: Record<string, BuildingTemplate> = {
   [BuildingKind.WaterTower]: {
     id: BuildingKind.WaterTower,
     name: 'Water Tower',
-    category: BuildingCategory.Civic,
+    category: LedgerGroup.Civic,
     footprint: { width: 2, height: 2 },
     cost: BUILD_COST[Tool.WaterTower],
     maintenance: 12,
@@ -150,7 +158,7 @@ export const CIVIC_BUILDING_TEMPLATES: Record<string, BuildingTemplate> = {
   [BuildingKind.Park]: {
     id: BuildingKind.Park,
     name: 'Small Park',
-    category: BuildingCategory.Civic,
+    category: LedgerGroup.Civic,
     footprint: { width: 1, height: 1 },
     cost: 10,
     maintenance: 0.05,
@@ -161,7 +169,7 @@ export const CIVIC_BUILDING_TEMPLATES: Record<string, BuildingTemplate> = {
   [BuildingKind.ParkLarge]: {
     id: BuildingKind.ParkLarge,
     name: 'Large Park',
-    category: BuildingCategory.Civic,
+    category: LedgerGroup.Civic,
     footprint: { width: 2, height: 2 },
     cost: 32,
     maintenance: 0.16,
@@ -172,7 +180,7 @@ export const CIVIC_BUILDING_TEMPLATES: Record<string, BuildingTemplate> = {
   [BuildingKind.ElementarySchool]: {
     id: BuildingKind.ElementarySchool,
     name: 'Elementary School',
-    category: BuildingCategory.Civic,
+    category: LedgerGroup.Civic,
     footprint: { width: 2, height: 2 },
     cost: BUILD_COST[Tool.ElementarySchool],
     maintenance: 40,
@@ -185,7 +193,7 @@ export const CIVIC_BUILDING_TEMPLATES: Record<string, BuildingTemplate> = {
   [BuildingKind.HighSchool]: {
     id: BuildingKind.HighSchool,
     name: 'High School',
-    category: BuildingCategory.Civic,
+    category: LedgerGroup.Civic,
     footprint: { width: 2, height: 2 },
     cost: BUILD_COST[Tool.HighSchool],
     maintenance: 55,
@@ -201,7 +209,7 @@ export const ZONE_BUILDING_TEMPLATES: Record<string, BuildingTemplate> = {
   [BuildingKind.Residential]: {
     id: 'zone-residential',
     name: 'Residential Lot',
-    category: BuildingCategory.Zone,
+    category: LedgerGroup.Zone,
     footprint: { width: 1, height: 1 },
     cost: BUILD_COST[Tool.Residential],
     maintenance: 1,
@@ -214,7 +222,7 @@ export const ZONE_BUILDING_TEMPLATES: Record<string, BuildingTemplate> = {
   [BuildingKind.Commercial]: {
     id: 'zone-commercial',
     name: 'Commercial Lot',
-    category: BuildingCategory.Zone,
+    category: LedgerGroup.Zone,
     footprint: { width: 1, height: 1 },
     cost: BUILD_COST[Tool.Commercial],
     maintenance: 1.2,
@@ -227,7 +235,7 @@ export const ZONE_BUILDING_TEMPLATES: Record<string, BuildingTemplate> = {
   [BuildingKind.Industrial]: {
     id: 'zone-industrial',
     name: 'Industrial Lot',
-    category: BuildingCategory.Zone,
+    category: LedgerGroup.Zone,
     footprint: { width: 1, height: 1 },
     cost: BUILD_COST[Tool.Industrial],
     maintenance: 1.4,

--- a/app/src/game/bylawAnalytics.ts
+++ b/app/src/game/bylawAnalytics.ts
@@ -1,4 +1,4 @@
-import { BuildingCategory, getBuildingTemplate } from './buildings/templates';
+import { LedgerGroup, getBuildingTemplate } from './buildings/templates';
 import { BuildingStatus } from './buildings/state';
 import type { GameState } from './gameState';
 import {
@@ -19,19 +19,19 @@ export function computeLightingBaseStats(state: GameState): LightingBaseStats {
   for (const building of state.buildings) {
     const template = getBuildingTemplate(building.templateId);
     if (!template) continue;
-    if (template.category === BuildingCategory.Power) continue;
+    if (template.category === LedgerGroup.Power) continue;
 
     if (template.maintenance) {
-      if (template.category === BuildingCategory.Civic) base.maintenanceCivic += template.maintenance;
-      if (template.category === BuildingCategory.Zone) base.maintenanceZones += template.maintenance;
+      if (template.category === LedgerGroup.Civic) base.maintenanceCivic += template.maintenance;
+      if (template.category === LedgerGroup.Zone) base.maintenanceZones += template.maintenance;
     }
 
     const isActive = building.state.status === BuildingStatus.Active;
     if (!isActive) continue;
 
     if (template.powerUse) {
-      if (template.category === BuildingCategory.Civic) base.powerUseCivic += template.powerUse;
-      if (template.category === BuildingCategory.Zone) base.powerUseZones += template.powerUse;
+      if (template.category === LedgerGroup.Civic) base.powerUseCivic += template.powerUse;
+      if (template.category === LedgerGroup.Zone) base.powerUseZones += template.powerUse;
     }
   }
 

--- a/app/src/game/debugStats.ts
+++ b/app/src/game/debugStats.ts
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 import { BuildingStatus } from './buildings/state';
-import { BuildingCategory, BuildingKind, getBuildingTemplate } from './buildings/templates';
+import { LedgerGroup, BuildingKind, getBuildingTemplate } from './buildings/templates';
 import { GameState } from './gameState';
 import { computeDemand } from './demand';
 import { computeLabourStats, LabourStats } from './computeLabourStats';
@@ -114,7 +114,7 @@ export function getSimulationDebugStats(state: GameState): SimulationDebugStats 
     const isActive = building.state.status === BuildingStatus.Active;
     const contributesCapacity =
       isActive ||
-      (template.category === BuildingCategory.Zone &&
+      (template.category === LedgerGroup.Zone &&
         (building.state.status === BuildingStatus.InactiveNoPower ||
           building.state.status === BuildingStatus.InactiveNoWater));
     if (!isActive && !contributesCapacity) continue;

--- a/app/src/game/narrative/snapshot.ts
+++ b/app/src/game/narrative/snapshot.ts
@@ -1,6 +1,6 @@
 import { getCalendarPosition } from '../time';
 import { BuildingStatus } from '../buildings/state';
-import { BuildingCategory, getBuildingTemplate } from '../buildings/templates';
+import { LedgerGroup, getBuildingTemplate } from '../buildings/templates';
 import type { GameState } from '../gameState';
 import { computeLabourStats } from '../computeLabourStats';
 import type { CitySnapshot } from './types';
@@ -17,7 +17,7 @@ function computeCapacities(state: GameState) {
     const isActive = building.state.status === BuildingStatus.Active;
     const contributesCapacity =
       isActive ||
-      (template.category === BuildingCategory.Zone &&
+      (template.category === LedgerGroup.Zone &&
         (building.state.status === BuildingStatus.InactiveNoPower ||
           building.state.status === BuildingStatus.InactiveNoWater));
     if (!contributesCapacity) continue;

--- a/app/src/game/protocol/buildingKind.test.ts
+++ b/app/src/game/protocol/buildingKind.test.ts
@@ -1,0 +1,80 @@
+// buildingKind.test.ts — BuildingKind ↔ u8 wire mapping round-trips and the
+// pinned Rust discriminant table.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect } from 'vitest';
+import {
+  BUILDING_KIND_BY_U8,
+  BUILDING_KIND_COUNT,
+  buildingKindFromU8,
+  buildingKindToU8
+} from './buildingKind';
+import { BuildingKind } from '../buildings/templates';
+
+// Hand-copied from the approved table in crates/city-sim-protocol/src/building_kind.rs
+// (`BuildingKind::ALL` / `from_u8`) — a real assertion against the Rust discriminants,
+// not a copy of the table under test. If this drifts from the Rust side, the wire
+// silently decodes the wrong building; keep the two in lockstep by hand until a
+// generated parity fixture exists (`TileKind`'s `tileKindParity.json` pattern is not
+// wired up for `BuildingKind` because this alphabet is still pre-release/mutable).
+const RUST_DISCRIMINANTS: ReadonlyArray<readonly [number, BuildingKind]> = [
+  [0x10, BuildingKind.Residential],
+  [0x11, BuildingKind.Commercial],
+  [0x12, BuildingKind.Industrial],
+  [0x20, BuildingKind.HydroPlant],
+  [0x21, BuildingKind.CoalPlant],
+  [0x22, BuildingKind.WindTurbine],
+  [0x23, BuildingKind.SolarFarm],
+  [0x30, BuildingKind.WaterPump],
+  [0x31, BuildingKind.WaterTower],
+  [0x40, BuildingKind.ElementarySchool],
+  [0x41, BuildingKind.HighSchool],
+  [0x50, BuildingKind.Park],
+  [0x51, BuildingKind.ParkLarge]
+];
+
+describe('BUILDING_KIND_BY_U8', () => {
+  it('matches the Rust discriminant table exactly, byte for byte', () => {
+    expect(BUILDING_KIND_BY_U8.size).toBe(RUST_DISCRIMINANTS.length);
+    for (const [u8, kind] of RUST_DISCRIMINANTS) {
+      expect(BUILDING_KIND_BY_U8.get(u8)).toBe(kind);
+    }
+  });
+
+  it('covers every BuildingKind member exactly once', () => {
+    const values = Array.from(BUILDING_KIND_BY_U8.values());
+    const allKinds = Object.values(BuildingKind);
+    expect(values.length).toBe(allKinds.length);
+    for (const kind of allKinds) {
+      expect(values.filter((v) => v === kind)).toHaveLength(1);
+    }
+  });
+
+  it('has no valid entry at 0x00', () => {
+    expect(BUILDING_KIND_BY_U8.has(0x00)).toBe(false);
+  });
+
+  it('BUILDING_KIND_COUNT matches the table size', () => {
+    expect(BUILDING_KIND_COUNT).toBe(BUILDING_KIND_BY_U8.size);
+  });
+});
+
+describe('buildingKindFromU8 / buildingKindToU8', () => {
+  it('round-trips every member', () => {
+    for (const [u8, kind] of RUST_DISCRIMINANTS) {
+      expect(buildingKindFromU8(u8)).toBe(kind);
+      expect(buildingKindToU8(kind)).toBe(u8);
+    }
+  });
+
+  it('returns undefined for an unassigned byte', () => {
+    expect(buildingKindFromU8(0x00)).toBeUndefined();
+    expect(buildingKindFromU8(0x99)).toBeUndefined();
+  });
+
+  it('throws for a value with no BuildingKind (defensive; not reachable through the enum type)', () => {
+    expect(() => buildingKindToU8('not-a-kind' as BuildingKind)).toThrow();
+  });
+});

--- a/app/src/game/protocol/buildingKind.ts
+++ b/app/src/game/protocol/buildingKind.ts
@@ -1,0 +1,66 @@
+// buildingKind.ts — BuildingKind ↔ u8 wire mapping, TS mirror of the Rust protocol crate.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+/**
+ * BuildingKind ↔ u8 wire mapping — TS mirror of
+ * `crates/city-sim-protocol/src/building_kind.rs`.
+ *
+ * Unlike `TileKind` (`tileKind.ts`), this alphabet is **not** frozen legacy
+ * save vocabulary — pre-release, the discriminants below are free to be
+ * renumbered or extended, per the maintainer-approved design in
+ * `docs/tile-model.md`. They still have to match the Rust side byte-for-byte
+ * today, though: `WireBuilding.kind` on the wire (`wasmSimBridge.ts`,
+ * `tauriSimBridge.ts`) and `BuildingInstance.kind` in a CSIM snapshot both
+ * carry this exact u8. High nibble = category, low nibble = kind within it;
+ * `0x00` is reserved and never valid.
+ *
+ * The `BuildingKind` string values here are the `app/src/game/buildings/
+ * templates.ts` enum — `getBuildingTemplate` is keyed by that string.
+ */
+
+import { BuildingKind } from '../buildings/templates';
+
+/** Stable u8 → BuildingKind lookup. A `Map`, not a dense array, because the
+ *  discriminants are sparse (0x10..0x51 with category-sized gaps) — see
+ *  `BuildingKind::dense_index` on the Rust side for why the *engine's*
+ *  internal tables use a separate compact index instead of this byte. */
+export const BUILDING_KIND_BY_U8: ReadonlyMap<number, BuildingKind> = new Map([
+  // Zone
+  [0x10, BuildingKind.Residential],
+  [0x11, BuildingKind.Commercial],
+  [0x12, BuildingKind.Industrial],
+  // Power
+  [0x20, BuildingKind.HydroPlant],
+  [0x21, BuildingKind.CoalPlant],
+  [0x22, BuildingKind.WindTurbine],
+  [0x23, BuildingKind.SolarFarm],
+  // Water
+  [0x30, BuildingKind.WaterPump],
+  [0x31, BuildingKind.WaterTower],
+  // Education
+  [0x40, BuildingKind.ElementarySchool],
+  [0x41, BuildingKind.HighSchool],
+  // Recreation
+  [0x50, BuildingKind.Park],
+  [0x51, BuildingKind.ParkLarge]
+]);
+
+/** BuildingKind → u8. */
+export const BUILDING_KIND_TO_U8: ReadonlyMap<BuildingKind, number> = new Map(
+  Array.from(BUILDING_KIND_BY_U8, ([u8, kind]) => [kind, u8])
+);
+
+/** Total number of building kinds — must match `BuildingKind::COUNT` in Rust. */
+export const BUILDING_KIND_COUNT = 13;
+
+export function buildingKindFromU8(u8: number): BuildingKind | undefined {
+  return BUILDING_KIND_BY_U8.get(u8);
+}
+
+export function buildingKindToU8(kind: BuildingKind): number {
+  const v = BUILDING_KIND_TO_U8.get(kind);
+  if (v === undefined) throw new Error(`Unknown BuildingKind: ${kind}`);
+  return v;
+}

--- a/app/src/game/serviceDistribution.ts
+++ b/app/src/game/serviceDistribution.ts
@@ -5,7 +5,7 @@
 
 import { getOrthogonalNeighbourCoords, isZone } from './adjacency';
 import { BuildingStatus } from './buildings/state';
-import { BuildingCategory, BuildingKind, getBuildingTemplate } from './buildings/templates';
+import { LedgerGroup, BuildingKind, getBuildingTemplate } from './buildings/templates';
 import type { GameState, Tile } from './gameState';
 import { getTile } from './gameState';
 import { Occupant, hasOccupant } from './protocol/occupants';
@@ -39,7 +39,7 @@ export function computeZoneLoads(state: GameState, workerShare = DEFAULT_WORKER_
     const template = getBuildingTemplate(building.templateId);
     if (!template) continue;
     if (building.state.status !== BuildingStatus.Active) continue;
-    if (template.category !== BuildingCategory.Zone) continue;
+    if (template.category !== LedgerGroup.Zone) continue;
     if (template.populationCapacity) totalPopCap += template.populationCapacity;
     if (template.jobsCapacity) {
       if (template.kind === BuildingKind.Commercial) totalComCap += template.jobsCapacity;
@@ -55,7 +55,7 @@ export function computeZoneLoads(state: GameState, workerShare = DEFAULT_WORKER_
     const template = getBuildingTemplate(building.templateId);
     if (!template) continue;
     if (building.state.status !== BuildingStatus.Active) continue;
-    if (template.category !== BuildingCategory.Zone) continue;
+    if (template.category !== LedgerGroup.Zone) continue;
     const idx = building.origin.y * state.width + building.origin.x;
 
     if (template.populationCapacity) {

--- a/app/src/game/tauriSimBridge.test.ts
+++ b/app/src/game/tauriSimBridge.test.ts
@@ -4,11 +4,12 @@
 // SPDX-License-Identifier: MIT
 
 import { describe, expect, it, vi } from 'vitest';
-import { createInitialState, TileKind } from './gameState';
+import { createInitialState } from './gameState';
 import { applyToolCmd, nextStrokeId } from './protocol/commands';
 import { Occupant, Terrain, ZoneDensity } from './protocol/occupants';
 import { BYTES_PER_TILE, STATUS, decodeEco, encodeHappiness, tileBufferOffsets } from './protocol/tileBuffer';
-import { tileKindToU8 } from './protocol/tileKind';
+import { buildingKindToU8 } from './protocol/buildingKind';
+import { BuildingKind } from './buildings/templates';
 import { ServiceId } from './services';
 import type { FromSim } from './protocol/events';
 import { Tool } from './toolTypes';
@@ -313,7 +314,7 @@ describe('TauriSimBridge onTick decode', () => {
       highServed: 0, highCapacity: 0, highLoad: 0,
       score: 0.6, elementaryCoverage: 0.6, highCoverage: 1,
     };
-    const school: WireBuilding = { id: 7, kind: tileKindToU8(TileKind.ElementarySchool), originX: 0, originY: 0 };
+    const school: WireBuilding = { id: 7, kind: buildingKindToU8(BuildingKind.ElementarySchool), originX: 0, originY: 0 };
 
     emit(baseTickEvent({
       education,
@@ -331,7 +332,7 @@ describe('TauriSimBridge onTick decode', () => {
     const { bridge, emit } = await makeBridge();
     const n = GRID_TILES;
     const o = tileBufferOffsets(n);
-    const coalPlant: WireBuilding = { id: 7, kind: tileKindToU8(TileKind.CoalPlant), originX: 0, originY: 0 };
+    const coalPlant: WireBuilding = { id: 7, kind: buildingKindToU8(BuildingKind.CoalPlant), originX: 0, originY: 0 };
 
     // CoalPlant's real 2x2 footprint, written straight onto the wire — no TS
     // template footprint is consulted for tile coverage any more.
@@ -348,7 +349,7 @@ describe('TauriSimBridge onTick decode', () => {
     expect(s1.tiles[8].buildingId).toBe(7);
     expect(s1.tiles[9].buildingId).toBe(7);
     expect(s1.buildings).toHaveLength(1);
-    expect(s1.buildings[0]).toMatchObject({ id: 7, templateId: TileKind.CoalPlant, origin: { x: 0, y: 0 } });
+    expect(s1.buildings[0]).toMatchObject({ id: 7, templateId: BuildingKind.CoalPlant, origin: { x: 0, y: 0 } });
 
     // Razed: the next TickEvent's wire carries building_id 0 everywhere, and no buildings.
     emit(baseTickEvent({ buildings: [] }));
@@ -366,7 +367,7 @@ describe('TauriSimBridge onTick decode', () => {
     // a pump) doesn't need its footprint to touch water terrain, so this
     // stays a pure power-gating test rather than tripping the #200 source
     // gate covered separately below.
-    const tower: WireBuilding = { id: 1, kind: tileKindToU8(TileKind.WaterTower), originX: 2, originY: 2 };
+    const tower: WireBuilding = { id: 1, kind: buildingKindToU8(BuildingKind.WaterTower), originX: 2, originY: 2 };
     const o = tileBufferOffsets(GRID_TILES);
     const originIndex = 2 * 8 + 2;
 
@@ -381,7 +382,7 @@ describe('TauriSimBridge onTick decode', () => {
 
   it('marks a water pump InactiveNoSource until its footprint touches water terrain', async () => {
     const { bridge, emit } = await makeBridge();
-    const pump: WireBuilding = { id: 3, kind: tileKindToU8(TileKind.WaterPump), originX: 2, originY: 2 };
+    const pump: WireBuilding = { id: 3, kind: buildingKindToU8(BuildingKind.WaterPump), originX: 2, originY: 2 };
     const o = tileBufferOffsets(GRID_TILES);
     const originIndex = 2 * 8 + 2;
     const neighbourIndex = 2 * 8 + 3; // (3,2), orthogonally east of the pump
@@ -402,7 +403,7 @@ describe('TauriSimBridge onTick decode', () => {
 
   it('marks a water-consuming building InactiveNoWater only once a water system exists and it is unwatered', async () => {
     const { bridge, emit } = await makeBridge();
-    const house: WireBuilding = { id: 2, kind: tileKindToU8(TileKind.Residential), originX: 5, originY: 5 };
+    const house: WireBuilding = { id: 2, kind: buildingKindToU8(BuildingKind.Residential), originX: 5, originY: 5 };
     const o = tileBufferOffsets(GRID_TILES);
     const originIndex = 5 * 8 + 5;
     const tiles = new Array(GRID_TILES * BYTES_PER_TILE).fill(0);

--- a/app/src/game/tauriSimBridge.ts
+++ b/app/src/game/tauriSimBridge.ts
@@ -30,13 +30,12 @@
  */
 
 import type { GameState, Tile, ViewStratum } from './gameState';
-import { TileKind } from './gameState';
 import { BuildingStatus, createBuildingState } from './buildings/state';
-import { getBuildingTemplate } from './buildings/templates';
+import { BuildingKind, getBuildingTemplate } from './buildings/templates';
 import type { SimBridge } from './simBridge';
 import type { SimCommand, CommandResult } from './protocol/commands';
 import type { FromSim } from './protocol/events';
-import { tileKindFromU8, tileKindToU8 } from './protocol/tileKind';
+import { buildingKindFromU8 } from './protocol/buildingKind';
 import { Occupant, Terrain, ZoneDensity, hasOccupant } from './protocol/occupants';
 import { decodeTileBuffer } from './protocol/tileBuffer';
 import { deriveNarrativeEventFromAlert } from './protocol/deficitNarrative';
@@ -271,7 +270,7 @@ export class TauriSimBridge implements SimBridge {
   private async seedEngine(state: GameState): Promise<void> {
     const terrain = new Uint8Array(state.tiles.length);
     for (let i = 0; i < terrain.length; i++) {
-      terrain[i] = tileKindToU8(state.tiles[i].terrain === Terrain.Water ? TileKind.Water : TileKind.Land);
+      terrain[i] = state.tiles[i].terrain === Terrain.Water ? Terrain.Water : Terrain.Land;
     }
     await this.plugin.setNaturalTerrain(terrain);
     await this.plugin.setPolicies(state.policies);
@@ -345,19 +344,24 @@ export class TauriSimBridge implements SimBridge {
     // Mirror of the engine's water opt-in gate (`GameState::has_water_system`):
     // until a pump, tower, or pipe exists, buildings don't require water.
     let hasWaterSystem = event.buildings.some((b) => {
-      const kind = tileKindFromU8(b.kind);
-      return kind === TileKind.WaterPump || kind === TileKind.WaterTower;
+      const kind = buildingKindFromU8(b.kind);
+      return kind === BuildingKind.WaterPump || kind === BuildingKind.WaterTower;
     });
     for (let i = 0; i < n && !hasWaterSystem; i++) {
       if (hasOccupant(s.tiles[i].underground, Occupant.Pipe)) hasWaterSystem = true;
     }
     const seatsUsedByBuildingId = new Map(event.educationSeatsUsed.map((e) => [e.buildingId, e.used]));
     s.buildings = event.buildings.map((b) => {
-      const kind = tileKindFromU8(b.kind) ?? TileKind.Land;
+      // `b.kind` decodes via `BUILDING_KIND_BY_U8`; an unrecognised byte
+      // (should never happen against a matching engine build) falls back to
+      // the empty string, which `getBuildingTemplate` returns `undefined`
+      // for, same as the old `TileKind.Land` fallback did (Land has no
+      // building template either).
+      const kind: string = buildingKindFromU8(b.kind) ?? '';
       // Derive status from the tile flags the status byte already set —
       // same derivation as the WASM path, for the same reason.
       const originTile = s.tiles[b.originY * s.width + b.originX];
-      const template = getBuildingTemplate(kind as string);
+      const template = getBuildingTemplate(kind);
       const bstate = createBuildingState();
       const needsPower = template ? template.requiresPower !== false : false;
       const needsWater =
@@ -365,7 +369,7 @@ export class TauriSimBridge implements SimBridge {
       // A pump only produces when its footprint touches water terrain (#200)
       // — distinct from needsWater above, which gates a *consumer* on
       // network coverage; a pump doesn't consume water.
-      const needsSource = kind === TileKind.WaterPump;
+      const needsSource = kind === BuildingKind.WaterPump;
       const origin = { x: b.originX, y: b.originY };
       if (needsPower && !originTile?.powered) {
         bstate.status = BuildingStatus.InactiveNoPower;
@@ -382,7 +386,7 @@ export class TauriSimBridge implements SimBridge {
       }
       return {
         id: b.id,
-        templateId: kind as string,
+        templateId: kind,
         origin,
         state: bstate
       };

--- a/app/src/game/wasmSimBridge.test.ts
+++ b/app/src/game/wasmSimBridge.test.ts
@@ -5,9 +5,10 @@
 
 import { describe, expect, it } from 'vitest';
 import { WasmSimBridge } from './wasmSimBridge';
-import { createInitialState, TileKind } from './gameState';
+import { createInitialState } from './gameState';
 import { applyToolCmd, nextStrokeId } from './protocol/commands';
-import { tileKindToU8 } from './protocol/tileKind';
+import { buildingKindToU8 } from './protocol/buildingKind';
+import { BuildingKind } from './buildings/templates';
 import { ServiceId } from './services';
 import type { FromSim } from './protocol/events';
 import type { SimStats } from '../workers/wasmSim.worker';
@@ -273,7 +274,7 @@ describe('WasmSimBridge undo/redo', () => {
     };
     worker.emit({
       type: 'step_result', bytes: emptyTileBuffer(), stats: zeroStats(), mutationSeq: 0, alerts: [],
-      buildingsJson: JSON.stringify([{ id: 7, kind: tileKindToU8(TileKind.ElementarySchool), originX: 0, originY: 0 }]),
+      buildingsJson: JSON.stringify([{ id: 7, kind: buildingKindToU8(BuildingKind.ElementarySchool), originX: 0, originY: 0 }]),
       powerComponentsJson: '[]', waterComponentsJson: '[]',
       educationJson: JSON.stringify(educationStats),
       educationSeatsUsedJson: JSON.stringify([{ buildingId: 7, used: 12 }]),

--- a/app/src/game/wasmSimBridge.ts
+++ b/app/src/game/wasmSimBridge.ts
@@ -14,7 +14,7 @@ import { recordEngineBuild } from '../buildInfo';
 import type { GameState, UtilityComponentStats, ViewStratum } from './gameState';
 import { TileKind } from './gameState';
 import { BuildingStatus, createBuildingState } from './buildings/state';
-import { getBuildingTemplate } from './buildings/templates';
+import { BuildingKind, getBuildingTemplate } from './buildings/templates';
 import { createTileServiceState } from './services';
 import type { LegacyEngineImport, SimBridge } from './simBridge';
 import type { BudgetPolicy, SimCommand, CommandResult } from './protocol/commands';
@@ -23,7 +23,7 @@ import type { FromSim } from './protocol/events';
 import type { SimStats, SimAlertWire } from '../workers/wasmSim.worker';
 import { deriveNarrativeEventFromAlert } from './protocol/deficitNarrative';
 import { decodeTileBuffer } from './protocol/tileBuffer';
-import { tileKindFromU8, tileKindToU8 } from './protocol/tileKind';
+import { buildingKindFromU8 } from './protocol/buildingKind';
 import { Occupant, Terrain, ZoneDensity, hasOccupant } from './protocol/occupants';
 import { Tool } from './toolTypes';
 import { footprintTouchesWater } from './adjacency';
@@ -686,20 +686,25 @@ export class WasmSimBridge implements SimBridge {
     // Mirror of the engine's water opt-in gate (`GameState::has_water_system`):
     // until a pump, tower, or pipe exists, buildings don't require water.
     let hasWaterSystem = wireBuildings.some((b) => {
-      const kind = tileKindFromU8(b.kind);
-      return kind === TileKind.WaterPump || kind === TileKind.WaterTower;
+      const kind = buildingKindFromU8(b.kind);
+      return kind === BuildingKind.WaterPump || kind === BuildingKind.WaterTower;
     });
     for (let i = 0; i < n && !hasWaterSystem; i++) {
       if (hasOccupant(this.state.tiles[i].underground, Occupant.Pipe)) hasWaterSystem = true;
     }
     const seatsUsedByBuildingId = new Map(seatsUsed.map((e) => [e.buildingId, e.used]));
     this.state.buildings = wireBuildings.map((b) => {
-      const kind = tileKindFromU8(b.kind) ?? TileKind.Land;
+      // `b.kind` decodes via `BUILDING_KIND_BY_U8` — an unrecognised byte
+      // (should never happen against a matching engine build) falls back to
+      // the empty string, which `getBuildingTemplate` returns `undefined`
+      // for, same as the old `TileKind.Land` fallback did (Land has no
+      // building template either).
+      const kind: string = buildingKindFromU8(b.kind) ?? '';
       // Status is derived from the tile flags the Rust buffer already set —
       // `hasWaterSystem` gates the water check so buildings in cities without
       // water infrastructure aren't misread as unwatered.
       const originTile = this.state.tiles[b.originY * this.state.width + b.originX];
-      const template = getBuildingTemplate(kind as string);
+      const template = getBuildingTemplate(kind);
       const bstate = createBuildingState();
       const needsPower = template ? template.requiresPower !== false : false;
       const needsWater =
@@ -707,7 +712,7 @@ export class WasmSimBridge implements SimBridge {
       // A pump only produces when its footprint touches water terrain (#200)
       // — distinct from needsWater above, which gates a *consumer* on
       // network coverage; a pump doesn't consume water.
-      const needsSource = kind === TileKind.WaterPump;
+      const needsSource = kind === BuildingKind.WaterPump;
       const origin = { x: b.originX, y: b.originY };
       if (needsPower && !originTile?.powered) {
         bstate.status = BuildingStatus.InactiveNoPower;
@@ -724,7 +729,7 @@ export class WasmSimBridge implements SimBridge {
       }
       return {
         id: b.id,
-        templateId: kind as string,
+        templateId: kind,
         origin,
         state: bstate
       };
@@ -732,11 +737,12 @@ export class WasmSimBridge implements SimBridge {
   }
 }
 
-/** A state's tile kinds as `TileKind` u8 bytes, for engine terrain seeding. */
+/** A state's terrain as `Terrain` u8 bytes (`Land` = 0, `Water` = 1), for
+ *  engine natural-terrain seeding. */
 function terrainBytes(state: GameState): Uint8Array {
   const bytes = new Uint8Array(state.tiles.length);
   for (let i = 0; i < bytes.length; i++) {
-    bytes[i] = tileKindToU8(state.tiles[i].terrain === Terrain.Water ? TileKind.Water : TileKind.Land);
+    bytes[i] = state.tiles[i].terrain === Terrain.Water ? Terrain.Water : Terrain.Land;
   }
   return bytes;
 }

--- a/crates/city-sim-core/src/buildings.rs
+++ b/crates/city-sim-core/src/buildings.rs
@@ -5,7 +5,7 @@
 
 use crate::adjacency::{footprint_touches_water, tile_has_power, tile_has_water};
 use crate::state::{GameState, ServiceKind, FLAG_ABANDONED};
-use city_sim_protocol::tile_kind::TileKind;
+use city_sim_protocol::building_kind::BuildingKind;
 
 // ---------------------------------------------------------------------------
 // BuildingStatus
@@ -59,11 +59,9 @@ pub struct BuildingTemplate {
     pub service_coverage: u32,
 }
 
-/// Look up static template data by the tile kind used when placing a building.
-///
-/// Returns `None` for non-building tile kinds (Land, Road, etc.).
-pub fn get_building_template(kind: TileKind) -> Option<&'static BuildingTemplate> {
-    use TileKind::*;
+/// Look up static template data by building kind.
+pub fn get_building_template(kind: BuildingKind) -> Option<&'static BuildingTemplate> {
+    use BuildingKind::*;
     macro_rules! tmpl {
         ($fp:expr, pwr=$p:expr, wat=$w:expr, wu=$wu:expr, wo=$wo:expr,
          pu=$pu:expr, pop=$pop:expr, jobs=$j:expr, maint=$m:expr,
@@ -162,7 +160,6 @@ pub fn get_building_template(kind: TileKind) -> Option<&'static BuildingTemplate
         ElementarySchool => Some(&ELEM_SCHOOL),
         HighSchool => Some(&HIGH_SCHOOL),
         HydroPlant | CoalPlant | WindTurbine | SolarFarm => Some(&POWER_PLANT),
-        _ => None,
     }
 }
 
@@ -184,8 +181,8 @@ pub const SOLAR_FARM_MW: u32 = 5;
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BuildingInstance {
     pub id: u32,
-    /// The tile kind used to identify this building (determines template lookup).
-    pub kind: TileKind,
+    /// Which building this is — determines template lookup.
+    pub kind: BuildingKind,
     /// Top-left corner of the building footprint.
     pub origin: (u32, u32),
     pub status: BuildingStatus,
@@ -202,7 +199,7 @@ pub struct BuildingInstance {
 }
 
 impl BuildingInstance {
-    pub fn new(id: u32, kind: TileKind, origin: (u32, u32)) -> Self {
+    pub fn new(id: u32, kind: BuildingKind, origin: (u32, u32)) -> Self {
         Self {
             id,
             kind,
@@ -345,9 +342,9 @@ pub fn apply_building_decay(state: &mut GameState, cfg: &DecayConfig) {
 
         // Inline demand lookup to avoid a second borrow of `state`
         let demand: f32 = match kind {
-            TileKind::Residential => state.demand.residential,
-            TileKind::Commercial => state.demand.commercial,
-            TileKind::Industrial => state.demand.industrial,
+            BuildingKind::Residential => state.demand.residential,
+            BuildingKind::Commercial => state.demand.commercial,
+            BuildingKind::Industrial => state.demand.industrial,
             _ => 0.0,
         };
 
@@ -366,10 +363,10 @@ pub fn apply_building_decay(state: &mut GameState, cfg: &DecayConfig) {
             .get(tile_idx)
             .map(|t| t.high_served)
             .unwrap_or(true);
-        let needs_elementary = kind == TileKind::Residential;
+        let needs_elementary = kind == BuildingKind::Residential;
         let needs_high = matches!(
             kind,
-            TileKind::Residential | TileKind::Commercial | TileKind::Industrial
+            BuildingKind::Residential | BuildingKind::Commercial | BuildingKind::Industrial
         );
         let education_unserved = (needs_elementary && !elem_served) || (needs_high && !high_served);
 
@@ -443,7 +440,7 @@ mod tests {
         GameState::new(w, h, 0)
     }
 
-    fn place(s: &mut GameState, kind: TileKind, x: u32, y: u32) -> u32 {
+    fn place(s: &mut GameState, kind: BuildingKind, x: u32, y: u32) -> u32 {
         let id = s.next_building_id;
         s.next_building_id += 1;
         let tile = s.tile_at_mut(x, y).unwrap();
@@ -457,7 +454,7 @@ mod tests {
     #[test]
     fn zone_building_active_when_powered_and_watered() {
         let mut s = gs(1, 1);
-        place(&mut s, TileKind::Residential, 0, 0);
+        place(&mut s, BuildingKind::Residential, 0, 0);
         s.tile_at_mut(0, 0).unwrap().set_flag(FLAG_POWERED, true);
         s.tile_at_mut(0, 0)
             .unwrap()
@@ -469,7 +466,7 @@ mod tests {
     #[test]
     fn zone_building_inactive_no_power() {
         let mut s = gs(1, 1);
-        place(&mut s, TileKind::Residential, 0, 0);
+        place(&mut s, BuildingKind::Residential, 0, 0);
         // not powered, not watered
         update_building_states(&mut s, true);
         assert_eq!(s.buildings[0].status, BuildingStatus::InactiveNoPower);
@@ -478,7 +475,7 @@ mod tests {
     #[test]
     fn zone_building_inactive_no_water_when_powered_but_not_watered() {
         let mut s = gs(1, 1);
-        place(&mut s, TileKind::Residential, 0, 0);
+        place(&mut s, BuildingKind::Residential, 0, 0);
         s.tile_at_mut(0, 0).unwrap().set_flag(FLAG_POWERED, true);
         // not watered
         update_building_states(&mut s, true);
@@ -488,7 +485,7 @@ mod tests {
     #[test]
     fn park_active_without_power_or_water() {
         let mut s = gs(1, 1);
-        place(&mut s, TileKind::Park, 0, 0);
+        place(&mut s, BuildingKind::Park, 0, 0);
         update_building_states(&mut s, true);
         assert_eq!(s.buildings[0].status, BuildingStatus::Active);
     }
@@ -497,7 +494,7 @@ mod tests {
     #[test]
     fn dry_pump_is_inactive_no_source() {
         let mut s = gs(1, 1);
-        place(&mut s, TileKind::WaterPump, 0, 0);
+        place(&mut s, BuildingKind::WaterPump, 0, 0);
         s.tile_at_mut(0, 0).unwrap().set_flag(FLAG_POWERED, true);
         update_building_states(&mut s, true);
         assert_eq!(s.buildings[0].status, BuildingStatus::InactiveNoSource);
@@ -508,7 +505,7 @@ mod tests {
     #[test]
     fn pump_beside_water_is_active() {
         let mut s = gs(2, 1);
-        place(&mut s, TileKind::WaterPump, 0, 0);
+        place(&mut s, BuildingKind::WaterPump, 0, 0);
         s.tile_at_mut(0, 0).unwrap().set_flag(FLAG_POWERED, true);
         s.tile_at_mut(1, 0).unwrap().terrain = Terrain::Water;
         update_building_states(&mut s, true);
@@ -531,7 +528,7 @@ mod tests {
             }
         }
         s.buildings
-            .push(BuildingInstance::new(id, TileKind::WaterTower, (0, 0)));
+            .push(BuildingInstance::new(id, BuildingKind::WaterTower, (0, 0)));
         s.next_building_id += 1;
         update_building_states(&mut s, true);
         assert_eq!(
@@ -554,7 +551,7 @@ mod tests {
             }
         }
         s.buildings
-            .push(BuildingInstance::new(id, TileKind::HydroPlant, (0, 0)));
+            .push(BuildingInstance::new(id, BuildingKind::HydroPlant, (0, 0)));
         s.next_building_id += 1;
         update_building_states(&mut s, true);
         assert_eq!(
@@ -567,7 +564,7 @@ mod tests {
     #[test]
     fn decay_increments_trouble_on_no_power() {
         let mut s = gs(1, 1);
-        place(&mut s, TileKind::Residential, 0, 0);
+        place(&mut s, BuildingKind::Residential, 0, 0);
         s.buildings[0].status = BuildingStatus::InactiveNoPower;
         s.demand.residential = 50.0; // above low threshold — only noPower + education penalty
                                      // Mark tile as education-served so this test isolates the power penalty
@@ -581,7 +578,7 @@ mod tests {
     #[test]
     fn decay_abandons_building_at_threshold() {
         let mut s = gs(1, 1);
-        place(&mut s, TileKind::Residential, 0, 0);
+        place(&mut s, BuildingKind::Residential, 0, 0);
         s.buildings[0].status = BuildingStatus::InactiveNoPower;
         let cfg = DecayConfig::default();
         s.buildings[0].trouble_ticks = cfg.trouble_abandon_thresh - 1.0;
@@ -599,7 +596,7 @@ mod tests {
     #[test]
     fn decay_bleeds_trouble_when_conditions_are_good() {
         let mut s = gs(1, 1);
-        place(&mut s, TileKind::Residential, 0, 0);
+        place(&mut s, BuildingKind::Residential, 0, 0);
         s.buildings[0].status = BuildingStatus::Active;
         s.buildings[0].trouble_ticks = 5.0;
         s.demand.residential = 50.0;
@@ -614,22 +611,29 @@ mod tests {
         assert!((s.buildings[0].trouble_ticks - expected).abs() < 0.001);
     }
 
+    /// Unlike the old `TileKind` key, `BuildingKind` names only buildings —
+    /// there is no non-building member to look up and get `None` back for —
+    /// so the lookup is total over `BuildingKind::ALL`.
     #[test]
-    fn get_building_template_returns_none_for_road() {
-        assert!(get_building_template(TileKind::Road).is_none());
-        assert!(get_building_template(TileKind::Land).is_none());
+    fn get_building_template_covers_every_building_kind() {
+        for &kind in BuildingKind::ALL {
+            assert!(
+                get_building_template(kind).is_some(),
+                "no template for {kind:?}"
+            );
+        }
     }
 
     #[test]
     fn get_building_template_returns_2x2_plant_for_all_power_plant_kinds() {
         // Regression: after BUG-30 added CoalPlant/WindTurbine/SolarFarm as distinct
-        // TileKinds, get_building_template only handled HydroPlant, causing placement
+        // BuildingKinds, get_building_template only handled HydroPlant, causing placement
         // of the other three to fail with "Unknown building type".
         for kind in [
-            TileKind::HydroPlant,
-            TileKind::CoalPlant,
-            TileKind::WindTurbine,
-            TileKind::SolarFarm,
+            BuildingKind::HydroPlant,
+            BuildingKind::CoalPlant,
+            BuildingKind::WindTurbine,
+            BuildingKind::SolarFarm,
         ] {
             let tmpl = get_building_template(kind)
                 .unwrap_or_else(|| panic!("get_building_template returned None for {kind:?}"));
@@ -644,9 +648,9 @@ mod tests {
     #[test]
     fn get_building_template_zone_footprint_is_1x1() {
         for k in [
-            TileKind::Residential,
-            TileKind::Commercial,
-            TileKind::Industrial,
+            BuildingKind::Residential,
+            BuildingKind::Commercial,
+            BuildingKind::Industrial,
         ] {
             let tmpl = get_building_template(k).unwrap();
             assert_eq!(tmpl.footprint, (1, 1));

--- a/crates/city-sim-core/src/commands.rs
+++ b/crates/city-sim-core/src/commands.rs
@@ -12,8 +12,8 @@ use crate::occupants::{
 };
 use crate::state::{GameState, Tile, FLAG_ABANDONED};
 use city_sim_protocol::{
+    building_kind::BuildingKind,
     commands::{CommandResult, Tool, ViewStratum},
-    tile_kind::TileKind,
 };
 
 // ---------------------------------------------------------------------------
@@ -329,44 +329,60 @@ pub fn apply_tool(
             CommandResult::ok()
         }
 
-        // Power plants — each uses its own TileKind; per-type MW output and
+        // Power plants — each uses its own BuildingKind; per-type MW output and
         // maintenance are stored in BuildingInstance for the budget and power BFS.
         Tool::HydroPlant => place_footprint_building(
             state,
-            TileKind::HydroPlant,
+            BuildingKind::HydroPlant,
             x,
             y,
             cost,
             HYDRO_PLANT_MW,
             150.0,
         ),
-        Tool::CoalPlant => {
-            place_footprint_building(state, TileKind::CoalPlant, x, y, cost, COAL_PLANT_MW, 300.0)
-        }
+        Tool::CoalPlant => place_footprint_building(
+            state,
+            BuildingKind::CoalPlant,
+            x,
+            y,
+            cost,
+            COAL_PLANT_MW,
+            300.0,
+        ),
         Tool::WindTurbine => place_footprint_building(
             state,
-            TileKind::WindTurbine,
+            BuildingKind::WindTurbine,
             x,
             y,
             cost,
             WIND_TURBINE_MW,
             30.0,
         ),
-        Tool::SolarFarm => {
-            place_footprint_building(state, TileKind::SolarFarm, x, y, cost, SOLAR_FARM_MW, 20.0)
+        Tool::SolarFarm => place_footprint_building(
+            state,
+            BuildingKind::SolarFarm,
+            x,
+            y,
+            cost,
+            SOLAR_FARM_MW,
+            20.0,
+        ),
+        Tool::WaterPump => {
+            place_footprint_building(state, BuildingKind::WaterPump, x, y, cost, 0, 0.0)
         }
-        Tool::WaterPump => place_footprint_building(state, TileKind::WaterPump, x, y, cost, 0, 0.0),
         Tool::WaterTower => {
-            place_footprint_building(state, TileKind::WaterTower, x, y, cost, 0, 0.0)
+            place_footprint_building(state, BuildingKind::WaterTower, x, y, cost, 0, 0.0)
         }
         Tool::ElementarySchool => {
-            place_footprint_building(state, TileKind::ElementarySchool, x, y, cost, 0, 0.0)
+            place_footprint_building(state, BuildingKind::ElementarySchool, x, y, cost, 0, 0.0)
         }
         Tool::HighSchool => {
-            place_footprint_building(state, TileKind::HighSchool, x, y, cost, 0, 0.0)
+            place_footprint_building(state, BuildingKind::HighSchool, x, y, cost, 0, 0.0)
         }
-        Tool::Park => place_footprint_building(state, TileKind::Park, x, y, cost, 0, 0.0),
-        Tool::ParkLarge => place_footprint_building(state, TileKind::ParkLarge, x, y, cost, 0, 0.0),
+        Tool::Park => place_footprint_building(state, BuildingKind::Park, x, y, cost, 0, 0.0),
+        Tool::ParkLarge => {
+            place_footprint_building(state, BuildingKind::ParkLarge, x, y, cost, 0, 0.0)
+        }
 
         Tool::Bulldoze => bulldoze(state, x, y, cost, stratum),
     }
@@ -449,11 +465,11 @@ pub fn remove_building(state: &mut GameState, building_id: u32) {
 /// plant).  Power plants pass their per-type constant; all other buildings pass 0.
 ///
 /// `maintenance_per_day`: stored on the `BuildingInstance` so each power plant type
-/// can carry its own cost without needing a separate `TileKind`.  Pass 0.0 to fall
-/// back to the template's `maintenance` field at budget time.
+/// can carry its own cost without needing a separate `BuildingKind`.  Pass 0.0 to
+/// fall back to the template's `maintenance` field at budget time.
 fn place_footprint_building(
     state: &mut GameState,
-    kind: TileKind,
+    kind: BuildingKind,
     x: u32,
     y: u32,
     cost: i64,
@@ -635,16 +651,17 @@ mod tests {
     use super::*;
     use crate::migrate::set_v4_kind;
     use city_sim_protocol::legacy_tile_buffer::legacy_flags as flags;
+    use city_sim_protocol::tile_kind::TileKind;
 
     fn gs(w: u32, h: u32) -> GameState {
         GameState::new(w, h, 0)
     }
 
-    /// The `TileKind` of the `BuildingInstance` covering (x,y), if any — the
-    /// one place a specific structure kind still lives since #177 step 3
+    /// The `BuildingKind` of the `BuildingInstance` covering (x,y), if any —
+    /// the one place a specific structure kind still lives since #177 step 3
     /// (`Occupant::Structure` is one flat tag; the structure's own kind is on
     /// its `BuildingInstance`, not the tile).
-    fn structure_kind_at(s: &GameState, x: u32, y: u32) -> Option<TileKind> {
+    fn structure_kind_at(s: &GameState, x: u32, y: u32) -> Option<BuildingKind> {
         let id = s.tile_at(x, y)?.building_id? as u32;
         s.buildings.iter().find(|b| b.id == id).map(|b| b.kind)
     }
@@ -760,7 +777,7 @@ mod tests {
         let before = s.money;
         let r = apply_tool(&mut s, Tool::WaterPump, 0, 0, ViewStratum::Surface);
         assert!(r.success);
-        assert_eq!(structure_kind_at(&s, 0, 0), Some(TileKind::WaterPump));
+        assert_eq!(structure_kind_at(&s, 0, 0), Some(BuildingKind::WaterPump));
         assert!(s.tile_at(0, 0).unwrap().building_id.is_some());
         assert_eq!(s.buildings.len(), 1);
         assert_eq!(s.money, before - tool_cost(Tool::WaterPump));
@@ -774,7 +791,10 @@ mod tests {
         let bid = s.tile_at(0, 0).unwrap().building_id.unwrap();
         for dy in 0..2 {
             for dx in 0..2 {
-                assert_eq!(structure_kind_at(&s, dx, dy), Some(TileKind::WaterTower));
+                assert_eq!(
+                    structure_kind_at(&s, dx, dy),
+                    Some(BuildingKind::WaterTower)
+                );
                 assert_eq!(s.tile_at(dx, dy).unwrap().building_id, Some(bid));
             }
         }
@@ -1394,7 +1414,7 @@ mod tests {
         assert!(r.success);
         assert_eq!(
             structure_kind_at(&s, 0, 0),
-            Some(TileKind::ElementarySchool)
+            Some(BuildingKind::ElementarySchool)
         );
         assert_eq!(s.buildings.len(), 1);
     }
@@ -1449,7 +1469,7 @@ mod tests {
             );
             assert_eq!(
                 structure_kind_at(&s, 1, 1),
-                Some(TileKind::WaterPump),
+                Some(BuildingKind::WaterPump),
                 "tile should not change"
             );
         }
@@ -1579,7 +1599,7 @@ mod tests {
 
             assert_eq!(
                 structure_kind_at(&s, 5, 5),
-                Some(TileKind::CoalPlant),
+                Some(BuildingKind::CoalPlant),
                 "{tool:?} moved the plant"
             );
             let t = s.tile_at(5, 5).unwrap();
@@ -1785,7 +1805,7 @@ mod tests {
         let r = apply_tool(&mut s, Tool::Tree, 5, 5, ViewStratum::Surface);
         assert!(!r.success, "a canopy was planted over a live plant");
         assert_eq!(s.money, before_money, "charged on rejection");
-        assert_eq!(structure_kind_at(&s, 5, 5), Some(TileKind::CoalPlant));
+        assert_eq!(structure_kind_at(&s, 5, 5), Some(BuildingKind::CoalPlant));
         assert_eq!(s.buildings.len(), 1);
 
         // Open ground still takes a tree.
@@ -1809,7 +1829,7 @@ mod tests {
             assert!(apply_tool(&mut s, tool, 1, 1, ViewStratum::Surface).success);
             let r = apply_tool(&mut s, Tool::Park, 1, 1, ViewStratum::Surface);
             assert!(r.success, "a park was refused over {tool:?}");
-            assert_eq!(structure_kind_at(&s, 1, 1), Some(TileKind::Park));
+            assert_eq!(structure_kind_at(&s, 1, 1), Some(BuildingKind::Park));
         }
     }
 
@@ -1877,14 +1897,18 @@ mod tests {
     #[test]
     fn all_power_plants_place_with_correct_tile_kind() {
         // Regression: before the BUG-30 fix, CoalPlant/WindTurbine/SolarFarm all
-        // wrote TileKind::HydroPlant. After the fix their TileKinds were added to
+        // wrote BuildingKind::HydroPlant. After the fix their kinds were added to
         // the protocol but get_building_template was not updated, so placement
         // failed with "Unknown building type" for every non-hydro plant.
         let cases = [
-            (Tool::HydroPlant, TileKind::HydroPlant, HYDRO_PLANT_MW),
-            (Tool::CoalPlant, TileKind::CoalPlant, COAL_PLANT_MW),
-            (Tool::WindTurbine, TileKind::WindTurbine, WIND_TURBINE_MW),
-            (Tool::SolarFarm, TileKind::SolarFarm, SOLAR_FARM_MW),
+            (Tool::HydroPlant, BuildingKind::HydroPlant, HYDRO_PLANT_MW),
+            (Tool::CoalPlant, BuildingKind::CoalPlant, COAL_PLANT_MW),
+            (
+                Tool::WindTurbine,
+                BuildingKind::WindTurbine,
+                WIND_TURBINE_MW,
+            ),
+            (Tool::SolarFarm, BuildingKind::SolarFarm, SOLAR_FARM_MW),
         ];
         for (tool, expected_kind, expected_mw) in cases {
             let mut s = gs(6, 6);

--- a/crates/city-sim-core/src/demand.rs
+++ b/crates/city-sim-core/src/demand.rs
@@ -7,7 +7,7 @@ use crate::buildings::{get_building_template, BuildingStatus};
 use crate::occupants::Occupant;
 use crate::state::{DemandStats, GameState};
 use crate::wilderness::{demand_delta, WildernessTunables};
-use city_sim_protocol::tile_kind::TileKind;
+use city_sim_protocol::building_kind::BuildingKind;
 
 /// Population and job capacity totals — extracted from the city count so
 /// the simulation driver can use them for population growth without a second
@@ -206,10 +206,10 @@ fn count_city(state: &GameState) -> CityCounters {
         }
         c.population_capacity += tmpl.population_capacity;
         c.job_capacity += tmpl.jobs_capacity;
-        if building.kind == TileKind::Commercial {
+        if building.kind == BuildingKind::Commercial {
             c.commercial_job_capacity += tmpl.jobs_capacity;
         }
-        if building.kind == TileKind::Industrial {
+        if building.kind == BuildingKind::Industrial {
             c.industrial_job_capacity += tmpl.jobs_capacity;
         }
     }

--- a/crates/city-sim-core/src/economy.rs
+++ b/crates/city-sim-core/src/economy.rs
@@ -7,7 +7,9 @@ use crate::buildings::get_building_template;
 use crate::occupants::{LedgerLine, Occupant, LEDGER_LINE_COUNT};
 use crate::state::{BudgetHistoryEntry, BudgetStats, GameState};
 use crate::wilderness::{tourism_dividend, WildernessTunables};
+use city_sim_protocol::building_kind::BuildingKind;
 use city_sim_protocol::commands::BudgetPolicy;
+#[cfg(test)]
 use city_sim_protocol::tile_kind::TileKind;
 
 // ---------------------------------------------------------------------------
@@ -120,7 +122,7 @@ pub fn compute_daily_budget(state: &GameState) -> BudgetStats {
             continue;
         };
         // Power plants carry their own maintenance in BuildingInstance so coal,
-        // wind, and solar can differ from hydro without separate TileKind variants.
+        // wind, and solar can differ from hydro without separate BuildingKind variants.
         let maint = if building.maintenance_per_day > 0.0 {
             building.maintenance_per_day
         } else {
@@ -132,27 +134,29 @@ pub fn compute_daily_budget(state: &GameState) -> BudgetStats {
         if tmpl.is_power_plant {
             maint_power += maint;
             match building.kind {
-                TileKind::HydroPlant => maint_power_hydro += maint,
-                TileKind::CoalPlant => maint_power_coal += maint,
-                TileKind::WindTurbine => maint_power_wind += maint,
-                TileKind::SolarFarm => maint_power_solar += maint,
+                BuildingKind::HydroPlant => maint_power_hydro += maint,
+                BuildingKind::CoalPlant => maint_power_coal += maint,
+                BuildingKind::WindTurbine => maint_power_wind += maint,
+                BuildingKind::SolarFarm => maint_power_solar += maint,
                 _ => {}
             }
         } else if tmpl.is_civic {
             maint_civic += maint;
             match building.kind {
-                TileKind::Park | TileKind::ParkLarge => maint_civic_park += maint,
-                TileKind::WaterPump => maint_civic_pump += maint,
-                TileKind::WaterTower => maint_civic_tower += maint,
-                TileKind::ElementarySchool | TileKind::HighSchool => maint_civic_school += maint,
+                BuildingKind::Park | BuildingKind::ParkLarge => maint_civic_park += maint,
+                BuildingKind::WaterPump => maint_civic_pump += maint,
+                BuildingKind::WaterTower => maint_civic_tower += maint,
+                BuildingKind::ElementarySchool | BuildingKind::HighSchool => {
+                    maint_civic_school += maint
+                }
                 _ => {}
             }
         } else if tmpl.is_zone {
             maint_zones += maint;
             match building.kind {
-                TileKind::Residential => maint_zones_res += maint,
-                TileKind::Commercial => maint_zones_com += maint,
-                TileKind::Industrial => maint_zones_ind += maint,
+                BuildingKind::Residential => maint_zones_res += maint,
+                BuildingKind::Commercial => maint_zones_com += maint,
+                BuildingKind::Industrial => maint_zones_ind += maint,
                 _ => {}
             }
         }
@@ -515,15 +519,15 @@ mod tests {
     fn building_maintenance_categorised_correctly() {
         let mut s = gs(4, 4);
         // Zone building
-        let mut res = BuildingInstance::new(1, TileKind::Residential, (0, 0));
+        let mut res = BuildingInstance::new(1, BuildingKind::Residential, (0, 0));
         res.status = BuildingStatus::Active;
         s.buildings.push(res);
         // Civic building
-        let mut park = BuildingInstance::new(2, TileKind::Park, (1, 0));
+        let mut park = BuildingInstance::new(2, BuildingKind::Park, (1, 0));
         park.status = BuildingStatus::Active;
         s.buildings.push(park);
         // Power plant
-        let mut plant = BuildingInstance::new(3, TileKind::HydroPlant, (2, 0));
+        let mut plant = BuildingInstance::new(3, BuildingKind::HydroPlant, (2, 0));
         plant.status = BuildingStatus::Active;
         s.buildings.push(plant);
         let b = compute_daily_budget(&s);
@@ -537,7 +541,7 @@ mod tests {
     fn power_plant_maintenance_per_day_overrides_template() {
         let mut s = gs(4, 4);
         // Coal plant: maintenance_per_day = 300 (template value is 150 for HydroPlant)
-        let mut coal = BuildingInstance::new(1, TileKind::HydroPlant, (0, 0));
+        let mut coal = BuildingInstance::new(1, BuildingKind::HydroPlant, (0, 0));
         coal.status = BuildingStatus::Active;
         coal.maintenance_per_day = 300.0;
         s.buildings.push(coal);
@@ -648,15 +652,15 @@ mod tests {
     #[test]
     fn power_maintenance_breaks_down_by_plant_type() {
         let mut s = gs(8, 8);
-        let mut hydro = BuildingInstance::new(1, TileKind::HydroPlant, (0, 0));
+        let mut hydro = BuildingInstance::new(1, BuildingKind::HydroPlant, (0, 0));
         hydro.status = BuildingStatus::Active;
         hydro.maintenance_per_day = 150.0;
         s.buildings.push(hydro);
-        let mut coal = BuildingInstance::new(2, TileKind::CoalPlant, (2, 0));
+        let mut coal = BuildingInstance::new(2, BuildingKind::CoalPlant, (2, 0));
         coal.status = BuildingStatus::Active;
         coal.maintenance_per_day = 300.0;
         s.buildings.push(coal);
-        let mut wind = BuildingInstance::new(3, TileKind::WindTurbine, (4, 0));
+        let mut wind = BuildingInstance::new(3, BuildingKind::WindTurbine, (4, 0));
         wind.status = BuildingStatus::Active;
         wind.maintenance_per_day = 30.0;
         s.buildings.push(wind);

--- a/crates/city-sim-core/src/education.rs
+++ b/crates/city-sim-core/src/education.rs
@@ -6,6 +6,8 @@
 use crate::buildings::{get_building_template, BuildingStatus};
 use crate::occupants::Occupant;
 use crate::state::{EducationStats, GameState, ServiceKind};
+use city_sim_protocol::building_kind::BuildingKind;
+#[cfg(test)]
 use city_sim_protocol::tile_kind::TileKind;
 use std::cmp::Reverse;
 use std::collections::{BinaryHeap, HashMap, HashSet};
@@ -35,8 +37,8 @@ fn compute_zone_loads(state: &GameState) -> ZoneLoads {
         }
         total_pop_cap += tmpl.population_capacity;
         match b.kind {
-            TileKind::Commercial => total_com_cap += tmpl.jobs_capacity,
-            TileKind::Industrial => total_ind_cap += tmpl.jobs_capacity,
+            BuildingKind::Commercial => total_com_cap += tmpl.jobs_capacity,
+            BuildingKind::Industrial => total_ind_cap += tmpl.jobs_capacity,
             _ => {}
         }
     }
@@ -76,14 +78,14 @@ fn compute_zone_loads(state: &GameState) -> ZoneLoads {
 
         if tmpl.jobs_capacity > 0 {
             let share = match b.kind {
-                TileKind::Commercial => {
+                BuildingKind::Commercial => {
                     if total_com_cap > 0 {
                         (tmpl.jobs_capacity as f32 / total_com_cap as f32) * jobs_in_commercial
                     } else {
                         0.0
                     }
                 }
-                TileKind::Industrial => {
+                BuildingKind::Industrial => {
                     if total_ind_cap > 0 {
                         (tmpl.jobs_capacity as f32 / total_ind_cap as f32) * jobs_in_industrial
                     } else {
@@ -379,7 +381,7 @@ mod tests {
         GameState::new(w, h, 0)
     }
 
-    fn place_building(s: &mut GameState, kind: TileKind, ox: u32, oy: u32) -> u32 {
+    fn place_building(s: &mut GameState, kind: BuildingKind, ox: u32, oy: u32) -> u32 {
         let id = s.next_building_id;
         let tmpl = get_building_template(kind).unwrap();
         let (fw, fh) = tmpl.footprint;
@@ -413,12 +415,12 @@ mod tests {
         // Layout: [School(0,0)(1,0)] [Road(2,0)] [Res(3,0)]
         //         [School(0,1)(1,1)] ...
         let mut s = gs(6, 2);
-        place_building(&mut s, TileKind::ElementarySchool, 0, 0);
+        place_building(&mut s, BuildingKind::ElementarySchool, 0, 0);
         set_v4_kind(s.tile_at_mut(2, 0).unwrap(), TileKind::Road);
         set_v4_kind(s.tile_at_mut(3, 0).unwrap(), TileKind::Residential);
         s.tile_at_mut(3, 0).unwrap().set_flag(FLAG_POWERED, true);
         // Place a residential zone building so it has load
-        place_building(&mut s, TileKind::Residential, 3, 0);
+        place_building(&mut s, BuildingKind::Residential, 3, 0);
         s.population = 14;
         update_building_states(&mut s, false);
         recompute_education(&mut s);
@@ -434,11 +436,11 @@ mod tests {
     #[test]
     fn active_school_records_seats_used_under_its_building_id() {
         let mut s = gs(6, 2);
-        let school_id = place_building(&mut s, TileKind::ElementarySchool, 0, 0);
+        let school_id = place_building(&mut s, BuildingKind::ElementarySchool, 0, 0);
         set_v4_kind(s.tile_at_mut(2, 0).unwrap(), TileKind::Road);
         set_v4_kind(s.tile_at_mut(3, 0).unwrap(), TileKind::Residential);
         s.tile_at_mut(3, 0).unwrap().set_flag(FLAG_POWERED, true);
-        place_building(&mut s, TileKind::Residential, 3, 0);
+        place_building(&mut s, BuildingKind::Residential, 3, 0);
         s.population = 14;
         update_building_states(&mut s, false);
         recompute_education(&mut s);
@@ -453,7 +455,7 @@ mod tests {
     #[test]
     fn inactive_school_records_no_seats_used() {
         let mut s = gs(4, 4);
-        let school_id = place_building(&mut s, TileKind::ElementarySchool, 0, 0);
+        let school_id = place_building(&mut s, BuildingKind::ElementarySchool, 0, 0);
         for dx in 0..2 {
             for dy in 0..2 {
                 s.tile_at_mut(dx, dy).unwrap().set_flag(FLAG_POWERED, false);
@@ -461,7 +463,7 @@ mod tests {
         }
         update_building_states(&mut s, false);
         set_v4_kind(s.tile_at_mut(3, 0).unwrap(), TileKind::Residential);
-        place_building(&mut s, TileKind::Residential, 3, 0);
+        place_building(&mut s, BuildingKind::Residential, 3, 0);
         s.population = 14;
         recompute_education(&mut s);
         assert!(!s.education_seats_used.contains_key(&school_id));
@@ -470,11 +472,11 @@ mod tests {
     #[test]
     fn seats_used_is_dropped_once_its_school_is_demolished() {
         let mut s = gs(6, 2);
-        let school_id = place_building(&mut s, TileKind::ElementarySchool, 0, 0);
+        let school_id = place_building(&mut s, BuildingKind::ElementarySchool, 0, 0);
         set_v4_kind(s.tile_at_mut(2, 0).unwrap(), TileKind::Road);
         set_v4_kind(s.tile_at_mut(3, 0).unwrap(), TileKind::Residential);
         s.tile_at_mut(3, 0).unwrap().set_flag(FLAG_POWERED, true);
-        place_building(&mut s, TileKind::Residential, 3, 0);
+        place_building(&mut s, BuildingKind::Residential, 3, 0);
         s.population = 14;
         update_building_states(&mut s, false);
         recompute_education(&mut s);
@@ -491,11 +493,11 @@ mod tests {
         // share, so its load (300) exceeds the elementary school's 180-seat
         // capacity — `used` must clamp at capacity, not the raw load.
         let mut s = gs(6, 2);
-        let school_id = place_building(&mut s, TileKind::ElementarySchool, 0, 0);
+        let school_id = place_building(&mut s, BuildingKind::ElementarySchool, 0, 0);
         set_v4_kind(s.tile_at_mut(2, 0).unwrap(), TileKind::Road);
         set_v4_kind(s.tile_at_mut(3, 0).unwrap(), TileKind::Residential);
         s.tile_at_mut(3, 0).unwrap().set_flag(FLAG_POWERED, true);
-        place_building(&mut s, TileKind::Residential, 3, 0);
+        place_building(&mut s, BuildingKind::Residential, 3, 0);
         s.population = 300;
         update_building_states(&mut s, false);
         recompute_education(&mut s);
@@ -506,7 +508,7 @@ mod tests {
     #[test]
     fn inactive_school_does_not_serve() {
         let mut s = gs(4, 4);
-        place_building(&mut s, TileKind::ElementarySchool, 0, 0);
+        place_building(&mut s, BuildingKind::ElementarySchool, 0, 0);
         // Make school inactive (no power)
         for dx in 0..2 {
             for dy in 0..2 {
@@ -515,7 +517,7 @@ mod tests {
         }
         update_building_states(&mut s, false);
         set_v4_kind(s.tile_at_mut(3, 0).unwrap(), TileKind::Residential);
-        place_building(&mut s, TileKind::Residential, 3, 0);
+        place_building(&mut s, BuildingKind::Residential, 3, 0);
         s.population = 14;
         recompute_education(&mut s);
         // School is inactive → no coverage (but load=0 still gives coverage=1 if no active buildings)
@@ -549,11 +551,11 @@ mod tests {
         // Layout: [HighSchool(0,0)(1,0)] [Road(2,0)] [Com(3,0)]
         //         [HighSchool(0,1)(1,1)]
         let mut s = gs(6, 2);
-        place_building(&mut s, TileKind::HighSchool, 0, 0);
+        place_building(&mut s, BuildingKind::HighSchool, 0, 0);
         set_v4_kind(s.tile_at_mut(2, 0).unwrap(), TileKind::Road);
         set_v4_kind(s.tile_at_mut(3, 0).unwrap(), TileKind::Commercial);
         s.tile_at_mut(3, 0).unwrap().set_flag(FLAG_POWERED, true);
-        place_building(&mut s, TileKind::Commercial, 3, 0);
+        place_building(&mut s, BuildingKind::Commercial, 3, 0);
         s.jobs = 8;
         update_building_states(&mut s, false);
         recompute_education(&mut s);

--- a/crates/city-sim-core/src/import.rs
+++ b/crates/city-sim-core/src/import.rs
@@ -142,7 +142,12 @@ pub fn from_tile_buffer(
             if let Some((mw, _)) = plant_stats(kind) {
                 tile.power_plant_mw = mw as i32;
             }
-            if let Some(tmpl) = get_building_template(kind) {
+            // `building_kind_of` is the legacy-import boundary: `kind` is a
+            // v4 wire byte here, and `get_building_template` is indexed by
+            // the live `BuildingKind` a `BuildingInstance` actually carries.
+            if let Some(tmpl) =
+                crate::migrate::building_kind_of(kind).and_then(get_building_template)
+            {
                 if tmpl.water_output > 0 {
                     tile.water_output = tmpl.water_output;
                 }
@@ -161,9 +166,15 @@ pub fn from_tile_buffer(
         if state.buildings.iter().any(|b| b.id == id) {
             continue;
         }
+        // A `building_id` with no matching `BuildingKind` is malformed
+        // legacy data — nothing legitimate produces it — so it is skipped
+        // rather than crashing the import.
+        let Some(building_kind) = crate::migrate::building_kind_of(kind) else {
+            continue;
+        };
         let x = (i as u32) % width;
         let y = (i as u32) / width;
-        let mut instance = BuildingInstance::new(id, kind, (x, y));
+        let mut instance = BuildingInstance::new(id, building_kind, (x, y));
         if let Some((_, maintenance)) = plant_stats(kind) {
             instance.maintenance_per_day = maintenance;
         }
@@ -226,11 +237,11 @@ mod tests {
             return TileKind::Water;
         }
         if let Some(kind) = lookup.structure_kind(tile) {
-            return kind;
+            return crate::migrate::tile_kind_of(kind);
         }
         if let Some(zone) = tile.zone_occupant() {
             if let Some(kind) = zone_template_kind(zone) {
-                return kind;
+                return crate::migrate::tile_kind_of(kind);
             }
         }
         if tile.has_occupant(Occupant::Trees) {

--- a/crates/city-sim-core/src/migrate.rs
+++ b/crates/city-sim-core/src/migrate.rs
@@ -3,28 +3,47 @@
 // (c) Copyright 2026 Liminal HQ, Scott Morris
 // SPDX-License-Identifier: MIT
 
-//! One function, [`tile_from_v4`], and two consumers.
+//! One function, [`tile_from_v4`], and its one production consumer.
 //!
 //! Before step 3 of #177 a tile was a single-valued `kind: TileKind` plus three
 //! structural flags (`ROAD_UNDERLAY`, `RAIL_UNDERLAY`, `POWER_OVERLAY`) and an
-//! `underground: Option<TileKind>`. That shape still arrives from two places:
-//!
-//! - `import.rs`, decoding the SoA tile buffer a legacy TS save is re-encoded
-//!   into — where the `kind` byte is legitimately canonical, because it is
-//!   the wire and the wire never changed shape;
-//! - the v4 snapshot migration, which reads the same triple out of a postcard
-//!   payload.
-//!
-//! Both go through this one function, so the legacy importer and the save
-//! migration are a single code path with a single test surface. Its body is
-//! literally the old derived `Tile::occupants()` predicate, relocated: the
-//! two spellings of a road under a line (`kind = Road` + `POWER_OVERLAY`, and
-//! `kind = PowerLine` + `ROAD_UNDERLAY | POWER_OVERLAY`) collapse to the same
+//! `underground: Option<TileKind>`. That shape still arrives from one place:
+//! `import.rs`, decoding the SoA tile buffer a legacy TS save is re-encoded
+//! into — where the `kind` byte is legitimately canonical, because it is the
+//! wire and the wire never changed shape. Its body is literally the old
+//! derived `Tile::occupants()` predicate, relocated: the two spellings of a
+//! road under a line (`kind = Road` with `POWER_OVERLAY`, and `kind =
+//! PowerLine` with `ROAD_UNDERLAY | POWER_OVERLAY`) collapse to the same
 //! `{Road, PowerLine}` here, which is what makes the decode into the strata
 //! lossless in the direction that matters.
+//!
+//! **The v4 *snapshot* migration this module also carried is gone — a
+//! deliberate compatibility break, not an oversight.** It read the same
+//! `(kind, flags, underground)` triple out of a postcard payload for
+//! `snapshot::from_bytes`'s v4 arm. `origin/main` does currently ship
+//! `VERSION = 4` as its one readable CSIM shape — a real `.citysim` download
+//! or IndexedDB engine snapshot saved against a released build is v4 bytes —
+//! so this is not "nothing ever shipped." It is the project's stated
+//! pre-release stance applied on purpose: the CSIM snapshot format, unlike
+//! the legacy JSON save vocabulary and the frozen `legacy_tile_buffer`
+//! layout, carries no compatibility guarantee before 1.0 (`docs/tile-model.md`).
+//! `snapshot.rs`'s `VERSION` moves straight to 6 (v5 itself never left this
+//! branch) and `from_bytes` refuses everything else outright — an old CSIM
+//! save fails loudly with `UnsupportedVersion` rather than loading into a
+//! wrong city. The legacy JSON save import (`import.rs`'s
+//! `from_tile_buffer`, driven by `persistence.ts`'s `deserialize`) is a
+//! separate mechanism — it was never a *snapshot* and this change doesn't
+//! touch it — so an old save is still recoverable through that door; a CSAV
+//! binary save containing a CSIM engine snapshot is not.
+//!
+//! `set_v4`/`set_v4_kind` below stay: they are how ~150 test call sites
+//! spell a tile in the old `kind`-and-flags vocabulary, which exercises
+//! [`tile_from_v4`] across essentially the whole Rust test suite rather than
+//! by one migration test alone.
 
 use crate::occupants::{is_structure_kind, Occupant, Terrain};
-use crate::state::{GameState, Tile, ZoneDensity, DERIVED_FLAG_MASK};
+use crate::state::{Tile, ZoneDensity, DERIVED_FLAG_MASK};
+use city_sim_protocol::building_kind::BuildingKind;
 use city_sim_protocol::legacy_tile_buffer::legacy_flags as wire_flags;
 use city_sim_protocol::tile_kind::TileKind;
 
@@ -105,139 +124,69 @@ pub fn tile_from_v4(
     tile
 }
 
-// ---------------------------------------------------------------------------
-// The v4 snapshot shim
-// ---------------------------------------------------------------------------
-
-/// The v4 `GameState` and `Tile`, described field for field and **in order**.
+/// The `BuildingKind` a legacy structure `TileKind` names, if any.
 ///
-/// Postcard is not self-describing: there are no field names and no lengths on
-/// the wire, so fields are decoded purely positionally. That means you cannot
-/// deserialise "just the tiles" differently — the whole top-level struct has to
-/// be spelled out, which is what this module is for.
+/// The one-time conversion at the legacy-import boundary. `TileKind` is
+/// frozen v4/save vocabulary (`docs/tile-model.md`); `BuildingKind` is the
+/// live `BuildingInstance` alphabet, free to be renumbered pre-release. This
+/// is the single function where the two are allowed to meet — `import.rs`'s
+/// tile-buffer import calls it to turn a decoded wire byte into a
+/// `BuildingInstance::kind` — so nothing downstream of the legacy boundary
+/// ever matches on a raw `TileKind` to decide what a *live* building is.
 ///
-/// **The nested types are the live ones on purpose.** `UtilityStats`,
-/// `DemandStats`, `BudgetStats`, `EducationStats`, `BudgetHistoryEntry`,
-/// `BuildingInstance`, `SeededRng`, `Policies` and `WildernessStats` are
-/// re-used rather than copied, because none of them changed shape in step 3
-/// — only [`Tile`] did. It is a deliberate trade: it saves ~200 lines of
-/// duplication, at the cost of a drift risk (someone edits `BudgetStats` in
-/// 2027 and silently changes what "v4" means). That risk is caught by
-/// `v4_snapshot_loads_the_same_city`, which decodes a committed byte-for-byte
-/// v4 file — and that is exactly the test that would have to catch a
-/// duplicated-and-diverged copy too, so duplication would buy nothing.
-pub(crate) mod v4 {
-    use crate::buildings::BuildingInstance;
-    use crate::rng::SeededRng;
-    use crate::state::{
-        BudgetHistoryEntry, BudgetStats, DemandStats, EducationStats, UtilityStats,
-    };
-    use crate::wilderness::WildernessStats;
-    use city_sim_protocol::commands::Policies;
-    use city_sim_protocol::tile_kind::TileKind;
-    use std::collections::VecDeque;
-
-    /// The pre-strata tile: one `kind` slot, three structural flags packed into
-    /// `flags`, and a separate `underground` slot.
-    #[derive(serde::Deserialize)]
-    pub struct Tile {
-        pub kind: TileKind,
-        pub flags: u8,
-        pub happiness: f32,
-        pub elevation: u8,
-        pub building_id: Option<u16>,
-        pub underground: Option<TileKind>,
-        pub power_plant_mw: i32,
-        pub water_output: i32,
-        pub elementary_served: bool,
-        pub high_served: bool,
-        pub elementary_score: f32,
-        pub high_score: f32,
-    }
-
-    /// The v4 top-level state. `tiles` is the one substituted field; every
-    /// other field is the live type at the live position.
-    #[derive(serde::Deserialize)]
-    pub struct GameState {
-        pub width: u32,
-        pub height: u32,
-        pub tiles: Vec<Tile>,
-        pub seed: u32,
-        pub rng: SeededRng,
-        pub money: i64,
-        pub day: u32,
-        pub tick: u64,
-        pub population: u32,
-        pub jobs: u32,
-        pub pop_frac: f64,
-        pub jobs_frac: f64,
-        pub money_frac: f64,
-        pub day_frac: f64,
-        pub utilities: UtilityStats,
-        pub demand: DemandStats,
-        pub tile_revision: u32,
-        pub next_building_id: u32,
-        pub buildings: Vec<BuildingInstance>,
-        pub education: EducationStats,
-        pub budget: BudgetStats,
-        pub budget_history: VecDeque<BudgetHistoryEntry>,
-        pub policies: Policies,
-        pub wilderness: WildernessStats,
+/// The thirteen building-capable `TileKind`s map across one for one, in the
+/// same order `BuildingKind::ALL` declares them; every other `TileKind`
+/// (terrain, transport, the zone-agnostic overlays) returns `None`.
+pub(crate) fn building_kind_of(kind: TileKind) -> Option<BuildingKind> {
+    match kind {
+        TileKind::Residential => Some(BuildingKind::Residential),
+        TileKind::Commercial => Some(BuildingKind::Commercial),
+        TileKind::Industrial => Some(BuildingKind::Industrial),
+        TileKind::HydroPlant => Some(BuildingKind::HydroPlant),
+        TileKind::CoalPlant => Some(BuildingKind::CoalPlant),
+        TileKind::WindTurbine => Some(BuildingKind::WindTurbine),
+        TileKind::SolarFarm => Some(BuildingKind::SolarFarm),
+        TileKind::WaterPump => Some(BuildingKind::WaterPump),
+        TileKind::WaterTower => Some(BuildingKind::WaterTower),
+        TileKind::ElementarySchool => Some(BuildingKind::ElementarySchool),
+        TileKind::HighSchool => Some(BuildingKind::HighSchool),
+        TileKind::Park => Some(BuildingKind::Park),
+        TileKind::ParkLarge => Some(BuildingKind::ParkLarge),
+        TileKind::Land
+        | TileKind::Water
+        | TileKind::Tree
+        | TileKind::Road
+        | TileKind::Rail
+        | TileKind::PowerLine
+        | TileKind::WaterPipe => None,
     }
 }
 
-/// Convert a decoded v4 snapshot into the current [`GameState`].
+/// The inverse of [`building_kind_of`]: the legacy `TileKind` a live
+/// `BuildingKind` was copied from.
 ///
-/// Only the tile vector actually changes shape; everything else moves across
-/// unchanged. Each tile goes through [`tile_from_v4`], so the save migration
-/// and the legacy `import.rs` buffer path are one code path with one test
-/// surface — and the derived fields the v4 tile carried (happiness, elevation,
-/// the cached utility outputs, the four education fields) are copied over it,
-/// because `tile_from_v4` only knows about structure.
-pub(crate) fn v4_to_v5(old: v4::GameState) -> GameState {
-    let tiles = old
-        .tiles
-        .into_iter()
-        .map(|t| Tile {
-            happiness: t.happiness,
-            elevation: t.elevation,
-            power_plant_mw: t.power_plant_mw,
-            water_output: t.water_output,
-            elementary_served: t.elementary_served,
-            high_served: t.high_served,
-            elementary_score: t.elementary_score,
-            high_score: t.high_score,
-            ..tile_from_v4(t.kind, t.flags, t.underground, t.building_id)
-        })
-        .collect();
-
-    GameState {
-        width: old.width,
-        height: old.height,
-        tiles,
-        seed: old.seed,
-        rng: old.rng,
-        money: old.money,
-        day: old.day,
-        tick: old.tick,
-        population: old.population,
-        jobs: old.jobs,
-        pop_frac: old.pop_frac,
-        jobs_frac: old.jobs_frac,
-        money_frac: old.money_frac,
-        day_frac: old.day_frac,
-        utilities: old.utilities,
-        demand: old.demand,
-        tile_revision: old.tile_revision,
-        next_building_id: old.next_building_id,
-        buildings: old.buildings,
-        education: old.education,
-        education_seats_used: std::collections::HashMap::new(),
-        budget: old.budget,
-        budget_history: old.budget_history,
-        policies: old.policies,
-        wilderness: old.wilderness,
-        utility_networks: crate::utilities::UtilityNetworks::default(),
+/// Exists for the direction only the legacy-export test path still needs —
+/// `import.rs`'s round-trip test re-derives a v4-shaped wire buffer from a
+/// live `GameState` to check `from_tile_buffer` against it, and that is the
+/// one place left that goes *from* `BuildingKind` back *to* `TileKind`.
+/// Production code never runs this direction: a live save is CSAV, not the
+/// legacy v4 buffer.
+#[cfg(test)]
+pub(crate) fn tile_kind_of(kind: BuildingKind) -> TileKind {
+    match kind {
+        BuildingKind::Residential => TileKind::Residential,
+        BuildingKind::Commercial => TileKind::Commercial,
+        BuildingKind::Industrial => TileKind::Industrial,
+        BuildingKind::HydroPlant => TileKind::HydroPlant,
+        BuildingKind::CoalPlant => TileKind::CoalPlant,
+        BuildingKind::WindTurbine => TileKind::WindTurbine,
+        BuildingKind::SolarFarm => TileKind::SolarFarm,
+        BuildingKind::WaterPump => TileKind::WaterPump,
+        BuildingKind::WaterTower => TileKind::WaterTower,
+        BuildingKind::ElementarySchool => TileKind::ElementarySchool,
+        BuildingKind::HighSchool => TileKind::HighSchool,
+        BuildingKind::Park => TileKind::Park,
+        BuildingKind::ParkLarge => TileKind::ParkLarge,
     }
 }
 
@@ -263,95 +212,6 @@ pub fn set_v4(tile: &mut Tile, kind: TileKind, flags: u8, underground: Option<Ti
 #[cfg(test)]
 pub fn set_v4_kind(tile: &mut Tile, kind: TileKind) {
     set_v4(tile, kind, 0, None);
-}
-
-#[cfg(test)]
-mod state_migration_tests {
-    use super::*;
-
-    /// Every per-tile field a v4 tile carried must arrive on the other side.
-    ///
-    /// [`tile_from_v4`] only knows about *structure* — it leaves the derived
-    /// fields at [`Tile::land`]'s defaults for the caller to fill in, and
-    /// [`v4_to_v5`] is that caller. The failure this guards is silent: add a
-    /// field to [`Tile`], forget it in `v4_to_v5`, and every v4 save loads with
-    /// it quietly zeroed. Naming all eight here means the next person to add a
-    /// field finds out from a test rather than from a player's ruined city.
-    #[test]
-    fn v4_to_v5_carries_every_derived_tile_field_across() {
-        let base = GameState::new(1, 1, 1);
-        let old = v4::GameState {
-            width: 1,
-            height: 1,
-            tiles: vec![v4::Tile {
-                kind: TileKind::Residential,
-                flags: wire_flags::POWERED,
-                happiness: 1.25,
-                elevation: 7,
-                building_id: Some(4),
-                underground: Some(TileKind::WaterPipe),
-                power_plant_mw: 55,
-                water_output: 66,
-                elementary_served: true,
-                high_served: false,
-                elementary_score: 0.75,
-                high_score: 0.25,
-            }],
-            seed: base.seed,
-            rng: base.rng.clone(),
-            money: 4321,
-            day: 9,
-            tick: 180,
-            population: 12,
-            jobs: 34,
-            pop_frac: 0.5,
-            jobs_frac: 0.25,
-            money_frac: 0.125,
-            day_frac: 0.0625,
-            utilities: base.utilities.clone(),
-            demand: base.demand.clone(),
-            tile_revision: 3,
-            next_building_id: 5,
-            buildings: Vec::new(),
-            education: base.education.clone(),
-            budget: base.budget.clone(),
-            budget_history: base.budget_history.clone(),
-            policies: base.policies,
-            wilderness: base.wilderness.clone(),
-        };
-
-        let new = v4_to_v5(old);
-        let t = &new.tiles[0];
-
-        // Derived fields — copied verbatim.
-        assert_eq!(t.happiness, 1.25);
-        assert_eq!(t.elevation, 7);
-        assert_eq!(t.power_plant_mw, 55);
-        assert_eq!(t.water_output, 66);
-        assert!(t.elementary_served);
-        assert!(!t.high_served);
-        assert_eq!(t.elementary_score, 0.75);
-        assert_eq!(t.high_score, 0.25);
-        // Structural fields — converted.
-        assert_eq!(t.terrain, Terrain::Land);
-        assert!(t.has_occupant(Occupant::ZoneResidential));
-        assert!(t.has_occupant(Occupant::Pipe));
-        assert_eq!(t.building_id, Some(4));
-        assert_eq!(t.flags, wire_flags::POWERED);
-
-        // And the scalars that simply move across.
-        assert_eq!(new.money, 4321);
-        assert_eq!(new.day, 9);
-        assert_eq!(new.tick, 180);
-        assert_eq!(new.population, 12);
-        assert_eq!(new.jobs, 34);
-        assert_eq!(new.pop_frac, 0.5);
-        assert_eq!(new.jobs_frac, 0.25);
-        assert_eq!(new.money_frac, 0.125);
-        assert_eq!(new.day_frac, 0.0625);
-        assert_eq!(new.tile_revision, 3);
-        assert_eq!(new.next_building_id, 5);
-    }
 }
 
 #[cfg(test)]
@@ -452,6 +312,70 @@ mod tests {
                 );
                 assert!(iter_set(t.occupants()).count() <= 11);
             }
+        }
+    }
+
+    /// [`building_kind_of`]'s domain is a strict superset of
+    /// [`is_structure_kind`]'s: every non-zone structure kind converts (the
+    /// two must agree there, or `import.rs`'s decode loop would tag a tile
+    /// `Structure` with no `BuildingKind` to build the instance from), *and*
+    /// the three zone kinds also convert even though `is_structure_kind` is
+    /// `false` for them — a developed lot's `BuildingInstance` is templated
+    /// from `Residential`/`Commercial`/`Industrial` too, it just carries a
+    /// zone tag rather than the `Structure` occupant (`is_structure_kind`'s
+    /// own doc comment). Every other `TileKind` converts to neither.
+    #[test]
+    fn building_kind_of_is_a_superset_of_is_structure_kind_covering_zones_too() {
+        for &kind in TileKind::ALL {
+            let is_zone = matches!(
+                kind,
+                TileKind::Residential | TileKind::Commercial | TileKind::Industrial
+            );
+            assert_eq!(
+                building_kind_of(kind).is_some(),
+                is_structure_kind(kind) || is_zone,
+                "{kind:?}: building_kind_of should be Some iff the kind is a \
+                 non-zone structure or one of the three zone kinds"
+            );
+        }
+    }
+
+    /// The thirteen conversions land on the `BuildingKind` the name says,
+    /// not just on *some* `Some(_)`.
+    #[test]
+    fn building_kind_of_maps_each_structure_tile_kind_to_the_matching_building_kind() {
+        let cases = [
+            (TileKind::Residential, BuildingKind::Residential),
+            (TileKind::Commercial, BuildingKind::Commercial),
+            (TileKind::Industrial, BuildingKind::Industrial),
+            (TileKind::HydroPlant, BuildingKind::HydroPlant),
+            (TileKind::CoalPlant, BuildingKind::CoalPlant),
+            (TileKind::WindTurbine, BuildingKind::WindTurbine),
+            (TileKind::SolarFarm, BuildingKind::SolarFarm),
+            (TileKind::WaterPump, BuildingKind::WaterPump),
+            (TileKind::WaterTower, BuildingKind::WaterTower),
+            (TileKind::ElementarySchool, BuildingKind::ElementarySchool),
+            (TileKind::HighSchool, BuildingKind::HighSchool),
+            (TileKind::Park, BuildingKind::Park),
+            (TileKind::ParkLarge, BuildingKind::ParkLarge),
+        ];
+        for (tile_kind, building_kind) in cases {
+            assert_eq!(building_kind_of(tile_kind), Some(building_kind));
+        }
+    }
+
+    #[test]
+    fn building_kind_of_is_none_for_non_structure_tile_kinds() {
+        for kind in [
+            TileKind::Land,
+            TileKind::Water,
+            TileKind::Tree,
+            TileKind::Road,
+            TileKind::Rail,
+            TileKind::PowerLine,
+            TileKind::WaterPipe,
+        ] {
+            assert_eq!(building_kind_of(kind), None, "{kind:?}");
         }
     }
 }

--- a/crates/city-sim-core/src/occupants.rs
+++ b/crates/city-sim-core/src/occupants.rs
@@ -20,19 +20,23 @@
 //! [`Overhead`] — hold everything standing on, over or under it, one bit per
 //! [`Occupant`]. There is one
 //! spelling, no precedence, and nothing to reconcile. `TileKind` no longer
-//! describes a tile at all, and it survives as exactly two other things: the
-//! *wire vocabulary* (the `kind` byte of the SoA tile buffer — see
-//! `display.rs`), and the *building template key* (`BuildingInstance::kind`),
-//! which is still canonical — for the structure, not for the tile.
+//! describes a tile at all, and it survives as exactly one other thing today:
+//! the *legacy wire vocabulary* (the `kind` byte of the frozen v4 tile buffer
+//! `import.rs`/`migrate.rs` decode — see `display.rs`). It is no longer the
+//! building template key either — that job moved to
+//! [`BuildingKind`] (`BuildingInstance::kind`), a dedicated
+//! alphabet free of `TileKind`'s frozen-save constraint, since a building is
+//! an entity occupying a tile, not a kind of tile.
 //!
 //! It was three until the wilderness eco tunables were split by concept. One
 //! dense `base_eco[TileKind]` array held terrain credits, occupant values and
 //! per-structure values side by side, and `EcoSource::Kind` pointed each
 //! occupant at its row — which is what kept `TileKind` alive as an
 //! engine-internal lookup key. There are three tables now, keyed by
-//! [`Terrain`], [`Occupant`] and `TileKind` respectively, and the surviving
-//! `TileKind` key is the building template key doing its own job: saying
-//! *which structure* stands there.
+//! [`Terrain`], [`Occupant`] and [`BuildingKind`]
+//! respectively (via [`BuildingKind::dense_index`]), and
+//! the surviving structure-eco key does its own job: saying *which
+//! structure* stands there.
 //!
 //! Three strata, stacked the way the world is:
 //!
@@ -77,6 +81,7 @@
 use crate::economy::{MAINT_POWER_LINE, MAINT_RAIL, MAINT_ROAD, MAINT_WATER_PIPE};
 use crate::state::{GameState, Tile};
 use crate::wilderness::WildernessTunables;
+use city_sim_protocol::building_kind::BuildingKind;
 use city_sim_protocol::commands::BudgetPolicy;
 use city_sim_protocol::tile_kind::TileKind;
 
@@ -336,9 +341,10 @@ pub const ALL_LEDGER_LINES: [LedgerLine; LEDGER_LINE_COUNT] = [
 /// (terrain credit, occupant value, structure value), so `Occupant::Road` did
 /// not own its −2.0; it owned a *pointer* to the row of a `TileKind`-indexed
 /// array that happened to hold it. The array is now three tables keyed by the
-/// three concepts, `Occupant::Road` reads its own row, and only the structure
-/// table is still keyed by `TileKind` — where the key is the building template
-/// key, which is canonical for structure identity.
+/// three concepts, `Occupant::Road` reads its own row, and the structure
+/// table is keyed by [`crate::buildings::get_building_template`]'s own key —
+/// [`BuildingKind`] — which is canonical for structure identity and, unlike
+/// `TileKind`, was never the frozen-save alphabet to begin with.
 ///
 /// What is **not** on this enum is a number. Eco values are tunable at
 /// runtime: the Green Industry programme rewrites the industrial row while the
@@ -1167,41 +1173,47 @@ pub fn occupant_is_strong_nature(o: Occupant) -> Option<bool> {
 
 /// Eco value of a specific structure kind — a 12.0 spread from +4.0 (park) to
 /// −8.0 (coal plant). It is the *spread* that matters, not the count: only four
-/// distinct values exist across the ten kinds, but collapsing them into one
-/// `Structure` constant would flatten a park and a coal plant into each other.
-pub fn structure_eco(kind: TileKind, t: &WildernessTunables) -> f32 {
-    debug_assert!(
-        is_structure_kind(kind),
-        "structure_eco called with a non-structure kind"
-    );
-    t.structure_eco[kind as usize]
+/// distinct values exist across the thirteen kinds, but collapsing them into
+/// one `Structure` constant would flatten a park and a coal plant into each
+/// other.
+pub fn structure_eco(kind: BuildingKind, t: &WildernessTunables) -> f32 {
+    t.structure_eco[kind.dense_index()]
 }
 
 /// Wilderness breakdown line for a specific structure kind.
-pub fn structure_category(kind: TileKind) -> EcoCategory {
+pub fn structure_category(kind: BuildingKind) -> EcoCategory {
     match kind {
-        TileKind::HydroPlant
-        | TileKind::CoalPlant
-        | TileKind::WindTurbine
-        | TileKind::SolarFarm => EcoCategory::Power,
-        TileKind::WaterPump
-        | TileKind::WaterTower
-        | TileKind::ElementarySchool
-        | TileKind::HighSchool => EcoCategory::Civic,
-        TileKind::Park | TileKind::ParkLarge => EcoCategory::Parks,
-        _ => EcoCategory::Neutral,
+        BuildingKind::HydroPlant
+        | BuildingKind::CoalPlant
+        | BuildingKind::WindTurbine
+        | BuildingKind::SolarFarm => EcoCategory::Power,
+        BuildingKind::WaterPump
+        | BuildingKind::WaterTower
+        | BuildingKind::ElementarySchool
+        | BuildingKind::HighSchool => EcoCategory::Civic,
+        BuildingKind::Park | BuildingKind::ParkLarge => EcoCategory::Parks,
+        BuildingKind::Residential | BuildingKind::Commercial | BuildingKind::Industrial => {
+            EcoCategory::Neutral
+        }
     }
 }
 
 /// Parks are strong nature; every other structure is not.
-pub fn structure_is_strong_nature(kind: TileKind) -> bool {
-    matches!(kind, TileKind::Park | TileKind::ParkLarge)
+pub fn structure_is_strong_nature(kind: BuildingKind) -> bool {
+    matches!(kind, BuildingKind::Park | BuildingKind::ParkLarge)
 }
 
-/// The ten `TileKind`s that derive to the single `Structure` occupant. They
-/// behave identically under every compatibility rule — `place_footprint_building`
-/// applies one guard to all of them — so one tag suffices, and the per-kind
-/// data (eco, upkeep, category) is looked up rather than duplicated.
+/// The ten non-zone `TileKind`s that derive to the single `Structure`
+/// occupant when decoding a legacy v4 byte (`migrate::tile_from_v4`) — the
+/// three zone kinds decode to a zone tag instead, never to `Structure`. They
+/// behave identically under every compatibility rule —
+/// `place_footprint_building` applies one guard to all of them — so one tag
+/// suffices, and the per-kind data (eco, upkeep, category) is looked up
+/// rather than duplicated.
+///
+/// Legacy-decode-only: this asks the question of a v4 wire byte, not of a
+/// live `BuildingInstance` — see `migrate::building_kind_of` for the
+/// analogous question asked of the *current* alphabet.
 pub const fn is_structure_kind(kind: TileKind) -> bool {
     matches!(
         kind,
@@ -1222,18 +1234,18 @@ pub const fn is_structure_kind(kind: TileKind) -> bool {
 // Structure identity
 // ---------------------------------------------------------------------------
 
-/// The `TileKind` a zone occupant's `BuildingInstance` is templated from.
+/// The `BuildingKind` a zone occupant's `BuildingInstance` is templated from.
 ///
-/// The inverse of the three `ZoneX => TileKind::X` arms that used to live in
-/// `Tile::zone_occupant`. `get_building_template` is indexed by `TileKind`, so
-/// growing a lot needs the tag turned back into a template key; the tag itself
-/// is what the *land use* question is asked of.
+/// The inverse of the three `ZoneX => BuildingKind::X` arms that used to live
+/// in `Tile::zone_occupant`. `get_building_template` is indexed by
+/// `BuildingKind`, so growing a lot needs the tag turned back into a template
+/// key; the tag itself is what the *land use* question is asked of.
 #[inline]
-pub fn zone_template_kind(o: Occupant) -> Option<TileKind> {
+pub fn zone_template_kind(o: Occupant) -> Option<BuildingKind> {
     match o {
-        Occupant::ZoneResidential => Some(TileKind::Residential),
-        Occupant::ZoneCommercial => Some(TileKind::Commercial),
-        Occupant::ZoneIndustrial => Some(TileKind::Industrial),
+        Occupant::ZoneResidential => Some(BuildingKind::Residential),
+        Occupant::ZoneCommercial => Some(BuildingKind::Commercial),
+        Occupant::ZoneIndustrial => Some(BuildingKind::Industrial),
         _ => None,
     }
 }
@@ -1249,7 +1261,7 @@ pub fn zone_template_kind(o: Occupant) -> Option<TileKind> {
 /// recompute.
 pub struct StructureLookup {
     /// Indexed by building id; `None` for ids that are not live buildings.
-    kinds: Vec<Option<TileKind>>,
+    kinds: Vec<Option<BuildingKind>>,
 }
 
 impl StructureLookup {
@@ -1271,7 +1283,7 @@ impl StructureLookup {
 
     /// The template kind of the building with this id, if it is live.
     #[inline]
-    pub fn kind_of(&self, id: u16) -> Option<TileKind> {
+    pub fn kind_of(&self, id: u16) -> Option<BuildingKind> {
         self.kinds.get(id as usize).copied().flatten()
     }
 
@@ -1281,7 +1293,7 @@ impl StructureLookup {
     /// `BuildingInstance` whose kind is `Residential`, but its occupant is a
     /// zone tag, not [`Occupant::Structure`].
     #[inline]
-    pub fn structure_kind(&self, tile: &Tile) -> Option<TileKind> {
+    pub fn structure_kind(&self, tile: &Tile) -> Option<BuildingKind> {
         if !tile.has_occupant(Occupant::Structure) {
             return None;
         }
@@ -1554,10 +1566,18 @@ mod tests {
 
     /// The [`StructureLookup`] that goes with [`tile`]: building id 1 is a
     /// `kind`, which is the development `tile` hands every structure kind.
+    /// Mirrors `tile`'s own `is_structure_kind` gate — a non-structure `kind`
+    /// gets no `BuildingInstance` here either, matching the ghost `tile`
+    /// leaves it with no `building_id` for.
     fn lookup(kind: TileKind) -> StructureLookup {
         let mut s = GameState::new(1, 1, 0);
-        s.buildings
-            .push(crate::buildings::BuildingInstance::new(1, kind, (0, 0)));
+        if let Some(building_kind) = crate::migrate::building_kind_of(kind) {
+            s.buildings.push(crate::buildings::BuildingInstance::new(
+                1,
+                building_kind,
+                (0, 0),
+            ));
+        }
         s.next_building_id = 2;
         StructureLookup::new(&s)
     }
@@ -1613,7 +1633,7 @@ mod tests {
         WildernessTunables {
             terrain_eco: [0.0; TERRAIN_COUNT],
             occupant_eco: [0.0; OCCUPANT_COUNT],
-            structure_eco: [0.0; TileKind::COUNT],
+            structure_eco: [0.0; BuildingKind::COUNT],
             patch_bonus_cap: 0.0,
             edge_bonus: 0.0,
             fragmentation_penalty: 0.0,
@@ -1692,14 +1712,19 @@ mod tests {
     /// A structure's eco comes from its development, so the probe tile needs a
     /// `BuildingInstance` behind it or it is scored as bare ground.
     fn breakdown_line_for_structure(kind: TileKind) -> EcoCategory {
+        let building_kind = crate::migrate::building_kind_of(kind)
+            .expect("breakdown_line_for_structure called with a non-structure TileKind");
         let mut t = zeroed_eco_tunables();
-        t.structure_eco[kind as usize] = 1.0;
+        t.structure_eco[building_kind.dense_index()] = 1.0;
         measure_breakdown_line(&t, |s| {
             s.tiles[4] = crate::state::Tile::land();
             s.tiles[4].set_occupant(Occupant::Structure, true);
             s.tiles[4].building_id = Some(1);
-            s.buildings
-                .push(crate::buildings::BuildingInstance::new(1, kind, (1, 1)));
+            s.buildings.push(crate::buildings::BuildingInstance::new(
+                1,
+                building_kind,
+                (1, 1),
+            ));
             s.next_building_id = 2;
         })
     }
@@ -2317,7 +2342,7 @@ mod tests {
         s.tiles[idx].building_id = Some(9);
         s.buildings.push(crate::buildings::BuildingInstance::new(
             9,
-            TileKind::Residential,
+            BuildingKind::Residential,
             (1, 1),
         ));
         crate::commands::remove_building(&mut s, 9);
@@ -3337,7 +3362,7 @@ mod tests {
         s.tiles[0] = lot;
         s.buildings.push(crate::buildings::BuildingInstance::new(
             3,
-            TileKind::Residential,
+            BuildingKind::Residential,
             (0, 0),
         ));
         s.next_building_id = 4;
@@ -3558,8 +3583,9 @@ mod tests {
             "a structure kind was added without an eco entry"
         );
         for (kind, eco, category) in table {
-            assert_eq!(structure_eco(kind, &t), eco, "{kind:?}");
-            assert_eq!(structure_category(kind), category, "{kind:?}");
+            let building_kind = crate::migrate::building_kind_of(kind).unwrap();
+            assert_eq!(structure_eco(building_kind, &t), eco, "{kind:?}");
+            assert_eq!(structure_category(building_kind), category, "{kind:?}");
             assert_eq!(eco_of(kind, 0, None, &t), eco, "{kind:?}");
         }
         // The `Structure` tag cannot answer, and says so rather than handing
@@ -3589,7 +3615,8 @@ mod tests {
         assert_eq!(occupant_eco(Occupant::Fibre, &t), Some(0.0));
 
         // The park/coal spread is the thing a flattened constant would destroy.
-        let spread = structure_eco(TileKind::Park, &t) - structure_eco(TileKind::CoalPlant, &t);
+        let spread =
+            structure_eco(BuildingKind::Park, &t) - structure_eco(BuildingKind::CoalPlant, &t);
         assert_eq!(spread, 12.0);
         // …and it survives every route into the score, not just `structure_eco`.
         let park = tile(TileKind::Park, 0, None);
@@ -3651,7 +3678,10 @@ mod tests {
         }
         for &kind in TileKind::ALL {
             if is_structure_kind(kind) {
-                note(structure_category(kind), &mut produced);
+                note(
+                    structure_category(crate::migrate::building_kind_of(kind).unwrap()),
+                    &mut produced,
+                );
             }
             if let Some(c) = tile(kind, 0, None).terrain_category() {
                 note(c, &mut produced);
@@ -3735,17 +3765,17 @@ mod tests {
             );
         }
 
-        let structures: [(TileKind, EcoCategory); 10] = [
-            (TileKind::HydroPlant, EcoCategory::Power),
-            (TileKind::CoalPlant, EcoCategory::Power),
-            (TileKind::WindTurbine, EcoCategory::Power),
-            (TileKind::SolarFarm, EcoCategory::Power),
-            (TileKind::WaterPump, EcoCategory::Civic),
-            (TileKind::WaterTower, EcoCategory::Civic),
-            (TileKind::ElementarySchool, EcoCategory::Civic),
-            (TileKind::HighSchool, EcoCategory::Civic),
-            (TileKind::Park, EcoCategory::Parks),
-            (TileKind::ParkLarge, EcoCategory::Parks),
+        let structures: [(BuildingKind, EcoCategory); 10] = [
+            (BuildingKind::HydroPlant, EcoCategory::Power),
+            (BuildingKind::CoalPlant, EcoCategory::Power),
+            (BuildingKind::WindTurbine, EcoCategory::Power),
+            (BuildingKind::SolarFarm, EcoCategory::Power),
+            (BuildingKind::WaterPump, EcoCategory::Civic),
+            (BuildingKind::WaterTower, EcoCategory::Civic),
+            (BuildingKind::ElementarySchool, EcoCategory::Civic),
+            (BuildingKind::HighSchool, EcoCategory::Civic),
+            (BuildingKind::Park, EcoCategory::Parks),
+            (BuildingKind::ParkLarge, EcoCategory::Parks),
         ];
         assert_eq!(
             structures.len(),
@@ -3761,13 +3791,14 @@ mod tests {
             if !is_structure_kind(kind) {
                 continue;
             }
+            let building_kind = crate::migrate::building_kind_of(kind).unwrap();
             let want = structures
                 .iter()
-                .find(|(k, _)| *k == kind)
+                .find(|(k, _)| *k == building_kind)
                 .unwrap_or_else(|| panic!("{kind:?} has no pinned breakdown category"))
                 .1;
             println!("  {:<18} {want:?}", kind.ts_string());
-            assert_eq!(structure_category(kind), want, "{kind:?}");
+            assert_eq!(structure_category(building_kind), want, "{kind:?}");
             assert_eq!(
                 want,
                 breakdown_line_for_structure(kind),
@@ -3782,7 +3813,7 @@ mod tests {
         for &kind in TileKind::ALL {
             let tl = tile(kind, 0, None);
             let derived = if is_structure_kind(kind) {
-                structure_category(kind)
+                structure_category(crate::migrate::building_kind_of(kind).unwrap())
             } else {
                 let mut present = iter_set(tl.occupants());
                 let first = present.next();
@@ -3929,5 +3960,42 @@ mod tests {
         assert_eq!(Tile::water().terrain(), Terrain::Water);
         assert_eq!(Tile::land().occupants(), 0);
         assert_eq!(Tile::water().occupants(), 0, "terrain is not an occupant");
+    }
+
+    /// Every zone occupant maps to its own `BuildingKind`, not just "some
+    /// `Some(_)`" — `place_zone_building` (`zones.rs`) trusts this to pick the
+    /// right template when a lot develops, and a mutation-testing pass found
+    /// nothing exercised the `Commercial`/`Industrial` arms in isolation
+    /// (only end-to-end zone-growth tests touch them, and not tightly enough
+    /// to pin the mapping).
+    #[test]
+    fn zone_template_kind_maps_each_zone_tag_to_its_own_building_kind() {
+        assert_eq!(
+            zone_template_kind(Occupant::ZoneResidential),
+            Some(BuildingKind::Residential)
+        );
+        assert_eq!(
+            zone_template_kind(Occupant::ZoneCommercial),
+            Some(BuildingKind::Commercial)
+        );
+        assert_eq!(
+            zone_template_kind(Occupant::ZoneIndustrial),
+            Some(BuildingKind::Industrial)
+        );
+    }
+
+    /// Every non-zone occupant answers `None` — a zone lot's template lookup
+    /// only ever fires off a zone tag.
+    #[test]
+    fn zone_template_kind_is_none_for_every_non_zone_occupant() {
+        for &o in ALL_OCCUPANTS.iter() {
+            if matches!(
+                o,
+                Occupant::ZoneResidential | Occupant::ZoneCommercial | Occupant::ZoneIndustrial
+            ) {
+                continue;
+            }
+            assert_eq!(zone_template_kind(o), None, "{o:?}");
+        }
     }
 }

--- a/crates/city-sim-core/src/sim.rs
+++ b/crates/city-sim-core/src/sim.rs
@@ -663,20 +663,20 @@ mod tests {
     #[test]
     fn a_buildings_kind_changes_the_hash_even_behind_a_stable_id() {
         use crate::buildings::BuildingInstance;
-        use city_sim_protocol::tile_kind::TileKind;
+        use city_sim_protocol::building_kind::BuildingKind;
 
         let mut park = Simulation::new(4, 4, 1);
         park.state.tiles[5].building_id = Some(7);
         park.state
             .buildings
-            .push(BuildingInstance::new(7, TileKind::Park, (1, 1)));
+            .push(BuildingInstance::new(7, BuildingKind::Park, (1, 1)));
 
         let mut plant = Simulation::new(4, 4, 1);
         plant.state.tiles[5].building_id = Some(7);
         plant
             .state
             .buildings
-            .push(BuildingInstance::new(7, TileKind::CoalPlant, (1, 1)));
+            .push(BuildingInstance::new(7, BuildingKind::CoalPlant, (1, 1)));
 
         assert_ne!(
             state_hash(&park.state),
@@ -721,8 +721,8 @@ mod tests {
     fn water_requirement_is_opt_in_until_infrastructure_exists() {
         use crate::buildings::BuildingStatus;
         use crate::commands::apply_tool;
+        use city_sim_protocol::building_kind::BuildingKind;
         use city_sim_protocol::commands::{Tool, ViewStratum};
-        use city_sim_protocol::tile_kind::TileKind;
 
         let mut sim = Simulation::new(16, 16, 42);
         for x in 0..12 {
@@ -754,7 +754,7 @@ mod tests {
             .state
             .buildings
             .iter()
-            .filter(|b| b.kind == TileKind::Residential)
+            .filter(|b| b.kind == BuildingKind::Residential)
             .map(|b| b.status)
             .collect();
         assert!(!zone_statuses.is_empty(), "zones should have grown");
@@ -784,7 +784,7 @@ mod tests {
             sim.state
                 .buildings
                 .iter()
-                .any(|b| b.kind == TileKind::Residential
+                .any(|b| b.kind == BuildingKind::Residential
                     && b.status == BuildingStatus::InactiveNoWater),
             "with a water system present, unwatered zones require water again"
         );
@@ -798,6 +798,7 @@ mod tests {
     fn a_starved_segment_is_invisible_to_the_pooled_city_balance() {
         use crate::buildings::{BuildingInstance, BuildingStatus};
         use crate::migrate::set_v4_kind;
+        use city_sim_protocol::building_kind::BuildingKind;
         use city_sim_protocol::tile_kind::TileKind;
 
         let mut sim = Simulation::new(14, 2, 1);
@@ -813,7 +814,7 @@ mod tests {
                 }
             }
             s.buildings.push({
-                let mut b = BuildingInstance::new(1, TileKind::CoalPlant, (0, 0));
+                let mut b = BuildingInstance::new(1, BuildingKind::CoalPlant, (0, 0));
                 b.status = BuildingStatus::Active;
                 b
             });
@@ -830,7 +831,7 @@ mod tests {
                 }
             }
             s.buildings.push({
-                let mut b = BuildingInstance::new(2, TileKind::WindTurbine, (5, 0));
+                let mut b = BuildingInstance::new(2, BuildingKind::WindTurbine, (5, 0));
                 b.status = BuildingStatus::Active;
                 b
             });
@@ -840,7 +841,7 @@ mod tests {
                 let id = 10 + i as u32;
                 s.tile_at_mut(x, 0).unwrap().building_id = Some(id as u16);
                 s.buildings.push({
-                    let mut b = BuildingInstance::new(id, TileKind::Residential, (x, 0));
+                    let mut b = BuildingInstance::new(id, BuildingKind::Residential, (x, 0));
                     b.status = BuildingStatus::Active;
                     b
                 });
@@ -887,6 +888,7 @@ mod tests {
         use crate::buildings::{BuildingInstance, BuildingStatus};
         use crate::migrate::set_v4_kind;
         use crate::occupants::Occupant;
+        use city_sim_protocol::building_kind::BuildingKind;
         use city_sim_protocol::tile_kind::TileKind;
 
         let mut sim = Simulation::new(3, 1, 1);
@@ -896,7 +898,7 @@ mod tests {
             set_v4_kind(s.tile_at_mut(0, 0).unwrap(), TileKind::WaterPump);
             s.tile_at_mut(0, 0).unwrap().building_id = Some(1);
             s.buildings.push({
-                let mut b = BuildingInstance::new(1, TileKind::WaterPump, (0, 0));
+                let mut b = BuildingInstance::new(1, BuildingKind::WaterPump, (0, 0));
                 b.status = BuildingStatus::Active;
                 b
             });
@@ -906,7 +908,7 @@ mod tests {
             set_v4_kind(s.tile_at_mut(2, 0).unwrap(), TileKind::Residential);
             s.tile_at_mut(2, 0).unwrap().building_id = Some(2);
             s.buildings.push({
-                let mut b = BuildingInstance::new(2, TileKind::Residential, (2, 0));
+                let mut b = BuildingInstance::new(2, BuildingKind::Residential, (2, 0));
                 b.status = BuildingStatus::Active;
                 b
             });
@@ -1114,6 +1116,7 @@ mod tests {
     fn load_state_repopulates_utility_networks_without_clobbering_used() {
         use crate::buildings::{BuildingInstance, BuildingStatus};
         use crate::migrate::set_v4_kind;
+        use city_sim_protocol::building_kind::BuildingKind;
         use city_sim_protocol::tile_kind::TileKind;
 
         let mut sim = Simulation::new(3, 1, 1);
@@ -1122,7 +1125,7 @@ mod tests {
             s.tile_at_mut(0, 0).unwrap().power_plant_mw = 60;
             s.tile_at_mut(0, 0).unwrap().building_id = Some(1);
             s.buildings.push({
-                let mut b = BuildingInstance::new(1, TileKind::CoalPlant, (0, 0));
+                let mut b = BuildingInstance::new(1, BuildingKind::CoalPlant, (0, 0));
                 b.status = BuildingStatus::Active;
                 b
             });
@@ -1134,14 +1137,14 @@ mod tests {
             set_v4_kind(s.tile_at_mut(1, 0).unwrap(), TileKind::Residential);
             s.tile_at_mut(1, 0).unwrap().building_id = Some(2);
             s.buildings.push({
-                let mut b = BuildingInstance::new(2, TileKind::Residential, (1, 0));
+                let mut b = BuildingInstance::new(2, BuildingKind::Residential, (1, 0));
                 b.status = BuildingStatus::Active;
                 b
             });
             s.tile_at_mut(2, 0).unwrap().water_output = 50;
             s.tile_at_mut(2, 0).unwrap().building_id = Some(3);
             s.buildings.push({
-                let mut b = BuildingInstance::new(3, TileKind::WaterPump, (2, 0));
+                let mut b = BuildingInstance::new(3, BuildingKind::WaterPump, (2, 0));
                 b.status = BuildingStatus::Active;
                 b
             });

--- a/crates/city-sim-core/src/snapshot.rs
+++ b/crates/city-sim-core/src/snapshot.rs
@@ -17,34 +17,27 @@ const MAGIC: &[u8; 4] = b"CSIM";
 /// Terrain` + `underground: StratumSet<Underground>` + `surface:
 /// StratumSet<Surface>` + `overhead: StratumSet<Overhead>` + `density:
 /// ZoneDensity`.
+/// v6: `BuildingInstance::kind` moved from the frozen `TileKind` alphabet to
+/// the new `BuildingKind` (`crates/city-sim-protocol/src/building_kind.rs`)
+/// — a building is an entity occupying a tile, not a kind of tile.
 ///
-/// **The three stratum fields landed inside v5, not in a v6.** v5 has never
-/// been released — `origin/main` and `main` both read `VERSION = 4` — so it was
-/// introduced and reshaped on the same unpushed branch, and a v6 would exist
-/// solely to describe a shape that was never published. What a version number
-/// buys is a migration path for bytes that exist; there are none to speak of,
-/// so it would buy nothing and cost a permanent dead arm in [`from_bytes`].
-/// The moment this branch is pushed that reasoning expires — the next change to
-/// the tile's shape is a v6.
-///
-/// Be precise about what that costs, because it is not nothing. The restructure
-/// changed no *simulated* behaviour, but it did move the persisted bytes:
-/// `Tile` went from one varint `occupants` field to three, so a snapshot
-/// written by an earlier commit *on this branch* no longer loads. The exposure
-/// is a `.citysim` download or an IndexedDB save made while dev-running the
-/// branch between the first stratum commit and this one, and nothing else. The
-/// failure is loud rather than silent — the hand-written `Deserialize` on
-/// `StratumSet` rejects a foreign bit pattern outright, which is what
-/// `tests::a_snapshot_with_a_cross_stratum_bit_is_refused` covers — so such a
-/// save errors instead of decoding into a wrong city.
-///
-/// v4 is still **readable**: [`from_bytes`] dispatches it through
-/// [`crate::migrate::v4_to_v5`], which describes the old `GameState` field for
-/// field and converts each tile with [`crate::migrate::tile_from_v4`] — the
-/// same function `import.rs` uses for the legacy buffer path. Loading a v4 save
-/// and saving it again upgrades it in place; there is no downgrade path and
-/// none is wanted.
-const VERSION: u32 = 5;
+/// **v4 and v5 are both refused outright now — a deliberate pre-release
+/// compatibility break, not an oversight.** `origin/main` currently ships
+/// `VERSION = 4` as its one readable shape: a real `.citysim` download or
+/// IndexedDB engine snapshot saved against a released build *is* v4 bytes,
+/// and v5 never left this branch (see the superseded doc this replaces, in
+/// git history, for how that one stayed live). Both are dropped in the same
+/// change: `docs/tile-model.md` states the project's pre-release stance
+/// plainly — the CSIM snapshot format, wire bytes, and u8 alphabets may
+/// change freely before 1.0; only the legacy JSON save vocabulary and the
+/// frozen `legacy_tile_buffer` layout are fixed. A pre-1.0 CSAV file
+/// containing an old CSIM engine snapshot fails to load after this change,
+/// loudly (`SnapshotError::UnsupportedVersion`) rather than silently
+/// decoding a `BuildingInstance::kind` byte against the wrong alphabet. The
+/// legacy JSON save path (`import.rs`'s `from_tile_buffer`, driven by
+/// `persistence.ts`'s `transcodeLegacySave`) is untouched — it was never a
+/// *snapshot* — so an old save is still recoverable through that door.
+const VERSION: u32 = 6;
 
 /// Serialise `state` to a compact postcard byte vector prefixed by a 8-byte
 /// header: magic `CSIM` (4 bytes) + version u32 (4 bytes, little-endian).
@@ -71,11 +64,6 @@ pub fn from_bytes(bytes: &[u8]) -> Result<GameState, SnapshotError> {
     let version = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
     let payload = &bytes[8..];
     match version {
-        // The pre-strata tile shape — decoded against a shim that spells the
-        // old `GameState` out positionally, then converted.
-        4 => postcard::from_bytes::<crate::migrate::v4::GameState>(payload)
-            .map(crate::migrate::v4_to_v5)
-            .map_err(SnapshotError::Postcard),
         VERSION => postcard::from_bytes(payload).map_err(SnapshotError::Postcard),
         v => Err(SnapshotError::UnsupportedVersion(v)),
     }
@@ -136,6 +124,26 @@ mod tests {
             from_bytes(&bytes),
             Err(SnapshotError::UnsupportedVersion(99))
         ));
+    }
+
+    /// The deliberate pre-release compatibility break this `VERSION` bump
+    /// makes: a real `origin/main`-shipped v4 CSIM snapshot, and the v5 shape
+    /// that only ever lived on the stratification branch, are both refused
+    /// outright now — no silent decode against the wrong `BuildingInstance::kind`
+    /// alphabet, and no dead conversion arm kept alive for either.
+    #[test]
+    fn old_snapshot_versions_are_refused_not_silently_migrated() {
+        for old_version in [4u32, 5u32] {
+            let mut bytes = to_bytes(&GameState::new(4, 4, 0)).unwrap();
+            bytes[4..8].copy_from_slice(&old_version.to_le_bytes());
+            assert!(
+                matches!(
+                    from_bytes(&bytes),
+                    Err(SnapshotError::UnsupportedVersion(v)) if v == old_version
+                ),
+                "v{old_version} should be refused, not migrated"
+            );
+        }
     }
 
     /// A snapshot whose `surface` field carries an overhead bit is **refused**,
@@ -233,12 +241,12 @@ mod tests {
     fn round_trip_city_with_buildings_and_history() {
         use crate::buildings::{BuildingInstance, BuildingStatus};
         use crate::state::BudgetHistoryEntry;
-        use city_sim_protocol::tile_kind::TileKind;
+        use city_sim_protocol::building_kind::BuildingKind;
 
         let mut state = GameState::new(4, 4, 7);
         state.buildings.push(BuildingInstance {
             id: 1,
-            kind: TileKind::Residential,
+            kind: BuildingKind::Residential,
             origin: (0, 0),
             status: BuildingStatus::Active,
             health: 80,

--- a/crates/city-sim-core/src/state.rs
+++ b/crates/city-sim-core/src/state.rs
@@ -7,7 +7,9 @@ use crate::buildings::BuildingInstance;
 use crate::occupants::{Occupant, Overhead, Stratum, StratumSet, Surface, Terrain, Underground};
 use crate::rng::SeededRng;
 use crate::wilderness::WildernessStats;
+use city_sim_protocol::building_kind::BuildingKind;
 use city_sim_protocol::commands::Policies;
+#[cfg(test)]
 use city_sim_protocol::tile_kind::TileKind;
 use std::collections::{HashMap, VecDeque};
 
@@ -538,7 +540,7 @@ impl GameState {
     pub fn has_water_system(&self) -> bool {
         self.buildings
             .iter()
-            .any(|b| matches!(b.kind, TileKind::WaterPump | TileKind::WaterTower))
+            .any(|b| matches!(b.kind, BuildingKind::WaterPump | BuildingKind::WaterTower))
             || self.tiles.iter().any(|t| t.has_occupant(Occupant::Pipe))
     }
 
@@ -546,33 +548,41 @@ impl GameState {
         self.tile_index(x, y).map(|i| &mut self.tiles[i])
     }
 
-    /// Overwrite untouched `Land` tiles with natural `Water`/`Tree` terrain
-    /// from a row-major kind byte array (one `TileKind` u8 per tile).
+    /// Overwrite untouched `Land` tiles with natural `Water` terrain from a
+    /// row-major `Terrain as u8` byte array (`Terrain::Land` = 0,
+    /// `Terrain::Water` = 1 — see `Terrain`'s discriminants).
     ///
-    /// Only `Water` and `Tree` are accepted — anything else in the array is
-    /// ignored so player-built kinds present in a display snapshot can never
-    /// leak into the engine as free construction. Tiles that are no longer
-    /// `Land` (already built on) are left alone.
+    /// Only `1` (`Water`) is accepted — anything else in the array (including
+    /// `0`/`Land`, and any byte that isn't a declared `Terrain`) is a no-op,
+    /// so player-built terrain present in a display snapshot can never leak
+    /// into the engine as free construction. Tiles that are no longer `Land`
+    /// (already built on) are left alone.
     ///
-    /// "No longer `Land`" was `kind != TileKind::Land`, and the question it was
-    /// asking is *has anything happened to this cell yet?* — which the strata
-    /// answer as bare land carrying nothing you can see. A hydro line is not a
-    /// disqualifier: it lived in `FLAG_POWER_OVERLAY` on a `kind = Land` tile,
-    /// so a terraformed line has always been seeded straight over. A buried
-    /// pipe is not one either, for the same reason.
-    pub fn seed_natural_terrain(&mut self, kinds: &[u8]) {
-        let n = self.tiles.len().min(kinds.len());
-        for (tile, &kind_byte) in self.tiles.iter_mut().zip(kinds.iter()).take(n) {
+    /// This byte array carries bare terrain only — no tree canopy. Both TS
+    /// bridges' `terrainBytes` only ever emit `Land`/`Water` (never a third
+    /// value), and always did even back when this function decoded the byte
+    /// as a `TileKind`: a `TileKind::Tree` arm exhumed here was dead code,
+    /// unreachable from either bridge, so it was dropped rather than ported —
+    /// see `seed_natural_terrain_ignores_a_tree_byte_because_no_caller_sends_one`.
+    ///
+    /// "No longer `Land`" was `kind != TileKind::Land` before the strata, and
+    /// the question it was asking is *has anything happened to this cell
+    /// yet?* — which the strata answer as bare land carrying nothing you can
+    /// see. A hydro line is not a disqualifier: it lived in
+    /// `FLAG_POWER_OVERLAY` on a `kind = Land` tile, so a terraformed line has
+    /// always been seeded straight over. A buried pipe is not one either, for
+    /// the same reason.
+    pub fn seed_natural_terrain(&mut self, terrain_bytes: &[u8]) {
+        let n = self.tiles.len().min(terrain_bytes.len());
+        for (tile, &byte) in self.tiles.iter_mut().zip(terrain_bytes.iter()).take(n) {
             let untouched = tile.terrain == Terrain::Land
                 && tile.occupants_in(Stratum::Surface) == 0
                 && !tile.has_occupant(Occupant::Trees);
             if !untouched {
                 continue;
             }
-            match TileKind::from_u8(kind_byte) {
-                Some(TileKind::Water) => tile.terrain = Terrain::Water,
-                Some(TileKind::Tree) => tile.set_occupant(Occupant::Trees, true),
-                _ => {}
+            if byte == Terrain::Water as u8 {
+                tile.terrain = Terrain::Water;
             }
         }
         self.tile_revision += 1;
@@ -599,14 +609,61 @@ mod tests {
 
         s.buildings.push(crate::buildings::BuildingInstance::new(
             1,
-            TileKind::WaterPump,
+            BuildingKind::WaterPump,
             (0, 0),
         ));
         assert!(s.has_water_system(), "a pump opts in");
-        s.buildings[0].kind = TileKind::WaterTower;
+        s.buildings[0].kind = BuildingKind::WaterTower;
         assert!(s.has_water_system(), "a tower opts in");
-        s.buildings[0].kind = TileKind::Residential;
+        s.buildings[0].kind = BuildingKind::Residential;
         assert!(!s.has_water_system(), "zones alone do not opt in");
+    }
+
+    #[test]
+    fn seed_natural_terrain_paints_water_and_leaves_land_alone() {
+        let mut s = GameState::new(3, 1, 0);
+        s.seed_natural_terrain(&[0, 1, 0]);
+        assert_eq!(s.tiles[0].terrain, Terrain::Land);
+        assert_eq!(s.tiles[1].terrain, Terrain::Water);
+        assert_eq!(s.tiles[2].terrain, Terrain::Land);
+    }
+
+    /// Confirms the byte really is `Terrain as u8`, not a coincidence of
+    /// `0`/`1` meaning the same thing under two different encodings — the
+    /// dead `TileKind::Tree` arm this replaced happened to be byte `2`, so a
+    /// regression back to decoding `TileKind` would only show up on a byte
+    /// no real caller sends. Any byte that isn't exactly `Terrain::Water as
+    /// u8` — including a `TileKind::Water` value of `1`, which is the same
+    /// number by coincidence, and only proves this test doesn't distinguish
+    /// them — must leave the tile as `Land`.
+    #[test]
+    fn seed_natural_terrain_ignores_a_tree_byte_because_no_caller_sends_one() {
+        let mut s = GameState::new(1, 1, 0);
+        // `2` was `TileKind::Tree`'s byte; neither TS bridge ever sends it.
+        s.seed_natural_terrain(&[2]);
+        assert_eq!(s.tiles[0].terrain, Terrain::Land);
+        assert!(!s.tiles[0].has_occupant(Occupant::Trees));
+    }
+
+    #[test]
+    fn seed_natural_terrain_leaves_a_built_tile_alone() {
+        let mut s = GameState::new(1, 1, 0);
+        set_v4_kind(&mut s.tiles[0], TileKind::Road);
+        s.seed_natural_terrain(&[1]);
+        assert_eq!(
+            s.tiles[0].terrain,
+            Terrain::Land,
+            "a tile that already has something on it must not be reterrained"
+        );
+        assert!(s.tiles[0].has_occupant(Occupant::Road));
+    }
+
+    #[test]
+    fn seed_natural_terrain_ignores_bytes_past_the_tile_count() {
+        let mut s = GameState::new(1, 1, 0);
+        // Longer than the tile vector — must not panic or read out of bounds.
+        s.seed_natural_terrain(&[1, 1, 1, 1]);
+        assert_eq!(s.tiles[0].terrain, Terrain::Water);
     }
 
     fn gs() -> GameState {

--- a/crates/city-sim-core/src/utilities.rs
+++ b/crates/city-sim-core/src/utilities.rs
@@ -368,6 +368,7 @@ mod tests {
     use crate::migrate::{set_v4_kind, tile_from_v4};
     use crate::occupants::Occupant;
     use crate::state::Tile;
+    use city_sim_protocol::building_kind::BuildingKind;
     use city_sim_protocol::commands::{Tool, ViewStratum};
     use city_sim_protocol::legacy_tile_buffer::legacy_flags as flags;
     use city_sim_protocol::tile_kind::TileKind;
@@ -665,7 +666,7 @@ mod tests {
         g.tile_at_mut(x, y).unwrap().water_output = 50;
         set_v4_kind(g.tile_at_mut(x, y).unwrap(), TileKind::WaterPump);
         g.tile_at_mut(x, y).unwrap().building_id = Some(id as u16);
-        let mut b = BuildingInstance::new(id, TileKind::WaterPump, (x, y));
+        let mut b = BuildingInstance::new(id, BuildingKind::WaterPump, (x, y));
         b.status = BuildingStatus::Active;
         g.buildings.push(b);
     }
@@ -705,7 +706,7 @@ mod tests {
         g.tile_at_mut(0, 0).unwrap().water_output = 50;
         set_v4_kind(g.tile_at_mut(0, 0).unwrap(), TileKind::WaterPump);
         g.tile_at_mut(0, 0).unwrap().building_id = Some(1);
-        let mut b = BuildingInstance::new(1, TileKind::WaterPump, (0, 0));
+        let mut b = BuildingInstance::new(1, BuildingKind::WaterPump, (0, 0));
         b.status = BuildingStatus::InactiveNoPower;
         g.buildings.push(b);
         g.tile_at_mut(1, 0)
@@ -732,7 +733,7 @@ mod tests {
         g.tile_at_mut(1, 0).unwrap().water_output = 50;
         set_v4_kind(g.tile_at_mut(1, 0).unwrap(), TileKind::WaterPump);
         g.tile_at_mut(1, 0).unwrap().building_id = Some(2);
-        let mut b = BuildingInstance::new(2, TileKind::WaterPump, (1, 0));
+        let mut b = BuildingInstance::new(2, BuildingKind::WaterPump, (1, 0));
         b.status = BuildingStatus::InactiveNoPower;
         g.buildings.push(b);
 
@@ -766,7 +767,7 @@ mod tests {
             .set_flag(crate::state::FLAG_POWERED, true);
         g.buildings.push(crate::buildings::BuildingInstance::new(
             1,
-            TileKind::WaterPump,
+            BuildingKind::WaterPump,
             (0, 0),
         ));
 
@@ -994,7 +995,7 @@ mod tests {
         g.tile_at_mut(0, 0).unwrap().water_output = 50;
         set_v4_kind(g.tile_at_mut(0, 0).unwrap(), TileKind::WaterPump);
         g.tile_at_mut(0, 0).unwrap().building_id = Some(1);
-        let mut b = BuildingInstance::new(1, TileKind::WaterPump, (0, 0));
+        let mut b = BuildingInstance::new(1, BuildingKind::WaterPump, (0, 0));
         b.status = BuildingStatus::InactiveNoPower;
         g.buildings.push(b);
 

--- a/crates/city-sim-core/src/wilderness.rs
+++ b/crates/city-sim-core/src/wilderness.rs
@@ -32,9 +32,9 @@
 //! [`terrain_eco`](WildernessTunables::terrain_eco) keyed by [`Terrain`],
 //! [`occupant_eco`](WildernessTunables::occupant_eco) keyed by [`Occupant`],
 //! and [`structure_eco`](WildernessTunables::structure_eco) keyed by
-//! `TileKind` — the last legitimately so, because that is the building
-//! template key and it is what identifies *which* structure. Every value stayed
-//! exactly where it was on the number line; only its address changed.
+//! [`BuildingKind::dense_index`] — the building template key, and it is what
+//! identifies *which* structure. Every value stayed exactly where it was on
+//! the number line; only its address changed.
 //!
 //! All three are **tables, not constants**, and that is a requirement rather
 //! than a habit: the Green Industry programme rewrites the industrial row at
@@ -49,7 +49,9 @@ use crate::occupants::{
     tile_eco, EcoCategory, Occupant, StructureLookup, Terrain, OCCUPANT_COUNT, TERRAIN_COUNT,
 };
 use crate::state::GameState;
+use city_sim_protocol::building_kind::BuildingKind;
 use city_sim_protocol::commands::WildernessPolicy;
+#[cfg(test)]
 use city_sim_protocol::tile_kind::TileKind;
 
 // ---------------------------------------------------------------------------
@@ -73,12 +75,12 @@ pub struct WildernessTunables {
     /// sends that one occupant to [`Self::structure_eco`] instead. See
     /// `the_structure_row_of_the_occupant_table_is_never_read`.
     pub occupant_eco: [f32; OCCUPANT_COUNT],
-    /// Eco value of a structure, indexed by `TileKind as usize` — the building
-    /// template key, which is what identifies *which* structure. Read by
-    /// [`structure_eco`]; only the
-    /// [`is_structure_kind`](crate::occupants::is_structure_kind) rows are ever
-    /// live, and the rest stay `0.0`.
-    pub structure_eco: [f32; TileKind::COUNT],
+    /// Eco value of a structure, indexed by
+    /// [`BuildingKind::dense_index`] — the building template key, which is
+    /// what identifies *which* structure. Read by [`structure_eco`]. Dense
+    /// rather than indexed by the raw (sparse) discriminant, because
+    /// `BuildingKind`'s thirteen members span `0x10..=0x51`.
+    pub structure_eco: [f32; BuildingKind::COUNT],
     /// Patch bonus ceiling per strong-nature tile (saturating curve).
     pub patch_bonus_cap: f32,
     /// Cluster size at which the patch bonus reaches ~63% of its cap.
@@ -164,17 +166,17 @@ impl Default for WildernessTunables {
         // is decides, and that is the table below.
 
         // --- one row per structure, keyed by its building template ---
-        let mut structure_eco = [0.0_f32; TileKind::COUNT];
-        structure_eco[TileKind::HydroPlant as usize] = -2.0;
-        structure_eco[TileKind::WaterPump as usize] = -1.0;
-        structure_eco[TileKind::WaterTower as usize] = -1.0;
-        structure_eco[TileKind::ElementarySchool as usize] = -1.0;
-        structure_eco[TileKind::HighSchool as usize] = -1.0;
-        structure_eco[TileKind::Park as usize] = 4.0;
-        structure_eco[TileKind::ParkLarge as usize] = 4.0;
-        structure_eco[TileKind::CoalPlant as usize] = -8.0;
-        structure_eco[TileKind::WindTurbine as usize] = -1.0;
-        structure_eco[TileKind::SolarFarm as usize] = -1.0;
+        let mut structure_eco = [0.0_f32; BuildingKind::COUNT];
+        structure_eco[BuildingKind::HydroPlant.dense_index()] = -2.0;
+        structure_eco[BuildingKind::WaterPump.dense_index()] = -1.0;
+        structure_eco[BuildingKind::WaterTower.dense_index()] = -1.0;
+        structure_eco[BuildingKind::ElementarySchool.dense_index()] = -1.0;
+        structure_eco[BuildingKind::HighSchool.dense_index()] = -1.0;
+        structure_eco[BuildingKind::Park.dense_index()] = 4.0;
+        structure_eco[BuildingKind::ParkLarge.dense_index()] = 4.0;
+        structure_eco[BuildingKind::CoalPlant.dense_index()] = -8.0;
+        structure_eco[BuildingKind::WindTurbine.dense_index()] = -1.0;
+        structure_eco[BuildingKind::SolarFarm.dense_index()] = -1.0;
 
         Self {
             terrain_eco,
@@ -540,11 +542,20 @@ mod tests {
     /// tag, so a park with no `BuildingInstance` behind it is bare ground.
     fn set(state: &mut GameState, x: u32, y: u32, kind: TileKind) {
         if crate::occupants::is_structure_kind(kind) {
+            // `is_structure_kind` is a subset of `building_kind_of`'s domain
+            // (it excludes the three zone kinds, which take the `else`
+            // branch below), so this is always `Some`.
+            let building_kind = crate::migrate::building_kind_of(kind)
+                .expect("is_structure_kind implies building_kind_of");
             let id = state.next_building_id;
             state.next_building_id += 1;
             state
                 .buildings
-                .push(crate::buildings::BuildingInstance::new(id, kind, (x, y)));
+                .push(crate::buildings::BuildingInstance::new(
+                    id,
+                    building_kind,
+                    (x, y),
+                ));
             let tile = state.tile_at_mut(x, y).unwrap();
             tile.set_occupant(Occupant::Structure, true);
             tile.building_id = Some(id as u16);
@@ -806,30 +817,37 @@ mod tests {
         let t = WildernessTunables::default();
         assert_eq!(t.terrain_eco.len(), Terrain::ALL.len());
         assert_eq!(t.occupant_eco.len(), ALL_OCCUPANTS.len());
-        assert_eq!(t.structure_eco.len(), TileKind::ALL.len());
+        assert_eq!(t.structure_eco.len(), BuildingKind::COUNT);
         for terrain in Terrain::ALL {
             let _ = t.terrain_eco[terrain as usize];
         }
         for o in ALL_OCCUPANTS {
             let _ = t.occupant_eco[o as usize];
         }
-        for &kind in TileKind::ALL {
-            let _ = t.structure_eco[kind as usize];
+        for &kind in BuildingKind::ALL {
+            let _ = t.structure_eco[kind.dense_index()];
         }
     }
 
-    /// The structure table's live rows are exactly the structure kinds. Every
-    /// other `TileKind` row is `0.0` and stays that way: a road's −2.0 moved
-    /// *out* of the `TileKind`-keyed table when the split happened, rather
-    /// than being copied into a second home where the two could drift.
+    /// The structure table's live rows are exactly the ten non-zone structure
+    /// kinds. The three zone kinds' rows are `0.0` and stay that way: a
+    /// developed lot's occupant is a zone tag, not `Structure`, so
+    /// `structure_eco` is never asked about `Residential`/`Commercial`/
+    /// `Industrial` in real scoring — a road's −2.0 (an *occupant* value)
+    /// moved *out* of this table when the split happened, rather than being
+    /// copied into a second home where the two could drift.
     #[test]
-    fn only_structure_kinds_carry_a_structure_eco() {
+    fn only_non_zone_structure_kinds_carry_a_structure_eco() {
         let t = WildernessTunables::default();
-        for &kind in TileKind::ALL {
+        for &kind in BuildingKind::ALL {
+            let is_zone = matches!(
+                kind,
+                BuildingKind::Residential | BuildingKind::Commercial | BuildingKind::Industrial
+            );
             assert_eq!(
-                t.structure_eco[kind as usize] != 0.0,
-                crate::occupants::is_structure_kind(kind),
-                "{kind:?}: only structures belong in the structure eco table"
+                t.structure_eco[kind.dense_index()] != 0.0,
+                !is_zone,
+                "{kind:?}: only non-zone structures belong in the structure eco table"
             );
         }
     }
@@ -845,7 +863,7 @@ mod tests {
         // Poison the row: nothing may notice.
         t.occupant_eco[Occupant::Structure as usize] = 999.0;
         assert_eq!(occupant_eco(Occupant::Structure, &t), None);
-        assert_eq!(structure_eco(TileKind::CoalPlant, &t), -8.0);
+        assert_eq!(structure_eco(BuildingKind::CoalPlant, &t), -8.0);
 
         // …and no route into the score may notice either.
         let mut s = grid(8, 8);
@@ -910,16 +928,16 @@ mod tests {
     fn coal_is_worse_than_wind_and_solar() {
         let t = WildernessTunables::default();
         assert!(
-            t.structure_eco[TileKind::CoalPlant as usize]
-                < t.structure_eco[TileKind::HydroPlant as usize]
+            t.structure_eco[BuildingKind::CoalPlant.dense_index()]
+                < t.structure_eco[BuildingKind::HydroPlant.dense_index()]
         );
         assert!(
-            t.structure_eco[TileKind::HydroPlant as usize]
-                < t.structure_eco[TileKind::WindTurbine as usize]
+            t.structure_eco[BuildingKind::HydroPlant.dense_index()]
+                < t.structure_eco[BuildingKind::WindTurbine.dense_index()]
         );
         assert_eq!(
-            t.structure_eco[TileKind::WindTurbine as usize],
-            t.structure_eco[TileKind::SolarFarm as usize]
+            t.structure_eco[BuildingKind::WindTurbine.dense_index()],
+            t.structure_eco[BuildingKind::SolarFarm.dense_index()]
         );
     }
 

--- a/crates/city-sim-core/tests/fixtures/golden_city.expected
+++ b/crates/city-sim-core/tests/fixtures/golden_city.expected
@@ -37,7 +37,7 @@ jobs 117
 buildings 32
 next_building_id 36
 tile_revision 190
-state_hash 0x4f62a999a5da958f
+state_hash 0x128bd6e2d85707cb
 
 [utilities]
 power 24

--- a/crates/city-sim-protocol/src/building_kind.rs
+++ b/crates/city-sim-protocol/src/building_kind.rs
@@ -1,0 +1,289 @@
+// building_kind.rs — canonical BuildingKind ↔ u8 mapping, the building-template key.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+/// Which category a [`BuildingKind`] belongs to — the high nibble of its
+/// discriminant. `Safety` and `Health` are reserved: declared here so the
+/// alphabet has room for them, but no [`BuildingKind`] carries either yet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[repr(u8)]
+pub enum BuildingCategory {
+    Zone = 1,
+    Power = 2,
+    Water = 3,
+    Education = 4,
+    Recreation = 5,
+    Safety = 6,
+    Health = 7,
+}
+
+/// Canonical BuildingKind ↔ u8 mapping — the stable identity of a building
+/// template, on the wire and in a `BuildingInstance`.
+///
+/// A building is an entity that occupies a tile, not a kind of tile — see
+/// `docs/tile-model.md` and `app/src/game/buildings/templates.ts`'s
+/// `BuildingKind`, whose string values this mirrors one-for-one via
+/// [`BuildingKind::ts_string`]. Unlike [`crate::tile_kind::TileKind`], this
+/// enum is **not** frozen legacy-save vocabulary — the discriminants below are
+/// free to be renumbered or extended pre-release, per the maintainer-approved
+/// design. `0x00` is reserved and never valid: every real member's high
+/// nibble is its [`BuildingCategory`] (1–7) and the low nibble distinguishes
+/// members within that category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(into = "u8", try_from = "u8")]
+#[repr(u8)]
+pub enum BuildingKind {
+    // Zone
+    Residential = 0x10,
+    Commercial = 0x11,
+    Industrial = 0x12,
+    // Power
+    HydroPlant = 0x20,
+    CoalPlant = 0x21,
+    WindTurbine = 0x22,
+    SolarFarm = 0x23,
+    // Water
+    WaterPump = 0x30,
+    WaterTower = 0x31,
+    // Education
+    ElementarySchool = 0x40,
+    HighSchool = 0x41,
+    // Recreation
+    Park = 0x50,
+    ParkLarge = 0x51,
+}
+
+impl BuildingKind {
+    /// All variants, grouped by category and in ascending discriminant order.
+    pub const ALL: &'static [BuildingKind] = &[
+        Self::Residential,
+        Self::Commercial,
+        Self::Industrial,
+        Self::HydroPlant,
+        Self::CoalPlant,
+        Self::WindTurbine,
+        Self::SolarFarm,
+        Self::WaterPump,
+        Self::WaterTower,
+        Self::ElementarySchool,
+        Self::HighSchool,
+        Self::Park,
+        Self::ParkLarge,
+    ];
+
+    /// Number of variants — the length of a table indexed by
+    /// [`BuildingKind::dense_index`] rather than by the raw (sparse)
+    /// discriminant.
+    pub const COUNT: usize = Self::ALL.len();
+
+    /// The category this kind belongs to — the high nibble of its
+    /// discriminant.
+    pub fn category(self) -> BuildingCategory {
+        match (self as u8) >> 4 {
+            1 => BuildingCategory::Zone,
+            2 => BuildingCategory::Power,
+            3 => BuildingCategory::Water,
+            4 => BuildingCategory::Education,
+            5 => BuildingCategory::Recreation,
+            6 => BuildingCategory::Safety,
+            7 => BuildingCategory::Health,
+            _ => unreachable!("every BuildingKind's high nibble is a declared category"),
+        }
+    }
+
+    /// A dense, gapless index (`0..COUNT`) for tables keyed by building kind —
+    /// e.g. `WildernessTunables::structure_eco` — so a 13-member alphabet
+    /// spread across `0x10..=0x51` doesn't force a ~90-entry array of mostly
+    /// holes. Order matches [`BuildingKind::ALL`].
+    pub const fn dense_index(self) -> usize {
+        match self {
+            Self::Residential => 0,
+            Self::Commercial => 1,
+            Self::Industrial => 2,
+            Self::HydroPlant => 3,
+            Self::CoalPlant => 4,
+            Self::WindTurbine => 5,
+            Self::SolarFarm => 6,
+            Self::WaterPump => 7,
+            Self::WaterTower => 8,
+            Self::ElementarySchool => 9,
+            Self::HighSchool => 10,
+            Self::Park => 11,
+            Self::ParkLarge => 12,
+        }
+    }
+
+    /// Convert a u8 byte (from the wire or a `BuildingInstance`) to a
+    /// `BuildingKind`. `0x00` and any byte not naming a declared member
+    /// return `None`.
+    pub fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            0x10 => Some(Self::Residential),
+            0x11 => Some(Self::Commercial),
+            0x12 => Some(Self::Industrial),
+            0x20 => Some(Self::HydroPlant),
+            0x21 => Some(Self::CoalPlant),
+            0x22 => Some(Self::WindTurbine),
+            0x23 => Some(Self::SolarFarm),
+            0x30 => Some(Self::WaterPump),
+            0x31 => Some(Self::WaterTower),
+            0x40 => Some(Self::ElementarySchool),
+            0x41 => Some(Self::HighSchool),
+            0x50 => Some(Self::Park),
+            0x51 => Some(Self::ParkLarge),
+            _ => None,
+        }
+    }
+
+    pub fn to_u8(self) -> u8 {
+        self as u8
+    }
+
+    /// Canonical string name — matches the TS `BuildingKind` string-enum
+    /// value in `app/src/game/buildings/templates.ts`, and the legacy
+    /// `TileKind::ts_string` spelling those 13 members were copied from once,
+    /// on purpose, so save/MCP vocabulary doesn't move.
+    pub fn ts_string(self) -> &'static str {
+        match self {
+            Self::HydroPlant => "hydro",
+            Self::CoalPlant => "coal",
+            Self::WindTurbine => "wind",
+            Self::SolarFarm => "solar",
+            Self::WaterPump => "pump",
+            Self::WaterTower => "water_tower",
+            Self::Park => "park",
+            Self::ParkLarge => "park_large",
+            Self::ElementarySchool => "elementary_school",
+            Self::HighSchool => "high_school",
+            Self::Residential => "residential",
+            Self::Commercial => "commercial",
+            Self::Industrial => "industrial",
+        }
+    }
+}
+
+// Stable-discriminant-byte serde: postcard and JSON both carry a plain u8,
+// same shape as `TileKind`'s custom (de)serialisation but expressed through
+// `into`/`try_from` since `to_u8`/`from_u8` already exist and this repo has
+// no reason to hand-roll a `Visitor` twice.
+impl From<BuildingKind> for u8 {
+    fn from(k: BuildingKind) -> u8 {
+        k.to_u8()
+    }
+}
+
+impl TryFrom<u8> for BuildingKind {
+    type Error = InvalidBuildingKindByte;
+
+    fn try_from(v: u8) -> Result<Self, Self::Error> {
+        Self::from_u8(v).ok_or(InvalidBuildingKindByte(v))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("{0:#04x} is not a valid BuildingKind byte")]
+pub struct InvalidBuildingKindByte(pub u8);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_all_variants() {
+        for &kind in BuildingKind::ALL {
+            let byte = kind.to_u8();
+            let back =
+                BuildingKind::from_u8(byte).expect("from_u8 should succeed for every variant");
+            assert_eq!(
+                kind, back,
+                "round-trip failed for {kind:?} (byte {byte:#04x})"
+            );
+        }
+    }
+
+    #[test]
+    fn no_duplicate_u8_values() {
+        let mut seen = std::collections::HashSet::new();
+        for &kind in BuildingKind::ALL {
+            let byte = kind.to_u8();
+            assert!(
+                seen.insert(byte),
+                "duplicate u8 value {byte:#04x} for {kind:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn count_matches_all_len() {
+        assert_eq!(BuildingKind::ALL.len(), 13);
+        assert_eq!(BuildingKind::COUNT, BuildingKind::ALL.len());
+    }
+
+    #[test]
+    fn dense_index_is_a_gapless_permutation_of_0_to_count() {
+        let mut seen = [false; BuildingKind::COUNT];
+        for &kind in BuildingKind::ALL {
+            let idx = kind.dense_index();
+            assert!(
+                idx < BuildingKind::COUNT,
+                "{kind:?} index {idx} out of range"
+            );
+            assert!(
+                !seen[idx],
+                "{kind:?} shares dense_index {idx} with another kind"
+            );
+            seen[idx] = true;
+        }
+        assert!(seen.iter().all(|&s| s), "dense_index leaves a gap");
+    }
+
+    #[test]
+    fn category_matches_the_high_nibble_for_every_member() {
+        for &kind in BuildingKind::ALL {
+            let expected = match kind.to_u8() >> 4 {
+                1 => BuildingCategory::Zone,
+                2 => BuildingCategory::Power,
+                3 => BuildingCategory::Water,
+                4 => BuildingCategory::Education,
+                5 => BuildingCategory::Recreation,
+                n => panic!("unexpected high nibble {n} for {kind:?}"),
+            };
+            assert_eq!(kind.category(), expected, "{kind:?}");
+        }
+    }
+
+    #[test]
+    fn zero_byte_is_never_valid() {
+        assert_eq!(BuildingKind::from_u8(0x00), None);
+        assert!(BuildingKind::try_from(0x00u8).is_err());
+    }
+
+    #[test]
+    fn unassigned_bytes_are_rejected() {
+        for v in [
+            0x00, 0x01, 0x0F, 0x13, 0x24, 0x32, 0x42, 0x52, 0x60, 0x70, 0xFF,
+        ] {
+            assert_eq!(
+                BuildingKind::from_u8(v),
+                None,
+                "byte {v:#04x} should be invalid"
+            );
+            assert!(
+                BuildingKind::try_from(v).is_err(),
+                "byte {v:#04x} should be invalid"
+            );
+        }
+    }
+
+    #[test]
+    fn ts_string_is_unique_per_member() {
+        let mut seen = std::collections::HashSet::new();
+        for &kind in BuildingKind::ALL {
+            assert!(
+                seen.insert(kind.ts_string()),
+                "duplicate ts_string for {kind:?}"
+            );
+        }
+    }
+}

--- a/crates/city-sim-protocol/src/lib.rs
+++ b/crates/city-sim-protocol/src/lib.rs
@@ -3,6 +3,7 @@
 // (c) Copyright 2026 Liminal HQ, Scott Morris
 // SPDX-License-Identifier: MIT
 
+pub mod building_kind;
 pub mod commands;
 pub mod events;
 pub mod legacy_tile_buffer;

--- a/crates/city-sim-protocol/src/wire_types.rs
+++ b/crates/city-sim-protocol/src/wire_types.rs
@@ -22,8 +22,7 @@
 #[serde(rename_all = "camelCase")]
 pub struct WireBuilding {
     pub id: u32,
-    /// `TileKind as u8` — decode with `tileKindFromU8` in TS, matching every
-    /// other wire use of `TileKind`.
+    /// `BuildingKind as u8` — decode with `BUILDING_KIND_BY_U8` in TS.
     pub kind: u8,
     pub origin_x: u32,
     pub origin_y: u32,

--- a/crates/city-sim-wasm/src/lib.rs
+++ b/crates/city-sim-wasm/src/lib.rs
@@ -266,14 +266,15 @@ impl SimHost {
         Ok(())
     }
 
-    /// Seed the natural terrain baseline (row-major `TileKind` u8 per tile).
+    /// Seed the natural terrain baseline (row-major `Terrain as u8` byte per
+    /// tile — `Land` = 0, `Water` = 1).
     ///
-    /// Only `Water`/`Tree` kinds are applied — see
-    /// `GameState::seed_natural_terrain`. Call once, after construction and
-    /// before any commands. Terrain lives inside the state, so undo snapshots
-    /// and save snapshots carry it automatically.
-    pub fn set_natural_terrain(&mut self, kinds: &[u8]) {
-        self.sim.state.seed_natural_terrain(kinds);
+    /// Only `Water` is applied — see `GameState::seed_natural_terrain`. Call
+    /// once, after construction and before any commands. Terrain lives
+    /// inside the state, so undo snapshots and save snapshots carry it
+    /// automatically.
+    pub fn set_natural_terrain(&mut self, terrain_bytes: &[u8]) {
+        self.sim.state.seed_natural_terrain(terrain_bytes);
     }
 
     /// Advance the simulation by `dt` seconds (real time). The speed
@@ -460,12 +461,12 @@ impl SimHost {
     }
 
     /// The building list as JSON (`Vec<WireBuilding>`) — `id`, template
-    /// `kind` (as the `TileKind` u8, matching every other wire use of
-    /// `TileKind`), and footprint origin.
+    /// `kind` (as the `BuildingKind` u8 — decode with `BUILDING_KIND_BY_U8`
+    /// in TS), and footprint origin.
     ///
     /// The live tile buffer's `Structure` occupant bit says only that a
     /// building stands on a tile, not which one — since #177's TS/wire
-    /// follow-up, a structure's `TileKind` lives on its `BuildingInstance`,
+    /// follow-up, a structure's `BuildingKind` lives on its `BuildingInstance`,
     /// not on the tile. TS needs this list to resolve `building_id` to a
     /// template; call it alongside `tile_buffer()`. Status/health/trouble are
     /// deliberately not carried here — TS derives building status locally

--- a/crates/tauri-plugin-city-sim/guest-js/index.ts
+++ b/crates/tauri-plugin-city-sim/guest-js/index.ts
@@ -297,14 +297,15 @@ export async function setPolicies(policies: Policies): Promise<void> {
 }
 
 /**
- * Seed the natural terrain baseline (row-major `TileKind` u8 per tile).
+ * Seed the natural terrain baseline (row-major `Terrain` u8 byte per tile —
+ * `Land` = 0, `Water` = 1).
  *
- * Only Water/Tree kinds are applied onto untouched Land tiles, so player-built
- * kinds present in a display snapshot can never leak into the engine. Call
- * once, right after `start()`.
+ * Only Water is applied onto untouched Land tiles, so player-built terrain
+ * present in a display snapshot can never leak into the engine. Call once,
+ * right after `start()`.
  */
-export async function setNaturalTerrain(kinds: Uint8Array): Promise<void> {
-  await invoke('plugin:city-sim|set_natural_terrain', { kinds: Array.from(kinds) })
+export async function setNaturalTerrain(terrainBytes: Uint8Array): Promise<void> {
+  await invoke('plugin:city-sim|set_natural_terrain', { terrainBytes: Array.from(terrainBytes) })
 }
 
 export async function stop(): Promise<void> {

--- a/crates/tauri-plugin-city-sim/src/commands.rs
+++ b/crates/tauri-plugin-city-sim/src/commands.rs
@@ -298,8 +298,8 @@ pub fn start(
                     Ok(SimCmd::SetPolicies(policies)) => {
                         sim.state.policies = policies.clamped();
                     }
-                    Ok(SimCmd::SetNaturalTerrain(kinds)) => {
-                        sim.state.seed_natural_terrain(&kinds);
+                    Ok(SimCmd::SetNaturalTerrain(terrain_bytes)) => {
+                        sim.state.seed_natural_terrain(&terrain_bytes);
                     }
                     Ok(SimCmd::GetSnapshot(tx)) => {
                         let result = snapshot::to_bytes(&sim.state).map_err(|e| e.to_string());
@@ -408,13 +408,17 @@ pub fn set_policies(state: State<'_, SimState>, policies: Policies) -> Result<()
     state.send(SimCmd::SetPolicies(policies))
 }
 
-/// Seed the natural terrain baseline (row-major `TileKind` u8 per tile).
+/// Seed the natural terrain baseline (row-major `Terrain as u8` byte per
+/// tile — `Land` = 0, `Water` = 1).
 ///
-/// Only `Water`/`Tree` kinds are applied onto untouched `Land` tiles — see
+/// Only `Water` is applied onto untouched `Land` tiles — see
 /// `GameState::seed_natural_terrain`. Call once, right after `start`.
 #[tauri::command]
-pub fn set_natural_terrain(state: State<'_, SimState>, kinds: Vec<u8>) -> Result<(), Error> {
-    state.send(SimCmd::SetNaturalTerrain(kinds))
+pub fn set_natural_terrain(
+    state: State<'_, SimState>,
+    terrain_bytes: Vec<u8>,
+) -> Result<(), Error> {
+    state.send(SimCmd::SetNaturalTerrain(terrain_bytes))
 }
 
 /// Stop the simulation thread. The `on_tick` channel will stop receiving events.

--- a/crates/tauri-plugin-city-sim/src/lib.rs
+++ b/crates/tauri-plugin-city-sim/src/lib.rs
@@ -11,7 +11,7 @@
 //   apply_tool(tool: u8, x: u32, y: u32, stroke_id: u32, stratum: u8)
 //   set_speed(multiplier: f32)
 //   set_policies(policies: { budget: {...}, wilderness: {...} })
-//   set_natural_terrain(kinds: Vec<u8>)
+//   set_natural_terrain(terrain_bytes: Vec<u8>)
 //   stop()
 //   get_snapshot() -> Vec<u8>
 //   load_snapshot(bytes: Vec<u8>)


### PR DESCRIPTION
## Summary

Stacked on #259. The Rust side of the `BuildingKind` split: a building is an entity occupying a tile, and `TileKind` now exists solely inside the legacy import boundary — in both languages.

### Maintainer-facing changes
- **`crates/city-sim-protocol/src/building_kind.rs`** (new) — the approved u8 alphabet: high nibble = `BuildingCategory` (Zone/Power/Water/Education/Recreation + reserved Safety/Health), low nibble = kind, `0x00` never valid, serde as the stable discriminant byte. `category()` derives from the nibble; `dense_index()` gives gapless table keys; `ts_string()` mirrors the TS enum one-for-one.
- **`BuildingInstance.kind: BuildingKind`** and every live consumer migrated (economy ledger, demand, education, zones, wilderness tables, `has_water_system`, `place_footprint_building`, `StructureLookup`). The import boundary converts once, at the edge (`migrate::building_kind_of`).
- **`seed_natural_terrain`** stops speaking the TileKind alphabet — plain `Terrain` bytes on both hosts (the `Tree` branch was dead: no caller ever sent it); Tauri IPC param renamed `terrainBytes`.
- **`WireBuilding.kind`** is `BuildingKind as u8`, decoded by the new `app/src/game/protocol/buildingKind.ts` map; both bridges rewired.
- **Vocabulary evening** (pre-codegen): the six shared enums (Terrain, Occupant, ZoneDensity, Tool, AlertKind, BuildingKind) match name-for-name and value-for-value across languages. The one collision found — TS's coarse 3-member `BuildingCategory` — is renamed `LedgerGroup` (it's the power/civic/zone upkeep bucket, matching the engine ledger), so it no longer shares a name with Rust's 7-member taxonomy.

### Known limitations
- **Deliberate pre-release compatibility break (maintainer-approved):** the CSIM v4 snapshot shim (`migrate::v4`, `v4_to_v5`) is deleted and the snapshot `VERSION` moves to 6, accepting only itself. A CSIM snapshot saved by the *currently deployed* build (which writes v4) is refused with `UnsupportedVersion` — pinned by test — rather than silently migrated. The legacy JSON `.citysim` path remains the one old-save door. Flag before merge if v4 snapshots in the wild change the calculus; the alternative is restoring the shim with a v4→v6 hop.

## Test plan
- [x] `cargo test --workspace` — 345 + 5 + 2 + 2 + 31 pass; `cargo fmt`/`clippy` clean
- [x] `bun run test` — 347 pass (new `buildingKind.test.ts`); `bun run lint` clean
- [x] `golden_city.expected` regenerated deliberately: **only `state_hash` moved** (`0x4f62…` → `0x128b…`), every tile/section line unchanged — the sole delta is `BuildingInstance.kind`'s postcard byte. `tile_buffer_golden.json` and `tileKindParity.json` confirmed unmoved.
- [x] `cargo mutants --in-diff`: 77 mutants; all 36 misses triaged as pre-existing coverage gaps that moved with the mechanical rename (economy per-type breakdown, demand/education aggregates) — two `occupants.rs` gaps were cheap and real, tests added, now caught. The rest are recorded test debt, not new gaps.
- [x] Teeth proven by mutation on all new logic (category nibble, dense index, `building_kind_of`, terrain-byte seeding, version refusal, TS u8 map)
- [ ] Pre-existing gap noted, out of scope: `wasmSimBridge.test.ts` has no `InactiveNoSource` coverage (its Tauri twin does) — will be moot when #200's wire adoption deletes the client-side status reconstruction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKsiEhBJEYsxVxTdLrEAJU
